### PR TITLE
feat(chat): show Channel topic in header

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,6 +92,10 @@ _Avoid_: Room (all chats are rooms), conversation
 The unique handle for a Channel in its organization (`#team-soko`). The create UI collects the handle first; the display name is derived from it (`team-soko` → `Team Soko`) and can be edited before submit. After create the slug is stable: renaming the Channel does not change it. Name and slug need not match. Directs have none.
 _Avoid_: Room slug (Directs have no slug), treating the slug as the Channel’s identity (that is `id`), vanity URL, requiring the slug to match the name, regenerating the slug on rename
 
+**Channel topic**:
+An optional short description of what a Channel is for. Distinct from the Channel name and Channel slug. Absent when unset or blank. Directs have none.
+_Avoid_: Description, purpose, bio, treating a Direct as having a topic
+
 **External channel**:
 A Channel that host-organization members can browse and join, and that people outside that organization can join only as a Guest — without becoming organization members and without a seat.
 _Avoid_: Public channel (host-org only), guest channel, shared channel

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -323,6 +323,37 @@ describe("RoomsClient room header chrome", () => {
     expect(title.parentElement).not.toContainElement(search);
     expect(screen.getByRole("button", { name: "general" })).toBe(title);
     expect(screen.getByTestId("edit-channel-dialog-probe")).toBeTruthy();
+    expect(screen.queryByTestId("room-open-topic")).toBeNull();
+  });
+
+  it("shows a Channel topic beside the title, not inside the edit trigger", () => {
+    renderRoom({ ...channelRoom(), topic: "Weekly launch planning" });
+
+    const title = screen.getByTestId("room-open-title");
+    const topic = screen.getByTestId("room-open-topic");
+
+    expect(topic).toHaveTextContent("Weekly launch planning");
+    expect(title).not.toContainElement(topic);
+    expect(title).toHaveAccessibleName("general");
+    expect(title).toHaveAttribute("title", "editChannel");
+    expect(topic).toHaveAttribute("title", "Weekly launch planning");
+    expect(title.parentElement).toContainElement(topic);
+  });
+
+  it("hides a blank Channel topic", () => {
+    renderRoom({ ...channelRoom(), topic: "   " });
+
+    expect(screen.queryByTestId("room-open-topic")).toBeNull();
+    expect(screen.getByTestId("room-open-title")).toHaveAccessibleName(
+      "general",
+    );
+  });
+
+  it("does not show a topic on Directs", () => {
+    renderRoom({ ...humanDirectRoom(), topic: "Should stay hidden" });
+
+    expect(screen.queryByTestId("room-open-topic")).toBeNull();
+    expect(screen.getByTestId("room-open-title").tagName).not.toBe("BUTTON");
   });
 
   it("keeps Direct titles static and still puts search with the right actions", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -338,13 +338,29 @@ describe("RoomsClient room header chrome", () => {
     expect(title).toHaveAttribute("title", "editChannel");
     expect(topic).toHaveAttribute("title", "Weekly launch planning");
     expect(title.parentElement).toContainElement(topic);
-    expect(title).not.toHaveClass("shrink-0");
+    expect(title).toHaveClass("shrink-0");
     expect(topic).not.toHaveClass("hidden");
-    expect(topic).toHaveClass("min-w-16");
+    expect(topic).toHaveClass("min-w-0");
     expect(topic.tagName).not.toBe("BUTTON");
     expect(
       screen.queryByRole("button", { name: "Weekly launch planning" }),
     ).toBeNull();
+  });
+
+  it("keeps the Channel name as identity when a topic is present", () => {
+    renderRoom({
+      ...channelRoom(),
+      name: "Everyone",
+      topic: "General discussions & updates",
+    });
+
+    const title = screen.getByTestId("room-open-title");
+    const topic = screen.getByTestId("room-open-topic");
+
+    expect(title).toHaveAccessibleName("Everyone");
+    expect(title).toHaveClass("shrink-0");
+    expect(topic.className.split(/\s+/)).not.toContain("min-w-16");
+    expect(topic).toHaveClass("min-w-0");
   });
 
   it("trims a Channel topic for display", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -341,6 +341,18 @@ describe("RoomsClient room header chrome", () => {
     expect(title).not.toHaveClass("shrink-0");
     expect(topic).not.toHaveClass("hidden");
     expect(topic).toHaveClass("min-w-16");
+    expect(topic.tagName).not.toBe("BUTTON");
+    expect(
+      screen.queryByRole("button", { name: "Weekly launch planning" }),
+    ).toBeNull();
+  });
+
+  it("trims a Channel topic for display", () => {
+    renderRoom({ ...channelRoom(), topic: "  Weekly launch planning  " });
+
+    const topic = screen.getByTestId("room-open-topic");
+    expect(topic).toHaveTextContent("Weekly launch planning");
+    expect(topic).toHaveAttribute("title", "Weekly launch planning");
   });
 
   it("hides a blank Channel topic", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -338,6 +338,9 @@ describe("RoomsClient room header chrome", () => {
     expect(title).toHaveAttribute("title", "editChannel");
     expect(topic).toHaveAttribute("title", "Weekly launch planning");
     expect(title.parentElement).toContainElement(topic);
+    expect(title).not.toHaveClass("shrink-0");
+    expect(topic).not.toHaveClass("hidden");
+    expect(topic).toHaveClass("min-w-16");
   });
 
   it("hides a blank Channel topic", () => {

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -384,7 +384,7 @@ function RoomHeaderChrome({
 
   return (
     <div className="flex min-w-0 flex-1 items-center justify-between gap-1.5 overflow-hidden md:gap-4">
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 md:gap-2">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden md:gap-2">
         {isDirectRoom ? (
           <>
             <MessageCircle className="text-muted-foreground size-4 shrink-0" />

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -411,10 +411,7 @@ function RoomHeaderChrome({
             >
               <button
                 type="button"
-                className={cn(
-                  "text-foreground [@media(hover:hover)]:hover:bg-accent [@media(hover:hover)]:dark:hover:bg-accent/50 flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:gap-2",
-                  channelTopic ? "shrink-0" : "max-w-full",
-                )}
+                className="text-foreground [@media(hover:hover)]:hover:bg-accent [@media(hover:hover)]:dark:hover:bg-accent/50 flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:gap-2"
                 title={t("editChannel")}
                 data-testid="room-open-title"
               >
@@ -427,7 +424,7 @@ function RoomHeaderChrome({
             </EditChannelDialog>
             {channelTopic ? (
               <p
-                className="text-muted-foreground min-w-0 flex-1 truncate text-sm"
+                className="text-muted-foreground min-w-16 flex-1 truncate text-sm"
                 title={channelTopic}
                 data-testid="room-open-topic"
               >

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -379,10 +379,12 @@ function RoomHeaderChrome({
   showParticipants,
 }: RoomHeaderChromeProps) {
   const t = useTranslations("App.Channels");
+  const trimmedTopic = room.topic?.trim() ?? "";
+  const channelTopic = !isDirectRoom && trimmedTopic ? trimmedTopic : null;
 
   return (
     <div className="flex min-w-0 flex-1 items-center justify-between gap-1.5 overflow-hidden md:gap-4">
-      <div className="flex min-w-0 items-center gap-1.5 md:gap-2">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 md:gap-2">
         {isDirectRoom ? (
           <>
             <MessageCircle className="text-muted-foreground size-4 shrink-0" />
@@ -394,31 +396,45 @@ function RoomHeaderChrome({
             </p>
           </>
         ) : (
-          <EditChannelDialog
-            channel={room}
-            members={organizationMembers}
-            coworkers={coworkers}
-            currentUserId={currentUserId}
-            canEditMembers={canEditMembers}
-            canManageSettings={canManageSettings}
-            canArchive={canArchive}
-            canLeave={canLeave}
-            canInviteGuests={canInviteGuests}
-            membersLoadFailed={membersLoadFailed}
-          >
-            <button
-              type="button"
-              className="text-foreground [@media(hover:hover)]:hover:bg-accent [@media(hover:hover)]:dark:hover:bg-accent/50 flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:gap-2"
-              title={t("editChannel")}
-              data-testid="room-open-title"
+          <>
+            <EditChannelDialog
+              channel={room}
+              members={organizationMembers}
+              coworkers={coworkers}
+              currentUserId={currentUserId}
+              canEditMembers={canEditMembers}
+              canManageSettings={canManageSettings}
+              canArchive={canArchive}
+              canLeave={canLeave}
+              canInviteGuests={canInviteGuests}
+              membersLoadFailed={membersLoadFailed}
             >
-              <ChannelDiscoverabilityIcon
-                className="text-muted-foreground"
-                discoverability={room.discoverability}
-              />
-              <span className="min-w-0 truncate">{displayName}</span>
-            </button>
-          </EditChannelDialog>
+              <button
+                type="button"
+                className={cn(
+                  "text-foreground [@media(hover:hover)]:hover:bg-accent [@media(hover:hover)]:dark:hover:bg-accent/50 flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:gap-2",
+                  channelTopic ? "shrink-0" : "max-w-full",
+                )}
+                title={t("editChannel")}
+                data-testid="room-open-title"
+              >
+                <ChannelDiscoverabilityIcon
+                  className="text-muted-foreground"
+                  discoverability={room.discoverability}
+                />
+                <span className="min-w-0 truncate">{displayName}</span>
+              </button>
+            </EditChannelDialog>
+            {channelTopic ? (
+              <p
+                className="text-muted-foreground min-w-0 flex-1 truncate text-sm"
+                title={channelTopic}
+                data-testid="room-open-topic"
+              >
+                {channelTopic}
+              </p>
+            ) : null}
+          </>
         )}
       </div>
       <div className="flex shrink-0 items-center gap-1.5 md:gap-2">

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -411,7 +411,10 @@ function RoomHeaderChrome({
             >
               <button
                 type="button"
-                className="text-foreground [@media(hover:hover)]:hover:bg-accent [@media(hover:hover)]:dark:hover:bg-accent/50 flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:gap-2"
+                className={cn(
+                  "text-foreground [@media(hover:hover)]:hover:bg-accent [@media(hover:hover)]:dark:hover:bg-accent/50 flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:gap-2",
+                  channelTopic && "shrink-0",
+                )}
                 title={t("editChannel")}
                 data-testid="room-open-title"
               >
@@ -424,7 +427,7 @@ function RoomHeaderChrome({
             </EditChannelDialog>
             {channelTopic ? (
               <p
-                className="text-muted-foreground min-w-16 flex-1 truncate text-sm"
+                className="text-muted-foreground min-w-0 flex-1 truncate text-sm"
                 title={channelTopic}
                 data-testid="room-open-topic"
               >

--- a/apps/web/src/app/(app)/components/header/__tests__/header-center.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-center.client.test.tsx
@@ -55,7 +55,28 @@ describe("HeaderCenter", () => {
     expect(roomSlotClasses).not.toContain("hidden");
 
     expect(breadcrumbs).toHaveAttribute("data-hide-on-mobile-room", "true");
-    expect(breadcrumbClasses).toContain("sm:flex");
-    expect(breadcrumbClasses).toContain("max-md:hidden");
+    expect(breadcrumbClasses).not.toContain("sm:flex");
+    expect(breadcrumbClasses).toContain("md:flex");
+    expect(breadcrumbClasses).not.toContain("max-md:hidden");
+  });
+
+  it("does not let breadcrumbs claim sm while the room slot is still visible below md", () => {
+    mockPathname = "/chat/rooms/room-1";
+    render(
+      <HeaderCenter>
+        <span>Chat</span>
+        <span>Everyone</span>
+      </HeaderCenter>,
+    );
+
+    const roomSlot = screen.getByTestId("header-room-slot");
+    const breadcrumbs = screen.getByTestId("header-breadcrumbs");
+    const roomSlotClasses = roomSlot.className.split(/\s+/);
+    const breadcrumbClasses = breadcrumbs.className.split(/\s+/);
+
+    expect(roomSlotClasses).toContain("flex");
+    expect(roomSlotClasses).toContain("md:hidden");
+    expect(breadcrumbClasses).not.toContain("sm:flex");
+    expect(breadcrumbClasses).toContain("md:flex");
   });
 });

--- a/apps/web/src/app/(app)/components/header/header-center.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-center.client.tsx
@@ -12,7 +12,8 @@ interface HeaderCenterProps {
 /**
  * App-header center: mobile room toolbar slot + breadcrumbs.
  * Room slot only claims space on chat room routes below `md`.
- * Breadcrumbs keep `sm` wayfinding on non-room pages; hidden below `md` on rooms.
+ * Breadcrumbs keep `sm` wayfinding on non-room pages; on rooms they start at
+ * `md` so they never sit beside the slot in the sm–md band.
  */
 export function HeaderCenter({ children }: HeaderCenterProps) {
   const pathname = usePathname();
@@ -34,8 +35,8 @@ export function HeaderCenter({ children }: HeaderCenterProps) {
         data-testid="header-breadcrumbs"
         data-hide-on-mobile-room={isMobileRoom ? "true" : undefined}
         className={cn(
-          "hidden min-w-0 flex-1 flex-row gap-2 sm:flex",
-          isMobileRoom && "max-md:hidden",
+          "hidden min-w-0 flex-1 flex-row gap-2",
+          isMobileRoom ? "md:flex" : "sm:flex",
         )}
       >
         {children}


### PR DESCRIPTION
## Summary

If a Channel has a topic, the room header now shows it on the same row as the name pill: muted, truncated, after the name. The name pill is still the only Edit channel trigger. Directs stay name-only. Blank or whitespace-only topics stay hidden.

## User-facing

- Channel header shows the topic when one is set
- Empty topic: header is unchanged (name pill only)
- Direct titles are unchanged

## Verification

- [x] `pnpm test` (web 3741 passed, core 4206 passed)
- [x] Husky pre-commit: `biome check` + typecheck
- [ ] Open a Channel with a topic and confirm it appears beside the name, not inside the Edit channel control
- [ ] Open a Channel with no topic and confirm the header has no topic text
- [ ] Open a Direct and confirm no topic is shown

Browser check was blocked locally: `GET /v1/chats/rooms` 500s (`chat_room_user_mention` missing). Pre-existing schema gap, not this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Channel headers now display an optional, trimmed topic alongside the channel name.
  - Topics are hidden when blank and do not appear for direct conversations.
  - Channel names remain the editable title and primary room identity.

- **UI Improvements**
  - Header breadcrumbs now use improved responsive visibility on chat room and non-room pages.
  - Channel topics adapt to available header space without obscuring the channel name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->