### PR TITLE
fix(chat): chip composer mention persist tokens

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-composer-quote-preview.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-composer-quote-preview.test.tsx
@@ -100,4 +100,38 @@ describe("RoomComposer quote preview mentions", () => {
     expect(chip).not.toBeNull();
     expect(chip).toHaveTextContent("@Elena");
   });
+
+  it("chips a roster User mention omitted from the picker catalog", () => {
+    const { container } = render(
+      <RoomComposer
+        value=""
+        onValueChange={() => undefined}
+        mentions={{}}
+        usersById={
+          new Map([["b0user", { id: "b0user", name: "Andreas Osberghaus" }]])
+        }
+        onSelectedKeysChange={() => undefined}
+        placeholder="Message"
+        attachments={[]}
+        onAttachmentsChange={() => undefined}
+        onSubmit={(event) => event.preventDefault()}
+        isSending={false}
+        sendDisabled={false}
+        pendingQuote={{
+          messageId: "msg-1",
+          authorName: "Yves Bollinger",
+          snippet: "@b0user:andreas-osberghaus please look",
+          attachment: null,
+        }}
+        onClearPendingQuote={() => undefined}
+      />,
+    );
+
+    const chip = container.querySelector(
+      '[data-direct-kind="human"][data-direct-id="b0user"]',
+    );
+    expect(chip).not.toBeNull();
+    expect(chip).toHaveTextContent("@Andreas Osberghaus");
+    expect(container.textContent).not.toContain("@b0user:andreas-osberghaus");
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/lib/clients/generated/core";
 import {
   buildRoomAllMentionRecord,
+  composerMentionDisplayNames,
   formatRoomMarkdownContent,
   formatRoomMarkdownMentions,
   membershipVisibleChannelLinks,
@@ -533,5 +534,31 @@ describe("partitionRoomMentionSuggestions", () => {
     expect(groups).toHaveLength(1);
     expect(groups[0]?.id).toBe("people");
     expect(groups[0]?.items).toEqual([unknown]);
+  });
+});
+
+describe("composerMentionDisplayNames", () => {
+  it("lets roster names win over catalog for the same id", () => {
+    const { byKey, bySlug } = composerMentionDisplayNames({
+      usersById: new Map([["u1", { name: "Andreas Osberghaus" }]]),
+      usersBySlug: new Map([
+        ["andreas-osberghaus", { name: "Andreas Osberghaus" }],
+      ]),
+      mentionCatalog: {
+        u1: { value: "Andreas", slug: "andreas" },
+      },
+    });
+
+    expect(byKey.get("u1")).toBe("Andreas Osberghaus");
+    expect(bySlug.get("andreas-osberghaus")).toBe("Andreas Osberghaus");
+  });
+
+  it("keeps catalog-only entries such as @all", () => {
+    const { byKey, bySlug } = composerMentionDisplayNames({
+      mentionCatalog: { all: { value: "Everyone", slug: "all" } },
+    });
+
+    expect(byKey.get("all")).toBe("Everyone");
+    expect(bySlug.get("all")).toBe("Everyone");
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1684,6 +1684,42 @@ describe("ChatMessageRow", () => {
     expect(chip).not.toBeNull();
     expect(chip).toHaveTextContent("@Andreas Osberghaus");
     expect(editor.textContent).not.toContain("b0user");
+    expect(editor.closest(".border-input")).not.toBeNull();
+  });
+
+  it("saves persist @id:slug after editing a chipped User mention", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({
+        content: "@b0user:andreas-osberghaus please look",
+      }),
+      currentUserId: "b0user",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "@b0user:andreas-osberghaus please look",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit,
+      usersById: new Map([
+        ["b0user", { id: "b0user", name: "Andreas Osberghaus" }],
+      ]),
+    });
+
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    await user.keyboard(" again{Enter}");
+
+    expect(onSaveEdit).toHaveBeenCalledWith(
+      "@b0user:andreas-osberghaus please look again",
+    );
   });
 
   it("shows Delete in the sheet for the author and calls onDelete after confirm", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1,4 +1,11 @@
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -165,6 +172,7 @@ function renderRow({
   onSaveEdit,
   isSavingEdit = false,
   coworkersById = new Map(),
+  usersById,
   reserveHoverActionGutter,
 }: {
   message?: ChatRoomMessage;
@@ -187,12 +195,14 @@ function renderRow({
   onSaveEdit?: (content?: string) => void;
   isSavingEdit?: boolean;
   coworkersById?: Map<string, ChatRoomCoworkerParticipant>;
+  usersById?: Map<string, { id: string; name: string }>;
 } = {}) {
   render(
     <ChatMessageRow
       message={message}
       coworkersById={coworkersById}
       coworkersBySlug={new Map()}
+      usersById={usersById}
       currentUserId={currentUserId}
       onToggleReaction={vi.fn()}
       onQuote={onQuote}
@@ -1405,7 +1415,8 @@ describe("ChatMessageRow", () => {
       onSaveEdit: vi.fn(),
     });
 
-    expect(screen.getByDisplayValue("Original fixed")).toBeInTheDocument();
+    const editor = screen.getByRole("textbox");
+    expect(editor).toHaveTextContent("Original fixed");
     expect(screen.queryByText("Original")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Edit.save" }),
@@ -1427,12 +1438,16 @@ describe("ChatMessageRow", () => {
       onSaveEdit: vi.fn(),
     });
 
-    const textarea = screen.getByDisplayValue(
-      "Original fixed",
-    ) as HTMLTextAreaElement;
-    expect(document.activeElement).toBe(textarea);
-    expect(textarea.selectionStart).toBe("Original fixed".length);
-    expect(textarea.selectionEnd).toBe("Original fixed".length);
+    const editor = screen.getByRole("textbox");
+    expect(document.activeElement).toBe(editor);
+    const selection = window.getSelection();
+    expect(selection?.rangeCount).toBeGreaterThan(0);
+    const range = selection?.getRangeAt(0);
+    expect(range?.collapsed).toBe(true);
+    const prefix = range?.cloneRange();
+    prefix?.selectNodeContents(editor);
+    prefix?.setEnd(range?.endContainer as Node, range?.endOffset ?? 0);
+    expect(prefix?.toString()).toBe("Original fixed");
   });
 
   it("saves on Enter and cancels on Escape while editing", async () => {
@@ -1451,8 +1466,8 @@ describe("ChatMessageRow", () => {
       onSaveEdit,
     });
 
-    const textarea = screen.getByDisplayValue("Original fixed");
-    textarea.focus();
+    const editor = screen.getByRole("textbox");
+    editor.focus();
 
     await user.keyboard("{Enter}");
     expect(onSaveEdit).toHaveBeenCalledTimes(1);
@@ -1478,7 +1493,7 @@ describe("ChatMessageRow", () => {
       onSaveEdit,
     });
 
-    screen.getByDisplayValue("Original fixed").focus();
+    screen.getByRole("textbox").focus();
     await user.keyboard("{Shift>}{Enter}{/Shift}");
     expect(onSaveEdit).not.toHaveBeenCalled();
     expect(onCancelEdit).not.toHaveBeenCalled();
@@ -1500,13 +1515,13 @@ describe("ChatMessageRow", () => {
       onSaveEdit,
     });
 
-    screen.getByDisplayValue("Original").focus();
+    screen.getByRole("textbox").focus();
     await user.keyboard("{Enter}");
     expect(onSaveEdit).not.toHaveBeenCalled();
     expect(onCancelEdit).toHaveBeenCalledTimes(1);
   });
 
-  it("saves live textarea value on Enter even if draft prop is stale", async () => {
+  it("saves live editor value on Enter even if draft prop is stale", async () => {
     const user = userEvent.setup();
     const onSaveEdit = vi.fn();
 
@@ -1522,12 +1537,9 @@ describe("ChatMessageRow", () => {
       onSaveEdit,
     });
 
-    const textarea = screen.getByDisplayValue(
-      "Original",
-    ) as HTMLTextAreaElement;
-    textarea.focus();
-    // Bypass React onChange so the controlled prop stays stale while DOM updates.
-    textarea.value = "Original fixed live";
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = "Original fixed live";
     await user.keyboard("{Enter}");
     expect(onSaveEdit).toHaveBeenCalledWith("Original fixed live");
   });
@@ -1547,10 +1559,12 @@ describe("ChatMessageRow", () => {
       onSaveEdit: vi.fn(),
     });
 
-    const textarea = screen.getByDisplayValue("Original");
-    textarea.focus();
-    await user.tab(); // move focus away → blur
-    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    await user.tab();
+    await waitFor(() => {
+      expect(onCancelEdit).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("does not cancel on blur when draft is dirty", async () => {
@@ -1568,9 +1582,14 @@ describe("ChatMessageRow", () => {
       onSaveEdit: vi.fn(),
     });
 
-    const textarea = screen.getByDisplayValue("Original fixed");
-    textarea.focus();
+    const editor = screen.getByRole("textbox");
+    editor.focus();
     await user.tab();
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 200);
+      });
+    });
     expect(onCancelEdit).not.toHaveBeenCalled();
   });
 
@@ -1589,12 +1608,15 @@ describe("ChatMessageRow", () => {
       onSaveEdit: vi.fn(),
     });
 
-    const textarea = screen.getByDisplayValue(
-      "Original",
-    ) as HTMLTextAreaElement;
-    textarea.focus();
-    textarea.value = "Original fixed live";
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = "Original fixed live";
     await user.tab();
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 200);
+      });
+    });
     expect(onCancelEdit).not.toHaveBeenCalled();
   });
 
@@ -1635,9 +1657,33 @@ describe("ChatMessageRow", () => {
       onSaveEdit,
     });
 
-    screen.getByDisplayValue("Original fixed").focus();
+    screen.getByRole("textbox").focus();
     await user.keyboard("{Control>}{Enter}{/Control}");
     expect(onSaveEdit).toHaveBeenCalledWith("Original fixed");
+  });
+
+  it("chips a roster User mention in the edit composer", () => {
+    renderRow({
+      message: userMessage({
+        content: "@b0user:andreas-osberghaus please look",
+      }),
+      currentUserId: "b0user",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "@b0user:andreas-osberghaus please look",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit: vi.fn(),
+      usersById: new Map([
+        ["b0user", { id: "b0user", name: "Andreas Osberghaus" }],
+      ]),
+    });
+
+    const editor = screen.getByRole("textbox");
+    const chip = editor.querySelector("[data-mention-key='b0user']");
+    expect(chip).not.toBeNull();
+    expect(chip).toHaveTextContent("@Andreas Osberghaus");
+    expect(editor.textContent).not.toContain("b0user");
   });
 
   it("shows Delete in the sheet for the author and calls onDelete after confirm", async () => {

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -19,6 +19,7 @@ import {
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -69,6 +70,7 @@ import { getInitials } from "@/lib/utils/text";
 import { AiCoworkerIcon } from "./room-draft-shared";
 import {
   type ChatParticipantHoverProfile,
+  composerMentionDisplayNames,
   type PendingRoomQuote,
   partitionRoomMentionSuggestions,
   ROOM_QUOTE_MARKDOWN_CLASSNAME,
@@ -124,8 +126,28 @@ function RoomMentionSuggestion({
 
 type UserMentionLookup = Pick<ChatRoomUserParticipant, "id" | "name">;
 
+function mergeLookupMap<T>(
+  base: Map<string, T>,
+  extra?: Map<string, T>,
+): Map<string, T> {
+  if (!extra || extra.size === 0) {
+    return base;
+  }
+  const merged = new Map(base);
+  for (const [key, value] of extra) {
+    merged.set(key, value);
+  }
+  return merged;
+}
+
 function mentionLookupMapsFromCatalog(
   mentions: Record<string, MentionRecordEntry<RoomMentionParticipant>>,
+  roster?: {
+    coworkersById?: Map<string, ChatRoomCoworkerParticipant>;
+    coworkersBySlug?: Map<string, ChatRoomCoworkerParticipant>;
+    usersById?: Map<string, UserMentionLookup>;
+    usersBySlug?: Map<string, UserMentionLookup>;
+  },
 ): {
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
   coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
@@ -162,13 +184,22 @@ function mentionLookupMapsFromCatalog(
     }
   }
 
-  return { coworkersById, coworkersBySlug, usersById, usersBySlug };
+  return {
+    coworkersById: mergeLookupMap(coworkersById, roster?.coworkersById),
+    coworkersBySlug: mergeLookupMap(coworkersBySlug, roster?.coworkersBySlug),
+    usersById: mergeLookupMap(usersById, roster?.usersById),
+    usersBySlug: mergeLookupMap(usersBySlug, roster?.usersBySlug),
+  };
 }
 
 function PendingQuotePreview({
   quote,
   onDismiss,
   mentions,
+  usersById: rosterUsersById,
+  usersBySlug: rosterUsersBySlug,
+  coworkersById: rosterCoworkersById,
+  coworkersBySlug: rosterCoworkersBySlug,
   channelLinks,
   currentUserId,
   canOpenHumanDirect,
@@ -178,6 +209,10 @@ function PendingQuotePreview({
   quote: PendingRoomQuote;
   onDismiss: () => void;
   mentions: Record<string, MentionRecordEntry<RoomMentionParticipant>>;
+  usersById?: Map<string, UserMentionLookup>;
+  usersBySlug?: Map<string, UserMentionLookup>;
+  coworkersById?: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug?: Map<string, ChatRoomCoworkerParticipant>;
   channelLinks: readonly ChannelLinkTarget[];
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
@@ -186,7 +221,12 @@ function PendingQuotePreview({
 }) {
   const t = useTranslations("App.Channels.Quote");
   const { coworkersById, coworkersBySlug, usersById, usersBySlug } =
-    mentionLookupMapsFromCatalog(mentions);
+    mentionLookupMapsFromCatalog(mentions, {
+      usersById: rosterUsersById,
+      usersBySlug: rosterUsersBySlug,
+      coworkersById: rosterCoworkersById,
+      coworkersBySlug: rosterCoworkersBySlug,
+    });
 
   const attachment = quote.attachment;
 
@@ -249,6 +289,10 @@ export function RoomComposer({
   value,
   onValueChange,
   mentions,
+  usersById,
+  usersBySlug,
+  coworkersById,
+  coworkersBySlug,
   channels = [],
   channelLinks = [],
   onSelectedKeysChange,
@@ -275,6 +319,11 @@ export function RoomComposer({
   value: string;
   onValueChange: Dispatch<SetStateAction<string>>;
   mentions: Record<string, MentionRecordEntry<RoomMentionParticipant>>;
+  /** Room roster lookups for quote preview / hydrate chips (includes you). */
+  usersById?: Map<string, UserMentionLookup>;
+  usersBySlug?: Map<string, UserMentionLookup>;
+  coworkersById?: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug?: Map<string, ChatRoomCoworkerParticipant>;
   channels?: readonly ComposerChannelOption[];
   channelLinks?: readonly ChannelLinkTarget[];
   onSelectedKeysChange: (selectedKeys: string[]) => void;
@@ -328,6 +377,17 @@ export function RoomComposer({
   const handleSelectedKeysChange = showMentionShortcut
     ? onSelectedKeysChange
     : undefined;
+  const mentionDisplay = useMemo(
+    () =>
+      composerMentionDisplayNames({
+        usersById,
+        usersBySlug,
+        coworkersById,
+        coworkersBySlug,
+        mentionCatalog: mentions,
+      }),
+    [coworkersById, coworkersBySlug, mentions, usersById, usersBySlug],
+  );
 
   // Stored pref wins; else desktop open / mobile closed (SOK-681).
   // useLayoutEffect: apply before paint so Instant → real composer does not
@@ -533,6 +593,10 @@ export function RoomComposer({
                 quote={pendingQuote}
                 onDismiss={onClearPendingQuote}
                 mentions={mentions}
+                usersById={usersById}
+                usersBySlug={usersBySlug}
+                coworkersById={coworkersById}
+                coworkersBySlug={coworkersBySlug}
                 channelLinks={channelLinks}
                 currentUserId={currentUserId}
                 canOpenHumanDirect={canOpenHumanDirect}
@@ -643,6 +707,8 @@ export function RoomComposer({
           onChange={onValueChange}
           onSelectedKeysChange={handleSelectedKeysChange}
           mentions={composerMentions}
+          mentionDisplayByKey={mentionDisplay.byKey}
+          mentionDisplayBySlug={mentionDisplay.bySlug}
           channels={channels}
           placeholder={placeholder}
           onSubmitShortcut={() => formRef.current?.requestSubmit()}

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -99,6 +99,15 @@ export function composerMentionDisplayNames({
   const byKey = new Map<string, string>();
   const bySlug = new Map<string, string>();
 
+  // Catalog first (@all and picker labels), then roster overwrites so
+  // hydrate chips match posted quotes. Same win order as quote preview.
+  for (const [key, entry] of Object.entries(mentionCatalog ?? {})) {
+    if (!entry.value) continue;
+    byKey.set(key, entry.value);
+    if (entry.slug) {
+      bySlug.set(entry.slug, entry.value);
+    }
+  }
   for (const [id, user] of usersById ?? []) {
     byKey.set(id, user.name);
   }
@@ -110,13 +119,6 @@ export function composerMentionDisplayNames({
   }
   for (const [slug, coworker] of coworkersBySlug ?? []) {
     bySlug.set(slug, coworker.name);
-  }
-  for (const [key, entry] of Object.entries(mentionCatalog ?? {})) {
-    if (!entry.value) continue;
-    byKey.set(key, entry.value);
-    if (entry.slug) {
-      bySlug.set(entry.slug, entry.value);
-    }
   }
 
   return { byKey, bySlug };

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -82,6 +82,46 @@ export function isRoomMentionAllId(id: string): boolean {
   return id === ROOM_MENTION_ALL_ID;
 }
 
+/** Display names for composer hydrate chips. Picker catalog stays separate. */
+export function composerMentionDisplayNames({
+  usersById,
+  usersBySlug,
+  coworkersById,
+  coworkersBySlug,
+  mentionCatalog,
+}: {
+  usersById?: Map<string, { name: string }>;
+  usersBySlug?: Map<string, { name: string }>;
+  coworkersById?: Map<string, { name: string }>;
+  coworkersBySlug?: Map<string, { name: string }>;
+  mentionCatalog?: Record<string, { value?: string; slug?: string | null }>;
+}): { byKey: Map<string, string>; bySlug: Map<string, string> } {
+  const byKey = new Map<string, string>();
+  const bySlug = new Map<string, string>();
+
+  for (const [id, user] of usersById ?? []) {
+    byKey.set(id, user.name);
+  }
+  for (const [slug, user] of usersBySlug ?? []) {
+    bySlug.set(slug, user.name);
+  }
+  for (const [id, coworker] of coworkersById ?? []) {
+    byKey.set(id, coworker.name);
+  }
+  for (const [slug, coworker] of coworkersBySlug ?? []) {
+    bySlug.set(slug, coworker.name);
+  }
+  for (const [key, entry] of Object.entries(mentionCatalog ?? {})) {
+    if (!entry.value) continue;
+    byKey.set(key, entry.value);
+    if (entry.slug) {
+      bySlug.set(entry.slug, entry.value);
+    }
+  }
+
+  return { byKey, bySlug };
+}
+
 /** Shared mention-picker payload for humans, coworkers, and synthetic @all. */
 export interface RoomMentionParticipant {
   kind: "human" | "coworker" | "all";

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -92,6 +92,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { copyTextWithToast } from "@/hooks/use-clipboard";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import type {
   ChatRoomCoworkerParticipant,
   ChatRoomMessage,
@@ -1334,9 +1335,9 @@ function MessageEditComposer({
     [coworkersById, coworkersBySlug, mentions, usersById, usersBySlug],
   );
 
-  useEffect(() => {
+  useMountEffect(() => {
     editorRef.current?.focusAtEnd();
-  }, []);
+  });
 
   function liveMarkdown(): string {
     return editorRef.current?.getMarkdown() ?? liveRef.current;

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -17,7 +17,6 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
-  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
@@ -59,6 +58,11 @@ import {
   type RoomMessageFilesSegment,
   segmentRoomMessageContent,
 } from "@/app/chat/utils/room-message-segments";
+import type { ComposerChannelOption } from "@/components/chat/composer-suggestions";
+import {
+  ComposerWysiwygEditor,
+  type ComposerWysiwygEditorHandle,
+} from "@/components/chat/composer-wysiwyg-editor";
 import { EmojiPicker } from "@/components/chat/emoji-picker";
 import {
   AlertDialog,
@@ -74,6 +78,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { FileChipMiniPreviewFrame } from "@/components/ui/file-chip-mini-preview";
 import { FileTypeIcon } from "@/components/ui/file-icon";
+import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import {
   Sheet,
   SheetContent,
@@ -81,7 +86,6 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
@@ -105,10 +109,12 @@ import { participantDirectKey } from "./open-direct-with-participant";
 import { AiCoworkerAvatarBadge } from "./room-draft-shared";
 import {
   type ChatParticipantHoverProfile,
+  composerMentionDisplayNames,
   formatMessageTime,
   messageSender,
   ROOM_MESSAGE_MARKDOWN_CLASSNAME,
   ROOM_QUOTE_MARKDOWN_CLASSNAME,
+  type RoomMentionParticipant,
   scrollToRoomMessageElement,
 } from "./room-helpers";
 import { RoomMessageMarkdown } from "./room-mention-markdown";
@@ -1291,6 +1297,12 @@ function MessageEditComposer({
   onSave,
   onCancel,
   isSaving,
+  mentions = {},
+  usersById,
+  usersBySlug,
+  coworkersById,
+  coworkersBySlug,
+  channels = [],
 }: {
   value: string;
   originalContent: string;
@@ -1298,48 +1310,45 @@ function MessageEditComposer({
   onSave: (content: string) => void;
   onCancel: () => void;
   isSaving: boolean;
+  mentions?: Record<string, MentionRecordEntry<RoomMentionParticipant>>;
+  usersById?: Map<string, UserMentionLookup>;
+  usersBySlug?: Map<string, UserMentionLookup>;
+  coworkersById?: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug?: Map<string, ChatRoomCoworkerParticipant>;
+  channels?: readonly ComposerChannelOption[];
 }) {
   const t = useTranslations("App.Channels");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editorRef = useRef<ComposerWysiwygEditorHandle>(null);
+  const liveRef = useRef(value);
+  liveRef.current = value;
 
-  // autoFocus leaves the caret at 0; place it at the end so editing continues
-  // from the natural end of the message (Slack/Discord-style).
-  useLayoutEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.focus();
-    const end = el.value.length;
-    el.setSelectionRange(end, end);
+  const mentionDisplay = useMemo(
+    () =>
+      composerMentionDisplayNames({
+        usersById,
+        usersBySlug,
+        coworkersById,
+        coworkersBySlug,
+        mentionCatalog: mentions,
+      }),
+    [coworkersById, coworkersBySlug, mentions, usersById, usersBySlug],
+  );
+
+  useEffect(() => {
+    editorRef.current?.focusAtEnd();
   }, []);
 
-  // Live DOM via currentTarget: parent draft can lag the last keystroke's
-  // onChange. Enter with no real change (or empty) exits edit mode — no-op
-  // after preventDefault felt like a broken keyboard.
-  function handleKeyDown(event: ReactKeyboardEvent<HTMLTextAreaElement>) {
-    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
-      return;
-    }
+  function liveMarkdown(): string {
+    return editorRef.current?.getMarkdown() ?? liveRef.current;
+  }
 
-    if (event.key === "Escape") {
-      event.preventDefault();
-      if (!isSaving) onCancel();
-      return;
-    }
-
-    if (event.key !== "Enter") return;
-    // Shift+Enter → newline (default)
-    if (event.shiftKey) return;
-    // Alt+Enter ignored (leave default / no save)
-    if (event.altKey) return;
-
-    event.preventDefault();
+  function handleCommit() {
     if (isSaving) return;
-
-    const live = event.currentTarget.value;
-    const liveTrimmed = live.trim();
+    const markdown = liveMarkdown();
+    const liveTrimmed = markdown.trim();
     const originalTrimmed = originalContent.trim();
     if (liveTrimmed.length > 0 && liveTrimmed !== originalTrimmed) {
-      onSave(live);
+      onSave(markdown);
       return;
     }
     onCancel();
@@ -1347,24 +1356,31 @@ function MessageEditComposer({
 
   return (
     <div className="pt-0.5">
-      <Textarea
-        ref={textareaRef}
+      <ComposerWysiwygEditor
+        ref={editorRef}
         value={value}
-        onChange={(event) => {
-          onChange(event.target.value);
+        onChange={(next) => {
+          liveRef.current = next;
+          onChange(next);
         }}
+        mentions={mentions}
+        mentionDisplayByKey={mentionDisplay.byKey}
+        mentionDisplayBySlug={mentionDisplay.bySlug}
+        channels={channels}
         disabled={isSaving}
-        className="min-h-10 max-h-40 resize-none overflow-y-auto field-sizing-content px-3 py-2.5 leading-6"
-        aria-label={t("Edit.composerAria")}
-        onKeyDown={handleKeyDown}
+        ariaLabel={t("Edit.composerAria")}
+        modifierEnterSubmits
+        onSubmitShortcut={handleCommit}
+        onEscape={() => {
+          if (!isSaving) onCancel();
+        }}
         onBlur={() => {
           if (isSaving) return;
-          // Live DOM (same race as Enter): prop can lag a just-typed character.
-          const live = textareaRef.current?.value ?? value;
-          if (live.trim() === originalContent.trim()) {
+          if (liveMarkdown().trim() === originalContent.trim()) {
             onCancel();
           }
         }}
+        className="min-h-10 max-h-40 overflow-y-auto px-3 py-2.5 leading-6"
       />
     </div>
   );
@@ -1734,6 +1750,8 @@ export function ChatMessageRow({
   onCancelEdit,
   onSaveEdit,
   isSavingEdit = false,
+  mentions = {},
+  channels = [],
   showThreadButton = true,
   showQuoteButton = true,
   isContinuation = false,
@@ -1768,6 +1786,8 @@ export function ChatMessageRow({
   /** Optional content uses the live editor value (avoids stale draft on Enter). */
   onSaveEdit?: (content?: string) => void;
   isSavingEdit?: boolean;
+  mentions?: Record<string, MentionRecordEntry<RoomMentionParticipant>>;
+  channels?: readonly ComposerChannelOption[];
   showThreadButton?: boolean;
   showQuoteButton?: boolean;
   /** Slack-style continuation: omit avatar / name / wall-clock (group header time is enough). */
@@ -2012,6 +2032,12 @@ export function ChatMessageRow({
                   onSave={onSaveEdit}
                   onCancel={onCancelEdit}
                   isSaving={isSavingEdit}
+                  mentions={mentions}
+                  usersById={usersById}
+                  usersBySlug={usersBySlug}
+                  coworkersById={coworkersById}
+                  coworkersBySlug={coworkersBySlug}
+                  channels={channels}
                 />
               ) : isFailedMentionThoughtShell(message.metadata) ? (
                 <>

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1357,32 +1357,39 @@ function MessageEditComposer({
 
   return (
     <div className="pt-0.5">
-      <ComposerWysiwygEditor
-        ref={editorRef}
-        value={value}
-        onChange={(next) => {
-          liveRef.current = next;
-          onChange(next);
-        }}
-        mentions={mentions}
-        mentionDisplayByKey={mentionDisplay.byKey}
-        mentionDisplayBySlug={mentionDisplay.bySlug}
-        channels={channels}
-        disabled={isSaving}
-        ariaLabel={t("Edit.composerAria")}
-        modifierEnterSubmits
-        onSubmitShortcut={handleCommit}
-        onEscape={() => {
-          if (!isSaving) onCancel();
-        }}
-        onBlur={() => {
-          if (isSaving) return;
-          if (liveMarkdown().trim() === originalContent.trim()) {
-            onCancel();
-          }
-        }}
-        className="min-h-10 max-h-40 overflow-y-auto px-3 py-2.5 leading-6"
-      />
+      <div
+        className={cn(
+          "border-input focus-within:border-ring focus-within:ring-ring/50 dark:bg-input/30 rounded-md border bg-transparent focus-within:ring-[3px]",
+          isSaving && "pointer-events-none opacity-50",
+        )}
+      >
+        <ComposerWysiwygEditor
+          ref={editorRef}
+          value={value}
+          onChange={(next) => {
+            liveRef.current = next;
+            onChange(next);
+          }}
+          mentions={mentions}
+          mentionDisplayByKey={mentionDisplay.byKey}
+          mentionDisplayBySlug={mentionDisplay.bySlug}
+          channels={channels}
+          disabled={isSaving}
+          ariaLabel={t("Edit.composerAria")}
+          modifierEnterSubmits
+          onSubmitShortcut={handleCommit}
+          onEscape={() => {
+            if (!isSaving) onCancel();
+          }}
+          onBlur={() => {
+            if (isSaving) return;
+            if (liveMarkdown().trim() === originalContent.trim()) {
+              onCancel();
+            }
+          }}
+          className="min-h-10 max-h-40 overflow-y-auto px-3 py-2.5 leading-6"
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-session-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-session-composer.tsx
@@ -19,6 +19,10 @@ import {
 } from "@/app/chat/utils/compose-draft-storage";
 import type { ComposerChannelOption } from "@/components/chat/composer-suggestions";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
+import type {
+  ChatRoomCoworkerParticipant,
+  ChatRoomUserParticipant,
+} from "@/lib/clients/generated/core";
 
 import {
   RoomComposer,
@@ -56,6 +60,10 @@ interface RoomSessionComposerProps {
   roomId: string;
   draftKey: string;
   mentions: Record<string, MentionRecordEntry<RoomMentionParticipant>>;
+  usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+  usersBySlug?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+  coworkersById?: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug?: Map<string, ChatRoomCoworkerParticipant>;
   channels?: readonly ComposerChannelOption[];
   channelLinks?: readonly ChannelLinkTarget[];
   placeholder: string;
@@ -86,6 +94,10 @@ export function RoomSessionComposer({
   roomId,
   draftKey,
   mentions,
+  usersById,
+  usersBySlug,
+  coworkersById,
+  coworkersBySlug,
   channels,
   channelLinks,
   placeholder,
@@ -204,6 +216,10 @@ export function RoomSessionComposer({
       value={composerValue}
       onValueChange={setComposerValue}
       mentions={mentions}
+      usersById={usersById}
+      usersBySlug={usersBySlug}
+      coworkersById={coworkersById}
+      coworkersBySlug={coworkersBySlug}
       channels={channels}
       channelLinks={channelLinks}
       onSelectedKeysChange={setMentionedIds}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2707,6 +2707,8 @@ export function RoomsClient({
                       coworkersBySlug={coworkersBySlug}
                       usersById={usersById}
                       usersBySlug={usersBySlug}
+                      mentions={mentionRecords}
+                      channels={channelOptions}
                       channelLinks={channelLinks}
                       currentUserId={currentUserId}
                       canOpenHumanDirect={canOpenHumanDirect}
@@ -2832,6 +2834,10 @@ export function RoomsClient({
               roomId={selectedRoom.id}
               draftKey={composeDraftKey.room(selectedRoom.id)}
               mentions={mentionRecords}
+              usersById={usersById}
+              usersBySlug={usersBySlug}
+              coworkersById={coworkersById}
+              coworkersBySlug={coworkersBySlug}
               channels={channelOptions}
               channelLinks={channelLinks}
               placeholder={

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -261,6 +261,8 @@ export function ThreadPanel({
                 coworkersBySlug={coworkersBySlug}
                 usersById={usersById}
                 usersBySlug={usersBySlug}
+                mentions={mentionRecords}
+                channels={channelOptions}
                 channelLinks={channelLinks}
                 canOpenHumanDirect={canOpenHumanDirect}
                 onOpenDirectMessage={onOpenDirectMessage}
@@ -314,6 +316,8 @@ export function ThreadPanel({
                           coworkersBySlug={coworkersBySlug}
                           usersById={usersById}
                           usersBySlug={usersBySlug}
+                          mentions={mentionRecords}
+                          channels={channelOptions}
                           channelLinks={channelLinks}
                           canOpenHumanDirect={canOpenHumanDirect}
                           onOpenDirectMessage={onOpenDirectMessage}
@@ -354,6 +358,10 @@ export function ThreadPanel({
           roomId={roomId}
           draftKey={draftKey}
           mentions={mentionRecords}
+          usersById={usersById}
+          usersBySlug={usersBySlug}
+          coworkersById={coworkersById}
+          coworkersBySlug={coworkersBySlug}
           channels={channelOptions}
           channelLinks={channelLinks}
           placeholder={t("Thread.replyPlaceholder")}

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -1285,6 +1285,46 @@ describe("ComposerWysiwygEditor", () => {
     expect(editor.textContent).not.toContain("b0user");
   });
 
+  it("hydrates roster display names over picker catalog labels", () => {
+    render(
+      <ComposerWysiwygEditor
+        value="@u1:andreas hello"
+        onChange={() => undefined}
+        mentions={{
+          u1: { value: "Andreas", slug: "andreas" },
+        }}
+        mentionDisplayByKey={new Map([["u1", "Andreas Osberghaus"]])}
+        mentionDisplayBySlug={
+          new Map([["andreas-osberghaus", "Andreas Osberghaus"]])
+        }
+      />,
+    );
+
+    const editor = screen.getByRole("textbox");
+    const chip = editor.querySelector("[data-mention-key='u1']");
+    expect(chip).toHaveTextContent("@Andreas Osberghaus");
+  });
+
+  it("does not preventDefault Escape when onEscape is omitted", () => {
+    render(
+      <ComposerWysiwygEditor
+        value="hello"
+        onChange={() => undefined}
+        mentions={{}}
+      />,
+    );
+
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    editor.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it("leaves unknown persist tokens raw on hydrate", () => {
     render(
       <ComposerWysiwygEditor

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -1285,6 +1285,20 @@ describe("ComposerWysiwygEditor", () => {
     expect(editor.textContent).not.toContain("b0user");
   });
 
+  it("leaves unknown persist tokens raw on hydrate", () => {
+    render(
+      <ComposerWysiwygEditor
+        value="ping @missing:ghost hey"
+        onChange={() => undefined}
+        mentions={{}}
+      />,
+    );
+
+    const editor = screen.getByRole("textbox");
+    expect(editor.querySelector("[data-mention-key]")).toBeNull();
+    expect(editor).toHaveTextContent("ping @missing:ghost hey");
+  });
+
   it("does not list roster-only names in the mention picker", () => {
     render(
       <ComposerWysiwygEditor

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -1264,4 +1264,53 @@ describe("ComposerWysiwygEditor", () => {
     expect(onSubmitted).toHaveBeenCalledWith(expect.stringContaining("😉"));
     expect(onSubmitted).not.toHaveBeenCalledWith(expect.stringContaining(";)"));
   });
+
+  it("hydrates a roster User mention that is not in the picker catalog", () => {
+    render(
+      <ComposerWysiwygEditor
+        value="@b0user:andreas-osberghaus hello"
+        onChange={() => undefined}
+        mentions={{}}
+        mentionDisplayByKey={new Map([["b0user", "Andreas Osberghaus"]])}
+        mentionDisplayBySlug={
+          new Map([["andreas-osberghaus", "Andreas Osberghaus"]])
+        }
+      />,
+    );
+
+    const editor = screen.getByRole("textbox");
+    const chip = editor.querySelector("[data-mention-key='b0user']");
+    expect(chip).not.toBeNull();
+    expect(chip).toHaveTextContent("@Andreas Osberghaus");
+    expect(editor.textContent).not.toContain("b0user");
+  });
+
+  it("does not list roster-only names in the mention picker", () => {
+    render(
+      <ComposerWysiwygEditor
+        value=""
+        onChange={() => undefined}
+        mentions={{
+          alice: { value: "Alice", slug: "alice" },
+        }}
+        mentionDisplayByKey={new Map([["b0user", "Andreas Osberghaus"]])}
+      />,
+    );
+
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = "@";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    expect(screen.getByRole("option", { name: /Alice/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /Andreas Osberghaus/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -465,6 +465,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
         name: channel.name,
         slug: channel.slug,
       })),
+      wrapUnknownMentions: false,
     });
     const isFocused = editor.contains(document.activeElement);
     const editorLooksEmpty = isComposerEditorDomEmpty(editor);

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -25,7 +25,6 @@ import {
 import {
   createChannelLinkSpan,
   createMentionSpan,
-  deslugifyMentionSlug,
   filterNormalizedMentions,
   findPositionForOffset,
   getActiveChannelTrigger,
@@ -89,11 +88,13 @@ type SuggestionUiState =
 
 export interface ComposerWysiwygEditorHandle {
   focus: () => void;
+  focusAtEnd: () => void;
   insertText: (text: string) => void;
   openMentions: () => void;
   applyFormat: (command: ComposerFormatCommand) => void;
   insertLink: (text: string, url: string) => void;
   getSelectedPlainText: () => string;
+  getMarkdown: () => string;
   /** Flush bare trailing emoticons before submit when Send skips blur. */
   flushTrailingEmoticon: () => void;
 }
@@ -104,11 +105,25 @@ interface ComposerWysiwygEditorProps<TData = unknown> {
   value: string;
   onChange: (value: string) => void;
   mentions?: Record<string, MentionRecordEntry<TData>>;
+  /**
+   * Extra id/slug → display name for hydrating persist tokens (includes you).
+   * Does not appear in the `@` picker.
+   */
+  mentionDisplayByKey?: ReadonlyMap<string, string>;
+  mentionDisplayBySlug?: ReadonlyMap<string, string>;
   /** Membership-visible Channels for the `#` picker. */
   channels?: readonly ComposerChannelOption[];
   placeholder?: string;
   className?: string;
   onSubmitShortcut?: () => void;
+  /** Called when Escape is pressed and the suggestion popup is closed. */
+  onEscape?: () => void;
+  /** Called after blur, once suggestion clicks have been ruled out. */
+  onBlur?: () => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+  /** When true, Ctrl/Cmd+Enter submits instead of inserting a newline. */
+  modifierEnterSubmits?: boolean;
   onLinkShortcut?: () => void;
   onActiveFormatsChange?: (formats: ComposerActiveFormats) => void;
   onSelectedKeysChange?: (selectedKeys: string[]) => void;
@@ -196,10 +211,17 @@ export function ComposerWysiwygEditor<TData = unknown>({
   value,
   onChange,
   mentions = {},
+  mentionDisplayByKey,
+  mentionDisplayBySlug,
   channels = EMPTY_COMPOSER_CHANNELS,
   placeholder = "",
   className,
   onSubmitShortcut,
+  onEscape,
+  onBlur,
+  disabled = false,
+  ariaLabel,
+  modifierEnterSubmits = false,
   onLinkShortcut,
   onActiveFormatsChange,
   onSelectedKeysChange,
@@ -266,17 +288,21 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
   const resolveMentionDisplay = useCallback(
     (mentionKey: string, mentionSlug: string) => {
-      const isKnown =
-        keyToValue.has(mentionKey) || slugToValue.has(mentionSlug);
       const displayName =
         keyToValue.get(mentionKey) ??
+        mentionDisplayByKey?.get(mentionKey) ??
         slugToValue.get(mentionSlug) ??
+        mentionDisplayBySlug?.get(mentionSlug) ??
         slugToValue.get(slugifyMentionValue(mentionKey)) ??
-        deslugifyMentionSlug(mentionSlug);
+        mentionDisplayBySlug?.get(slugifyMentionValue(mentionKey));
 
-      return { displayName, isKnown };
+      if (displayName) {
+        return { displayName, isKnown: true };
+      }
+
+      return { displayName: mentionSlug, isKnown: false };
     },
-    [keyToValue, slugToValue],
+    [keyToValue, mentionDisplayByKey, mentionDisplayBySlug, slugToValue],
   );
 
   const mentionQuery =
@@ -1081,6 +1107,8 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (disabled) return;
+
       const key = event.key.toLowerCase();
       const hasModifier = event.metaKey || event.ctrlKey || event.altKey;
       const isDropdownVisible = isOpen && visibleSuggestionCount > 0;
@@ -1090,6 +1118,12 @@ export function ComposerWysiwygEditor<TData = unknown>({
       if (isOpen && !hasModifier && key === "escape") {
         event.preventDefault();
         closeSuggestions();
+        return;
+      }
+
+      if (!hasModifier && key === "escape") {
+        event.preventDefault();
+        onEscape?.();
         return;
       }
 
@@ -1157,8 +1191,8 @@ export function ComposerWysiwygEditor<TData = unknown>({
       if (key === "enter" && !event.nativeEvent.isComposing) {
         const action = resolveComposerEnterAction({
           shiftKey: event.shiftKey,
-          metaKey: event.metaKey,
-          ctrlKey: event.ctrlKey,
+          metaKey: modifierEnterSubmits ? false : event.metaKey,
+          ctrlKey: modifierEnterSubmits ? false : event.ctrlKey,
           isSuggestionKeyboardActive: isDropdownVisible,
         });
 
@@ -1183,6 +1217,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
       activeIndex,
       applyFormat,
       closeSuggestions,
+      disabled,
       emojiMatches,
       handleInput,
       channelMatches,
@@ -1190,6 +1225,8 @@ export function ComposerWysiwygEditor<TData = unknown>({
       insertEmojiShortcode,
       insertMention,
       isOpen,
+      modifierEnterSubmits,
+      onEscape,
       onLinkShortcut,
       onSubmitShortcut,
       selectableMentions,
@@ -1207,11 +1244,17 @@ export function ComposerWysiwygEditor<TData = unknown>({
     blurTimeoutRef.current = setTimeout(() => {
       if (!isSelectingRef.current) {
         closeSuggestions();
+        onBlur?.();
       }
       isSelectingRef.current = false;
       publishActiveFormats();
     }, 150);
-  }, [closeSuggestions, publishActiveFormats, tryFlushTrailingEmoticon]);
+  }, [
+    closeSuggestions,
+    onBlur,
+    publishActiveFormats,
+    tryFlushTrailingEmoticon,
+  ]);
 
   useEffect(() => {
     const onSelectionChange = () => {
@@ -1291,11 +1334,25 @@ export function ComposerWysiwygEditor<TData = unknown>({
       focus: () => {
         editorRef.current?.focus();
       },
+      focusAtEnd: () => {
+        const editor = editorRef.current;
+        if (!editor) return;
+        editor.focus();
+        const selection = window.getSelection();
+        if (!selection) return;
+        const range = document.createRange();
+        range.selectNodeContents(editor);
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      },
       insertText,
       openMentions,
       applyFormat,
       insertLink,
       getSelectedPlainText: () => window.getSelection()?.toString() ?? "",
+      getMarkdown: () =>
+        editorRef.current ? htmlToMarkdown(editorRef.current) : "",
       flushTrailingEmoticon: tryFlushTrailingEmoticon,
     }),
     [
@@ -1312,9 +1369,11 @@ export function ComposerWysiwygEditor<TData = unknown>({
       <div
         ref={editorRef}
         id={id}
-        contentEditable
+        contentEditable={!disabled}
         suppressContentEditableWarning
         enterKeyHint="send"
+        aria-label={ariaLabel}
+        aria-disabled={disabled || undefined}
         onInput={handleInput}
         onPaste={handlePaste}
         onKeyDown={handleKeyDown}

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -289,12 +289,12 @@ export function ComposerWysiwygEditor<TData = unknown>({
   const resolveMentionDisplay = useCallback(
     (mentionKey: string, mentionSlug: string) => {
       const displayName =
-        keyToValue.get(mentionKey) ??
         mentionDisplayByKey?.get(mentionKey) ??
-        slugToValue.get(mentionSlug) ??
+        keyToValue.get(mentionKey) ??
         mentionDisplayBySlug?.get(mentionSlug) ??
-        slugToValue.get(slugifyMentionValue(mentionKey)) ??
-        mentionDisplayBySlug?.get(slugifyMentionValue(mentionKey));
+        slugToValue.get(mentionSlug) ??
+        mentionDisplayBySlug?.get(slugifyMentionValue(mentionKey)) ??
+        slugToValue.get(slugifyMentionValue(mentionKey));
 
       if (displayName) {
         return { displayName, isKnown: true };
@@ -1122,9 +1122,9 @@ export function ComposerWysiwygEditor<TData = unknown>({
         return;
       }
 
-      if (!hasModifier && key === "escape") {
+      if (!hasModifier && key === "escape" && onEscape) {
         event.preventDefault();
-        onEscape?.();
+        onEscape();
         return;
       }
 

--- a/apps/web/src/lib/utils/__tests__/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/__tests__/composer-markdown-dom.test.ts
@@ -36,6 +36,31 @@ describe("markdownToHtml", () => {
     expect(html).toContain("#general");
     expect(html).not.toContain("[#general]");
   });
+
+  it("leaves unknown mention persist tokens as raw text", () => {
+    const html = markdownToHtml("ping @missing:ghost hey");
+    expect(html).toContain("ping @missing:ghost hey");
+    expect(html).not.toContain("data-mention-key");
+  });
+
+  it("wraps persisted internal mention placeholders as chips", () => {
+    const html = markdownToHtml("@@MENTION1@@");
+    expect(html).toContain("data-mention-key");
+    expect(html).not.toContain("@@MENTION1@@");
+  });
+
+  it("wraps known mention persist tokens as display-name chips", () => {
+    const html = markdownToHtml(
+      "ping @user_1:alice-smith hey",
+      (mentionKey, mentionSlug) =>
+        mentionKey === "user_1"
+          ? { displayName: "Alice Smith", isKnown: true }
+          : { displayName: mentionSlug, isKnown: false },
+    );
+    expect(html).toContain("@Alice Smith");
+    expect(html).toContain('data-mention-key="user_1"');
+    expect(html).not.toContain("@user_1:alice-smith");
+  });
 });
 
 describe("htmlToMarkdown", () => {

--- a/apps/web/src/lib/utils/__tests__/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/__tests__/composer-markdown-dom.test.ts
@@ -37,10 +37,18 @@ describe("markdownToHtml", () => {
     expect(html).not.toContain("[#general]");
   });
 
-  it("leaves unknown mention persist tokens as raw text", () => {
-    const html = markdownToHtml("ping @missing:ghost hey");
+  it("leaves unknown mention persist tokens as raw text when wrapping is off", () => {
+    const html = markdownToHtml("ping @missing:ghost hey", undefined, {
+      wrapUnknownMentions: false,
+    });
     expect(html).toContain("ping @missing:ghost hey");
     expect(html).not.toContain("data-mention-key");
+  });
+
+  it("wraps unknown mention persist tokens by default", () => {
+    const html = markdownToHtml("ping @missing:ghost hey");
+    expect(html).toContain("data-mention-key");
+    expect(html).not.toContain("@missing:ghost");
   });
 
   it("wraps persisted internal mention placeholders as chips", () => {
@@ -60,6 +68,18 @@ describe("markdownToHtml", () => {
     expect(html).toContain("@Alice Smith");
     expect(html).toContain('data-mention-key="user_1"');
     expect(html).not.toContain("@user_1:alice-smith");
+  });
+
+  it("round-trips known mention chips back to persist tokens", () => {
+    const source = "ping @user_1:alice-smith hey";
+    const html = markdownToHtml(source, (mentionKey, mentionSlug) =>
+      mentionKey === "user_1"
+        ? { displayName: "Alice Smith", isKnown: true }
+        : { displayName: mentionSlug, isKnown: false },
+    );
+    const root = document.createElement("div");
+    root.innerHTML = html;
+    expect(htmlToMarkdown(root)).toBe(source);
   });
 });
 

--- a/apps/web/src/lib/utils/__tests__/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/__tests__/composer-markdown-dom.test.ts
@@ -57,6 +57,14 @@ describe("markdownToHtml", () => {
     expect(html).not.toContain("@@MENTION1@@");
   });
 
+  it("still wraps @@MENTION salvage tokens when unknown wrapping is off", () => {
+    const html = markdownToHtml("@@MENTION1@@", undefined, {
+      wrapUnknownMentions: false,
+    });
+    expect(html).toContain('data-mention-key="unknown-mention-1"');
+    expect(html).not.toContain("@@MENTION1@@");
+  });
+
   it("wraps known mention persist tokens as display-name chips", () => {
     const html = markdownToHtml(
       "ping @user_1:alice-smith hey",

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -37,6 +37,12 @@ export type ResolveMentionDisplay = (
 
 export interface MarkdownToHtmlOptions {
   channelLinks?: readonly ChannelLinkIdentity[];
+  /**
+   * When false, unknown `@id:slug` tokens stay raw (chat transcript rule).
+   * Default true so task/other composers still chip unknowns.
+   * Internal `@@MENTION@@` salvage placeholders always wrap.
+   */
+  wrapUnknownMentions?: boolean;
 }
 
 function normalizePersistedInternalMentions(text: string): string {
@@ -153,7 +159,11 @@ export function markdownToHtml(
         mention.slug,
       );
       const isInternalPlaceholder = /^unknown-mention-\d+$/.test(mention.id);
-      if (!isKnown && !isInternalPlaceholder) {
+      if (
+        !isKnown &&
+        !isInternalPlaceholder &&
+        options.wrapUnknownMentions === false
+      ) {
         rebuilt += rawMentionToken;
         lastIndex = mention.end;
         continue;

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -24,6 +24,23 @@ import {
 import { parseMentions } from "@/lib/utils/mention-parser";
 
 const PERSISTED_INTERNAL_MENTION_REGEX = /@@MENTION_?(\d+)@@/g;
+const INTERNAL_MENTION_PLACEHOLDER_PREFIX = "unknown-mention-";
+
+function internalMentionPlaceholderKey(index: string): string {
+  return `${INTERNAL_MENTION_PLACEHOLDER_PREFIX}${index}`;
+}
+
+function internalMentionPlaceholderToken(index: string): string {
+  const key = internalMentionPlaceholderKey(index);
+  return `@${key}:${key}`;
+}
+
+function isInternalMentionPlaceholderId(id: string): boolean {
+  if (!id.startsWith(INTERNAL_MENTION_PLACEHOLDER_PREFIX)) {
+    return false;
+  }
+  return /^\d+$/.test(id.slice(INTERNAL_MENTION_PLACEHOLDER_PREFIX.length));
+}
 
 export interface MentionDisplayResolution {
   displayName: string;
@@ -49,7 +66,7 @@ function normalizePersistedInternalMentions(text: string): string {
   return text.replace(
     PERSISTED_INTERNAL_MENTION_REGEX,
     (_match, mentionIndex: string) =>
-      `@unknown-mention-${mentionIndex}:unknown-mention-${mentionIndex}`,
+      internalMentionPlaceholderToken(mentionIndex),
   );
 }
 
@@ -158,7 +175,7 @@ export function markdownToHtml(
         mention.id,
         mention.slug,
       );
-      const isInternalPlaceholder = /^unknown-mention-\d+$/.test(mention.id);
+      const isInternalPlaceholder = isInternalMentionPlaceholderId(mention.id);
       if (
         !isKnown &&
         !isInternalPlaceholder &&

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -148,11 +148,18 @@ export function markdownToHtml(
         continue;
       }
 
-      const token = `@@MENTIONTOKEN${mentionTokens.length}@@`;
       const { displayName, isKnown } = resolveMentionDisplay(
         mention.id,
         mention.slug,
       );
+      const isInternalPlaceholder = /^unknown-mention-\d+$/.test(mention.id);
+      if (!isKnown && !isInternalPlaceholder) {
+        rebuilt += rawMentionToken;
+        lastIndex = mention.end;
+        continue;
+      }
+
+      const token = `@@MENTIONTOKEN${mentionTokens.length}@@`;
       const mentionSpan = createMentionSpan(
         mention.id,
         mention.slug,


### PR DESCRIPTION
## Summary

Composer quote preview and message edit showed stored `@id:slug` User mentions (including mentions of you). Posted quotes already rendered `@Display Name`. Display now resolves against the room roster, including the current user. The `@` picker still omits you. Persist format is unchanged.

- Quote preview (channel + thread): same chip as a posted quote
- Edit: WYSIWYG chips; Enter saves, Esc cancels, blur-if-unchanged cancels; no format toolbar
- Live send box: hydrate chips self-mentions; paste stays plain text
- Unknown mentions stay raw `@id:slug`

## Verification

- `pnpm test`
- `pnpm check` / `pnpm typecheck` (pre-commit)

Quote a message that mentions you and confirm the composer preview shows `@Your Name`. Edit a message with a User mention and confirm the chip, not the persist token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved chat message editing with rich-text composition, mentions, channel suggestions, focus handling, and keyboard shortcuts.
  - Roster users and coworkers now resolve to readable mention chips, including users absent from the mention picker.
  - Mentions are preserved correctly when editing and saving messages.

- **Bug Fixes**
  - Unknown mention tokens are preserved safely without displaying incorrect labels.
  - Improved blur, Escape, accessibility, and disabled-state behavior in the message editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->