### PR TITLE
feat(chat): show latest pin under header

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -5203,7 +5203,10 @@
         "roomRequired": "Raum ist erforderlich.",
         "pinError": "Nachricht konnte nicht angeheftet werden.",
         "unpinError": "Nachricht konnte nicht gelöst werden.",
-        "count": "{count, plural, =0 {Angeheftet} one {# angeheftet} other {# angeheftet}}"
+        "count": "{count, plural, =0 {Angeheftet} one {# angeheftet} other {# angeheftet}}",
+        "latest": "Neueste Anheftung",
+        "jumpToLatest": "Zur angehefteten Nachricht von {author} springen",
+        "viewAll": "Alle angehefteten Nachrichten anzeigen"
       },
       "Quote": {
         "action": "Zitieren",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5203,7 +5203,10 @@
         "roomRequired": "Room is required.",
         "pinError": "Could not pin message.",
         "unpinError": "Could not unpin message.",
-        "count": "{count, plural, =0 {Pinned} one {# pinned} other {# pinned}}"
+        "count": "{count, plural, =0 {Pinned} one {# pinned} other {# pinned}}",
+        "latest": "Latest pin",
+        "jumpToLatest": "Jump to pinned message from {author}",
+        "viewAll": "View all pinned messages"
       },
       "Quote": {
         "action": "Quote",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -5203,7 +5203,10 @@
         "roomRequired": "La sala es obligatoria.",
         "pinError": "No se pudo fijar el mensaje.",
         "unpinError": "No se pudo desfijar el mensaje.",
-        "count": "{count, plural, =0 {Fijados} one {# fijado} other {# fijados}}"
+        "count": "{count, plural, =0 {Fijados} one {# fijado} other {# fijados}}",
+        "latest": "Último fijado",
+        "jumpToLatest": "Ir al mensaje fijado de {author}",
+        "viewAll": "Ver todos los mensajes fijados"
       },
       "Quote": {
         "action": "Citar",

--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -844,11 +844,12 @@ export async function pinRoomMessageAction(
 
 export async function listPinnedMessagesAction(
   roomId: string,
-  options?: { cursor?: string },
+  options?: { cursor?: string; limit?: number },
 ): Promise<
   RoomActionResult<{
     items: ChatRoomPinnedMessageListItem[];
     nextCursor: string | null;
+    total: number;
   }>
 > {
   const t = await getTranslations("App.Channels.PinnedMessages");
@@ -860,6 +861,7 @@ export async function listPinnedMessagesAction(
   try {
     const page = await chatRoomService.listPinnedMessages(cleanRoomId, {
       cursor: options?.cursor,
+      limit: options?.limit,
     });
     return roomOk(page);
   } catch (error) {

--- a/apps/web/src/app/(app)/chat/components/__tests__/latest-pinned-message-banner.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/latest-pinned-message-banner.test.tsx
@@ -1,5 +1,7 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ChatRoomMessage,
@@ -67,12 +69,28 @@ const labels = {
   couldNotLoad: "Message could not be loaded",
 };
 
+function createBannerQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
 function renderBanner(
   overrides: Partial<Parameters<typeof LatestPinnedMessageBanner>[0]> = {},
 ) {
   const onJump = vi.fn();
   const onOpenAll = vi.fn();
   const onIdsLoaded = vi.fn();
+  const queryClient = createBannerQueryClient();
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
   const result = render(
     <LatestPinnedMessageBanner
       roomId="room-channel"
@@ -83,6 +101,7 @@ function renderBanner(
       onIdsLoaded={onIdsLoaded}
       {...overrides}
     />,
+    { wrapper: Wrapper },
   );
   return { ...result, onJump, onOpenAll, onIdsLoaded };
 }
@@ -196,7 +215,7 @@ describe("LatestPinnedMessageBanner", () => {
     });
   });
 
-  it("keeps the current pin when a later refetch fails", async () => {
+  it("hides the banner when a later same-room fetch fails", async () => {
     listPinnedMessagesAction
       .mockResolvedValueOnce({
         ok: true,
@@ -224,9 +243,9 @@ describe("LatestPinnedMessageBanner", () => {
     await waitFor(() => {
       expect(listPinnedMessagesAction).toHaveBeenCalledTimes(2);
     });
-    expect(screen.getByTestId("latest-pinned-message")).toHaveTextContent(
-      "Don't freeze Friday",
-    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("latest-pinned-message")).toBeNull();
+    });
   });
 
   it("does not keep the previous room's pin when the next room fails to load", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/latest-pinned-message-banner.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/latest-pinned-message-banner.test.tsx
@@ -1,0 +1,321 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ChatRoomMessage,
+  ChatRoomPinnedMessageListItem,
+} from "@/lib/clients/generated/core";
+import {
+  LATEST_PINNED_FETCH_LIMIT,
+  LatestPinnedMessageBanner,
+} from "../latest-pinned-message-banner";
+
+const listPinnedMessagesAction = vi.fn();
+
+vi.mock("@/app/chat/actions", () => ({
+  listPinnedMessagesAction: (...args: unknown[]) =>
+    listPinnedMessagesAction(...args),
+}));
+
+function message(id: string, content: string, name = "Ada"): ChatRoomMessage {
+  return {
+    id,
+    roomId: "room-channel",
+    parentMessageId: null,
+    content,
+    createdAt: new Date("2026-08-26T12:00:00.000Z"),
+    editedAt: null,
+    deletedAt: null,
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: null,
+    quote: null,
+    membership: null,
+    unfurls: null,
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name,
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+  };
+}
+
+function pinItem(
+  overrides: Partial<ChatRoomPinnedMessageListItem> = {},
+): ChatRoomPinnedMessageListItem {
+  return {
+    messageId: "msg-latest",
+    pinnedAt: new Date("2026-08-26T15:00:00.000Z"),
+    pinnedBy: { id: "user-1", name: "Ada" },
+    message: message("msg-latest", "Don't freeze Friday"),
+    ...overrides,
+  };
+}
+
+const labels = {
+  latest: "Latest pin",
+  jumpToLatest: (author: string) => `Jump to pinned message from ${author}`,
+  viewAll: "View all pinned messages",
+  count: (count: number) => `${count} pinned`,
+  couldNotLoad: "Message could not be loaded",
+};
+
+function renderBanner(
+  overrides: Partial<Parameters<typeof LatestPinnedMessageBanner>[0]> = {},
+) {
+  const onJump = vi.fn();
+  const onOpenAll = vi.fn();
+  const onIdsLoaded = vi.fn();
+  const result = render(
+    <LatestPinnedMessageBanner
+      roomId="room-channel"
+      listGeneration={0}
+      labels={labels}
+      onJump={onJump}
+      onOpenAll={onOpenAll}
+      onIdsLoaded={onIdsLoaded}
+      {...overrides}
+    />,
+  );
+  return { ...result, onJump, onOpenAll, onIdsLoaded };
+}
+
+describe("LatestPinnedMessageBanner", () => {
+  beforeEach(() => {
+    listPinnedMessagesAction.mockReset();
+  });
+
+  it("renders the newest pin under the header after load", async () => {
+    listPinnedMessagesAction.mockResolvedValue({
+      ok: true,
+      value: {
+        items: [pinItem(), pinItem({ messageId: "msg-old" })],
+        nextCursor: null,
+        total: 2,
+      },
+    });
+
+    renderBanner();
+
+    expect(listPinnedMessagesAction).toHaveBeenCalledWith("room-channel", {
+      limit: LATEST_PINNED_FETCH_LIMIT,
+    });
+    const banner = await screen.findByTestId("latest-pinned-message");
+    expect(banner).toHaveTextContent("Latest pin");
+    expect(banner).toHaveTextContent("Ada");
+    expect(banner).toHaveTextContent("Don't freeze Friday");
+    expect(
+      screen.getByRole("button", {
+        name: "Jump to pinned message from Ada",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("jumps to the latest pin on click", async () => {
+    listPinnedMessagesAction.mockResolvedValue({
+      ok: true,
+      value: { items: [pinItem()], nextCursor: null, total: 1 },
+    });
+    const user = userEvent.setup();
+    const { onJump, onOpenAll } = renderBanner();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Jump to pinned message from Ada",
+      }),
+    );
+
+    expect(onJump).toHaveBeenCalledWith("msg-latest");
+    expect(onOpenAll).not.toHaveBeenCalled();
+  });
+
+  it("opens the full pin list from the count when more than one pin exists", async () => {
+    listPinnedMessagesAction.mockResolvedValue({
+      ok: true,
+      value: { items: [pinItem()], nextCursor: "next", total: 3 },
+    });
+    const user = userEvent.setup();
+    const { onJump, onOpenAll, onIdsLoaded } = renderBanner();
+
+    const count = await screen.findByRole("button", {
+      name: "View all pinned messages",
+    });
+    expect(count).toHaveTextContent("3 pinned");
+    await user.click(count);
+
+    expect(onOpenAll).toHaveBeenCalledTimes(1);
+    expect(onJump).not.toHaveBeenCalled();
+    expect(onIdsLoaded).toHaveBeenCalledWith(["msg-latest"]);
+  });
+
+  it("keeps the current pin visible while a later pin list refetch is in flight", async () => {
+    let resolveRefetch: ((value: unknown) => void) | undefined;
+    listPinnedMessagesAction
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { items: [pinItem()], nextCursor: null, total: 1 },
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefetch = resolve;
+          }),
+      );
+
+    const { rerender, onJump, onOpenAll, onIdsLoaded } = renderBanner();
+    expect(await screen.findByTestId("latest-pinned-message")).toBeTruthy();
+
+    rerender(
+      <LatestPinnedMessageBanner
+        roomId="room-channel"
+        listGeneration={1}
+        labels={labels}
+        onJump={onJump}
+        onOpenAll={onOpenAll}
+        onIdsLoaded={onIdsLoaded}
+      />,
+    );
+
+    expect(screen.getByTestId("latest-pinned-message")).toHaveTextContent(
+      "Don't freeze Friday",
+    );
+    expect(screen.queryByTestId("latest-pinned-message-loading")).toBeNull();
+    resolveRefetch?.({
+      ok: true,
+      value: { items: [pinItem()], nextCursor: null, total: 1 },
+    });
+    await waitFor(() => {
+      expect(listPinnedMessagesAction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("keeps the current pin when a later refetch fails", async () => {
+    listPinnedMessagesAction
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { items: [pinItem()], nextCursor: null, total: 1 },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: { message: "Could not load pinned messages" },
+      });
+
+    const { rerender, onJump, onOpenAll, onIdsLoaded } = renderBanner();
+    expect(await screen.findByTestId("latest-pinned-message")).toBeTruthy();
+
+    rerender(
+      <LatestPinnedMessageBanner
+        roomId="room-channel"
+        listGeneration={1}
+        labels={labels}
+        onJump={onJump}
+        onOpenAll={onOpenAll}
+        onIdsLoaded={onIdsLoaded}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listPinnedMessagesAction).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByTestId("latest-pinned-message")).toHaveTextContent(
+      "Don't freeze Friday",
+    );
+  });
+
+  it("does not keep the previous room's pin when the next room fails to load", async () => {
+    listPinnedMessagesAction
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { items: [pinItem()], nextCursor: null, total: 1 },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: { message: "Could not load pinned messages" },
+      });
+
+    const { rerender, onJump, onOpenAll, onIdsLoaded } = renderBanner();
+    expect(await screen.findByTestId("latest-pinned-message")).toBeTruthy();
+
+    rerender(
+      <LatestPinnedMessageBanner
+        roomId="room-other"
+        listGeneration={0}
+        labels={labels}
+        onJump={onJump}
+        onOpenAll={onOpenAll}
+        onIdsLoaded={onIdsLoaded}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listPinnedMessagesAction).toHaveBeenCalledWith("room-other", {
+        limit: LATEST_PINNED_FETCH_LIMIT,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("latest-pinned-message")).toBeNull();
+    });
+  });
+
+  it("hides when the channel has no pins", async () => {
+    listPinnedMessagesAction.mockResolvedValue({
+      ok: true,
+      value: { items: [], nextCursor: null, total: 0 },
+    });
+
+    renderBanner();
+
+    await waitFor(() => {
+      expect(listPinnedMessagesAction).toHaveBeenCalled();
+      expect(screen.queryByTestId("latest-pinned-message-loading")).toBeNull();
+    });
+    expect(screen.queryByTestId("latest-pinned-message")).toBeNull();
+  });
+
+  it("skips a deleted newest pin in favor of the next loadable message", async () => {
+    listPinnedMessagesAction.mockResolvedValue({
+      ok: true,
+      value: {
+        items: [
+          pinItem({ message: null, messageId: "msg-deleted" }),
+          pinItem({
+            messageId: "msg-ok",
+            message: message("msg-ok", "Still here"),
+          }),
+        ],
+        nextCursor: null,
+        total: 2,
+      },
+    });
+
+    renderBanner();
+
+    const banner = await screen.findByTestId("latest-pinned-message");
+    expect(banner).toHaveTextContent("Still here");
+    expect(banner).not.toHaveTextContent("Message could not be loaded");
+  });
+
+  it("shows a deleted latest pin as unloadable without jumping", async () => {
+    listPinnedMessagesAction.mockResolvedValue({
+      ok: true,
+      value: {
+        items: [pinItem({ message: null, messageId: "msg-deleted" })],
+        nextCursor: null,
+        total: 1,
+      },
+    });
+    const user = userEvent.setup();
+    const { onJump, onOpenAll } = renderBanner();
+
+    await user.click(await screen.findByText("Message could not be loaded"));
+    expect(onJump).not.toHaveBeenCalled();
+    expect(onOpenAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/latest-pinned-message-banner.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/latest-pinned-message-banner.test.tsx
@@ -162,6 +162,44 @@ describe("LatestPinnedMessageBanner", () => {
     expect(jump.querySelector(".whitespace-nowrap")).toHaveTextContent("@all");
   });
 
+  it("keeps a long pinned message to a single preview line", async () => {
+    listPinnedMessagesAction.mockResolvedValue({
+      ok: true,
+      value: {
+        items: [
+          pinItem({
+            message: message(
+              "msg-latest",
+              [
+                "@all:all Okay, so I have another big update for today.",
+                "",
+                "- Sokosumi, an AI platform for Marketing.",
+                "- Masumi, an Agent Wallet.",
+              ].join("\n"),
+            ),
+          }),
+        ],
+        nextCursor: null,
+        total: 1,
+      },
+    });
+
+    renderBanner();
+
+    const jump = await screen.findByRole("button", {
+      name: "Jump to pinned message from Ada",
+    });
+    const snippet = jump.querySelector(
+      "[data-testid='latest-pinned-message-snippet']",
+    );
+    expect(snippet).toBeTruthy();
+    expect(snippet).toHaveClass("truncate");
+    expect(jump.querySelector("ul, ol, li")).toBeNull();
+    expect(jump).toHaveTextContent("@all");
+    expect(jump).not.toHaveTextContent("@all:all");
+    expect(jump).toHaveTextContent("Sokosumi");
+  });
+
   it("jumps to the latest pin on click", async () => {
     listPinnedMessagesAction.mockResolvedValue({
       ok: true,

--- a/apps/web/src/app/(app)/chat/components/__tests__/latest-pinned-message-banner.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/latest-pinned-message-banner.test.tsx
@@ -137,6 +137,31 @@ describe("LatestPinnedMessageBanner", () => {
     ).toBeTruthy();
   });
 
+  it("renders persist mention tokens as @all chips in the preview", async () => {
+    listPinnedMessagesAction.mockResolvedValue({
+      ok: true,
+      value: {
+        items: [
+          pinItem({
+            message: message("msg-latest", "@all:all Okay, so"),
+          }),
+        ],
+        nextCursor: null,
+        total: 1,
+      },
+    });
+
+    renderBanner();
+
+    const jump = await screen.findByRole("button", {
+      name: "Jump to pinned message from Ada",
+    });
+    expect(jump).toHaveTextContent("@all");
+    expect(jump).toHaveTextContent("Okay, so");
+    expect(jump).not.toHaveTextContent("@all:all");
+    expect(jump.querySelector(".whitespace-nowrap")).toHaveTextContent("@all");
+  });
+
   it("jumps to the latest pin on click", async () => {
     listPinnedMessagesAction.mockResolvedValue({
       ok: true,

--- a/apps/web/src/app/(app)/chat/components/__tests__/pick-latest-pinned-message.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/pick-latest-pinned-message.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ChatRoomMessage,
+  ChatRoomPinnedMessageListItem,
+} from "@/lib/clients/generated/core";
+import { pickLatestPinnedMessage } from "../pick-latest-pinned-message";
+
+function message(id: string, content: string): ChatRoomMessage {
+  return {
+    id,
+    roomId: "room-1",
+    parentMessageId: null,
+    content,
+    createdAt: new Date("2026-08-26T12:00:00.000Z"),
+    editedAt: null,
+    deletedAt: null,
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: null,
+    quote: null,
+    membership: null,
+    unfurls: null,
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+  };
+}
+
+function pin(
+  overrides: Partial<ChatRoomPinnedMessageListItem> &
+    Pick<ChatRoomPinnedMessageListItem, "messageId">,
+): ChatRoomPinnedMessageListItem {
+  return {
+    pinnedAt: new Date("2026-08-26T12:00:00.000Z"),
+    pinnedBy: { id: "user-1", name: "Ada" },
+    message: message(overrides.messageId, "Pinned"),
+    ...overrides,
+  };
+}
+
+describe("pickLatestPinnedMessage", () => {
+  it("returns null when there are no pins", () => {
+    expect(pickLatestPinnedMessage([])).toBeNull();
+  });
+
+  it("returns the first pin because the API lists newest pin first", () => {
+    const latest = pin({
+      messageId: "msg-new",
+      message: message("msg-new", "Newest pin"),
+    });
+    const older = pin({
+      messageId: "msg-old",
+      message: message("msg-old", "Older pin"),
+    });
+
+    expect(pickLatestPinnedMessage([latest, older])).toBe(latest);
+  });
+
+  it("skips a deleted latest pin in favor of the next loadable message", () => {
+    const deletedLatest = pin({
+      messageId: "msg-deleted",
+      message: null,
+    });
+    const loadable = pin({
+      messageId: "msg-ok",
+      message: message("msg-ok", "Still here"),
+    });
+
+    expect(pickLatestPinnedMessage([deletedLatest, loadable])).toBe(loadable);
+  });
+
+  it("returns the deleted latest pin when nothing else loaded", () => {
+    const deletedLatest = pin({
+      messageId: "msg-deleted",
+      message: null,
+    });
+
+    expect(pickLatestPinnedMessage([deletedLatest])).toBe(deletedLatest);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, screen, waitFor } from "@testing-library/react";
 
 import userEvent from "@testing-library/user-event";
@@ -304,7 +305,18 @@ function roomClientProps(room: ChatRoom) {
 }
 
 function renderRoom(room: ChatRoom) {
-  return render(<RoomsClient {...roomClientProps(room)} />);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RoomsClient {...roomClientProps(room)} />
+    </QueryClientProvider>,
+  );
 }
 
 describe("RoomsClient room header chrome", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode, type Ref, useImperativeHandle } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { listPinnedMessagesAction } from "@/app/chat/actions";
 import type {
   ChatRoom,
   ChatRoomMessage,
@@ -114,6 +115,10 @@ vi.mock("@/app/chat/actions", () => ({
   deleteRoomMessageAction: vi.fn(),
   editRoomMessageAction: vi.fn(),
   listRoomMessagesAction: vi.fn(),
+  listPinnedMessagesAction: vi.fn(async () => ({
+    ok: true as const,
+    value: { items: [], nextCursor: null, total: 0 },
+  })),
   listThreadMessagesAction: vi.fn(),
   markThreadReadAction: vi.fn(),
   retryRoomMentionAction: vi.fn(),
@@ -457,5 +462,70 @@ describe("RoomsClient room header chrome", () => {
     renderRoom(groupDirectRoom());
     expect(await screen.findByTestId("room-roster-trigger")).toBeTruthy();
     expect(screen.queryByTestId("edit-channel-dialog-probe")).toBeNull();
+  });
+
+  it("highlights the latest pinned message under the Channel header", async () => {
+    vi.mocked(listPinnedMessagesAction).mockResolvedValue({
+      ok: true,
+      value: {
+        items: [
+          {
+            messageId: "msg-latest-pin",
+            pinnedAt: new Date("2026-08-26T15:00:00.000Z"),
+            pinnedBy: { id: "user-1", name: "Ada" },
+            message: {
+              id: "msg-latest-pin",
+              roomId: "room-channel",
+              parentMessageId: null,
+              content: "Don't freeze Friday",
+              createdAt: new Date("2026-08-26T14:00:00.000Z"),
+              editedAt: null,
+              deletedAt: null,
+              mentions: [],
+              reactions: [],
+              threadReplyCount: 0,
+              threadLastReplyAt: null,
+              metadata: null,
+              quote: null,
+              membership: null,
+              unfurls: null,
+              sender: {
+                type: "user",
+                user: {
+                  id: "user-1",
+                  name: "Ada",
+                  email: "ada@example.com",
+                  image: null,
+                  presence: "offline",
+                },
+              },
+            },
+          },
+        ],
+        nextCursor: null,
+        total: 2,
+      },
+    });
+
+    const { container } = renderRoom({
+      ...channelRoom(),
+      pinnedMessageCount: 2,
+    });
+
+    const banner = await screen.findByTestId("latest-pinned-message");
+    const header = container.querySelector("header");
+    expect(header?.nextElementSibling).toBe(banner);
+    expect(banner).toHaveTextContent("PinnedMessages.latest");
+    expect(banner).toHaveTextContent("Ada");
+    expect(banner).toHaveTextContent("Don't freeze Friday");
+    expect(banner).toHaveTextContent("PinnedMessages.count");
+    expect(screen.getByTestId("room-open-title")).not.toContainElement(banner);
+  });
+
+  it("does not show a latest pin on Directs", async () => {
+    renderRoom({ ...humanDirectRoom(), pinnedMessageCount: 3 });
+    await screen.findByTestId("room-open-title");
+    expect(screen.queryByTestId("latest-pinned-message")).toBeNull();
+    expect(screen.queryByTestId("latest-pinned-message-loading")).toBeNull();
   });
 });

--- a/apps/web/src/app/(app)/chat/components/latest-pinned-message-banner.tsx
+++ b/apps/web/src/app/(app)/chat/components/latest-pinned-message-banner.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { buildQuoteSnippet } from "@sokosumi/utils";
+import type { ChannelLinkTarget } from "@sokosumi/utils";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { Pin } from "lucide-react";
 import { listPinnedMessagesAction } from "@/app/chat/actions";
-import type { ChatRoomPinnedMessageListItem } from "@/lib/clients/generated/core";
+import type {
+  ChatRoomCoworkerParticipant,
+  ChatRoomPinnedMessageListItem,
+} from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { pickLatestPinnedMessage } from "./pick-latest-pinned-message";
-import { messageSender } from "./room-helpers";
+import {
+  type MentionHoverUserLookup,
+  messageSender,
+  ROOM_QUOTE_MARKDOWN_CLASSNAME,
+} from "./room-helpers";
+import { RoomMessageMarkdown } from "./room-mention-markdown";
 
 export interface LatestPinnedMessageBannerLabels {
   latest: string;
@@ -24,15 +32,24 @@ export interface LatestPinnedMessageBannerProps {
   onJump: (messageId: string) => void;
   onOpenAll: () => void;
   onIdsLoaded: (messageIds: readonly string[]) => void;
+  coworkersById?: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug?: Map<string, ChatRoomCoworkerParticipant>;
+  usersById?: Map<string, MentionHoverUserLookup>;
+  usersBySlug?: Map<string, MentionHoverUserLookup>;
+  channelLinks?: readonly ChannelLinkTarget[];
 }
 
 /** Page large enough to skip a few deleted newest pins. */
 export const LATEST_PINNED_FETCH_LIMIT = 8;
 
+const EMPTY_COWORKER_MAP = new Map<string, ChatRoomCoworkerParticipant>();
+const EMPTY_USER_MAP = new Map<string, MentionHoverUserLookup>();
+const EMPTY_CHANNEL_LINKS: ChannelLinkTarget[] = [];
+
 interface LatestPinnedBannerState {
   messageId: string;
   authorName: string | null;
-  snippet: string | null;
+  content: string | null;
   total: number;
 }
 
@@ -57,7 +74,7 @@ function selectLatestPinnedBanner(
   return {
     messageId: latest.messageId,
     authorName: message ? messageSender(message).name : null,
-    snippet: message ? buildQuoteSnippet(message.content) : null,
+    content: message ? message.content : null,
     total: page.total,
   };
 }
@@ -69,6 +86,11 @@ export function LatestPinnedMessageBanner({
   onJump,
   onOpenAll,
   onIdsLoaded,
+  coworkersById = EMPTY_COWORKER_MAP,
+  coworkersBySlug = EMPTY_COWORKER_MAP,
+  usersById = EMPTY_USER_MAP,
+  usersBySlug = EMPTY_USER_MAP,
+  channelLinks = EMPTY_CHANNEL_LINKS,
 }: LatestPinnedMessageBannerProps): React.ReactElement | null {
   const query = useQuery({
     queryKey: latestPinnedMessageQueryKey(roomId, listGeneration),
@@ -114,7 +136,7 @@ export function LatestPinnedMessageBanner({
   }
 
   const authorName = pin.authorName;
-  const snippet = pin.snippet;
+  const content = pin.content;
 
   return (
     <div
@@ -135,7 +157,7 @@ export function LatestPinnedMessageBanner({
           <p className="text-primary text-xs font-medium tracking-wide">
             {labels.latest}
           </p>
-          {authorName != null && snippet != null ? (
+          {authorName != null && content != null ? (
             <button
               type="button"
               className="flex min-w-0 max-w-full cursor-pointer items-baseline gap-1.5 text-left text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
@@ -147,8 +169,17 @@ export function LatestPinnedMessageBanner({
               <span className="text-foreground shrink-0 font-medium">
                 {authorName}
               </span>
-              <span className="text-muted-foreground min-w-0 truncate">
-                {snippet}
+              <span className="text-muted-foreground min-w-0 truncate text-sm [&_p]:inline">
+                <RoomMessageMarkdown
+                  content={content}
+                  markdownClassName={ROOM_QUOTE_MARKDOWN_CLASSNAME}
+                  coworkersById={coworkersById}
+                  coworkersBySlug={coworkersBySlug}
+                  usersById={usersById}
+                  usersBySlug={usersBySlug}
+                  channelLinks={channelLinks}
+                  hoverInteractive={false}
+                />
               </span>
             </button>
           ) : (

--- a/apps/web/src/app/(app)/chat/components/latest-pinned-message-banner.tsx
+++ b/apps/web/src/app/(app)/chat/components/latest-pinned-message-banner.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { buildQuoteSnippet } from "@sokosumi/utils";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { Pin } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
 import { listPinnedMessagesAction } from "@/app/chat/actions";
+import type { ChatRoomPinnedMessageListItem } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { pickLatestPinnedMessage } from "./pick-latest-pinned-message";
 import { messageSender } from "./room-helpers";
@@ -35,6 +36,32 @@ interface LatestPinnedBannerState {
   total: number;
 }
 
+interface LatestPinnedMessagesPage {
+  items: ChatRoomPinnedMessageListItem[];
+  nextCursor: string | null;
+  total: number;
+}
+
+function latestPinnedMessageQueryKey(roomId: string, listGeneration: number) {
+  return ["latest-pinned-message", roomId, listGeneration] as const;
+}
+
+function selectLatestPinnedBanner(
+  page: LatestPinnedMessagesPage,
+): LatestPinnedBannerState | null {
+  const latest = pickLatestPinnedMessage(page.items);
+  if (!latest) {
+    return null;
+  }
+  const message = latest.message;
+  return {
+    messageId: latest.messageId,
+    authorName: message ? messageSender(message).name : null,
+    snippet: message ? buildQuoteSnippet(message.content) : null,
+    total: page.total,
+  };
+}
+
 export function LatestPinnedMessageBanner({
   roomId,
   listGeneration,
@@ -43,68 +70,30 @@ export function LatestPinnedMessageBanner({
   onOpenAll,
   onIdsLoaded,
 }: LatestPinnedMessageBannerProps): React.ReactElement | null {
-  const [isLoading, setIsLoading] = useState(true);
-  const [pin, setPin] = useState<LatestPinnedBannerState | null>(null);
-  const loadedRoomIdRef = useRef<string | null>(null);
-  const pinRef = useRef(pin);
-  pinRef.current = pin;
-
-  useEffect(() => {
-    let cancelled = false;
-    if (loadedRoomIdRef.current !== roomId) {
-      pinRef.current = null;
-      setPin(null);
-    }
-    setIsLoading(true);
-    void listPinnedMessagesAction(roomId, {
-      limit: LATEST_PINNED_FETCH_LIMIT,
-    })
-      .then((result) => {
-        if (cancelled) {
-          return;
-        }
-        if (!result.ok) {
-          loadedRoomIdRef.current = roomId;
-          if (pinRef.current == null) {
-            setPin(null);
-          }
-          setIsLoading(false);
-          return;
-        }
-        const latest = pickLatestPinnedMessage(result.value.items);
-        onIdsLoaded(result.value.items.map((item) => item.messageId));
-        if (!latest) {
-          loadedRoomIdRef.current = roomId;
-          setPin(null);
-          setIsLoading(false);
-          return;
-        }
-        const message = latest.message;
-        loadedRoomIdRef.current = roomId;
-        setPin({
-          messageId: latest.messageId,
-          authorName: message ? messageSender(message).name : null,
-          snippet: message ? buildQuoteSnippet(message.content) : null,
-          total: result.value.total,
-        });
-        setIsLoading(false);
-      })
-      .catch(() => {
-        if (cancelled) {
-          return;
-        }
-        loadedRoomIdRef.current = roomId;
-        if (pinRef.current == null) {
-          setPin(null);
-        }
-        setIsLoading(false);
+  const query = useQuery({
+    queryKey: latestPinnedMessageQueryKey(roomId, listGeneration),
+    queryFn: async () => {
+      const result = await listPinnedMessagesAction(roomId, {
+        limit: LATEST_PINNED_FETCH_LIMIT,
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [listGeneration, onIdsLoaded, roomId]);
+      if (!result.ok) {
+        throw new Error(result.error.message ?? undefined);
+      }
+      onIdsLoaded(result.value.items.map((item) => item.messageId));
+      return result.value;
+    },
+    placeholderData: (previousData, previousQuery) => {
+      if (previousQuery?.queryKey[1] !== roomId) {
+        return undefined;
+      }
+      return keepPreviousData(previousData);
+    },
+    select: selectLatestPinnedBanner,
+  });
 
-  if (isLoading && pin == null) {
+  const pin = query.data;
+
+  if (query.isPending && pin === undefined) {
     return (
       <div
         className="border-border bg-muted/40 flex h-11 shrink-0 items-stretch border-b"
@@ -120,7 +109,7 @@ export function LatestPinnedMessageBanner({
     );
   }
 
-  if (!pin) {
+  if (pin == null) {
     return null;
   }
 

--- a/apps/web/src/app/(app)/chat/components/latest-pinned-message-banner.tsx
+++ b/apps/web/src/app/(app)/chat/components/latest-pinned-message-banner.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { buildQuoteSnippet } from "@sokosumi/utils";
+import { Pin } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { listPinnedMessagesAction } from "@/app/chat/actions";
+import { cn } from "@/lib/utils";
+import { pickLatestPinnedMessage } from "./pick-latest-pinned-message";
+import { messageSender } from "./room-helpers";
+
+export interface LatestPinnedMessageBannerLabels {
+  latest: string;
+  jumpToLatest: (author: string) => string;
+  viewAll: string;
+  count: (count: number) => string;
+  couldNotLoad: string;
+}
+
+export interface LatestPinnedMessageBannerProps {
+  roomId: string;
+  listGeneration: number;
+  labels: LatestPinnedMessageBannerLabels;
+  onJump: (messageId: string) => void;
+  onOpenAll: () => void;
+  onIdsLoaded: (messageIds: readonly string[]) => void;
+}
+
+/** Page large enough to skip a few deleted newest pins. */
+export const LATEST_PINNED_FETCH_LIMIT = 8;
+
+interface LatestPinnedBannerState {
+  messageId: string;
+  authorName: string | null;
+  snippet: string | null;
+  total: number;
+}
+
+export function LatestPinnedMessageBanner({
+  roomId,
+  listGeneration,
+  labels,
+  onJump,
+  onOpenAll,
+  onIdsLoaded,
+}: LatestPinnedMessageBannerProps): React.ReactElement | null {
+  const [isLoading, setIsLoading] = useState(true);
+  const [pin, setPin] = useState<LatestPinnedBannerState | null>(null);
+  const loadedRoomIdRef = useRef<string | null>(null);
+  const pinRef = useRef(pin);
+  pinRef.current = pin;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (loadedRoomIdRef.current !== roomId) {
+      pinRef.current = null;
+      setPin(null);
+    }
+    setIsLoading(true);
+    void listPinnedMessagesAction(roomId, {
+      limit: LATEST_PINNED_FETCH_LIMIT,
+    })
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        if (!result.ok) {
+          loadedRoomIdRef.current = roomId;
+          if (pinRef.current == null) {
+            setPin(null);
+          }
+          setIsLoading(false);
+          return;
+        }
+        const latest = pickLatestPinnedMessage(result.value.items);
+        onIdsLoaded(result.value.items.map((item) => item.messageId));
+        if (!latest) {
+          loadedRoomIdRef.current = roomId;
+          setPin(null);
+          setIsLoading(false);
+          return;
+        }
+        const message = latest.message;
+        loadedRoomIdRef.current = roomId;
+        setPin({
+          messageId: latest.messageId,
+          authorName: message ? messageSender(message).name : null,
+          snippet: message ? buildQuoteSnippet(message.content) : null,
+          total: result.value.total,
+        });
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        loadedRoomIdRef.current = roomId;
+        if (pinRef.current == null) {
+          setPin(null);
+        }
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [listGeneration, onIdsLoaded, roomId]);
+
+  if (isLoading && pin == null) {
+    return (
+      <div
+        className="border-border bg-muted/40 flex h-11 shrink-0 items-stretch border-b"
+        data-testid="latest-pinned-message-loading"
+        aria-hidden
+      >
+        <div className="bg-primary/40 w-1 shrink-0" />
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-3 md:px-6">
+          <div className="bg-muted size-3.5 animate-pulse rounded-full" />
+          <div className="bg-muted h-3 w-40 animate-pulse rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!pin) {
+    return null;
+  }
+
+  const authorName = pin.authorName;
+  const snippet = pin.snippet;
+
+  return (
+    <div
+      className="border-border bg-muted/40 flex min-h-11 shrink-0 items-stretch border-b"
+      data-testid="latest-pinned-message"
+      role="region"
+      aria-label={labels.latest}
+    >
+      <div className="bg-primary w-1 shrink-0" aria-hidden />
+      <div className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 md:px-6">
+        <Pin
+          className="text-primary size-3.5 shrink-0"
+          fill="currentColor"
+          fillOpacity={0.25}
+          aria-hidden
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-primary text-xs font-medium tracking-wide">
+            {labels.latest}
+          </p>
+          {authorName != null && snippet != null ? (
+            <button
+              type="button"
+              className="flex min-w-0 max-w-full cursor-pointer items-baseline gap-1.5 text-left text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+              aria-label={labels.jumpToLatest(authorName)}
+              onClick={() => {
+                onJump(pin.messageId);
+              }}
+            >
+              <span className="text-foreground shrink-0 font-medium">
+                {authorName}
+              </span>
+              <span className="text-muted-foreground min-w-0 truncate">
+                {snippet}
+              </span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="text-muted-foreground cursor-pointer truncate text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+              onClick={() => {
+                onOpenAll();
+              }}
+            >
+              {labels.couldNotLoad}
+            </button>
+          )}
+        </div>
+        {pin.total > 1 ? (
+          <button
+            type="button"
+            className={cn(
+              "text-muted-foreground hover:text-foreground hover:bg-accent shrink-0 cursor-pointer rounded-full border px-2 py-0.5 text-xs font-medium",
+              "outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            )}
+            title={labels.viewAll}
+            aria-label={labels.viewAll}
+            onClick={() => {
+              onOpenAll();
+            }}
+          >
+            {labels.count(pin.total)}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/chat/components/latest-pinned-message-banner.tsx
+++ b/apps/web/src/app/(app)/chat/components/latest-pinned-message-banner.tsx
@@ -9,6 +9,7 @@ import type {
   ChatRoomPinnedMessageListItem,
 } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
+import { stripMarkdownToText } from "@/lib/utils/strip-markdown";
 import { pickLatestPinnedMessage } from "./pick-latest-pinned-message";
 import {
   type MentionHoverUserLookup,
@@ -63,6 +64,10 @@ function latestPinnedMessageQueryKey(roomId: string, listGeneration: number) {
   return ["latest-pinned-message", roomId, listGeneration] as const;
 }
 
+function flattenLatestPinnedPreview(content: string): string {
+  return stripMarkdownToText(content) ?? "";
+}
+
 function selectLatestPinnedBanner(
   page: LatestPinnedMessagesPage,
 ): LatestPinnedBannerState | null {
@@ -74,7 +79,7 @@ function selectLatestPinnedBanner(
   return {
     messageId: latest.messageId,
     authorName: message ? messageSender(message).name : null,
-    content: message ? message.content : null,
+    content: message ? flattenLatestPinnedPreview(message.content) : null,
     total: page.total,
   };
 }
@@ -169,7 +174,10 @@ export function LatestPinnedMessageBanner({
               <span className="text-foreground shrink-0 font-medium">
                 {authorName}
               </span>
-              <span className="text-muted-foreground min-w-0 truncate text-sm [&_p]:inline">
+              <span
+                data-testid="latest-pinned-message-snippet"
+                className="text-muted-foreground min-w-0 truncate text-sm [&_p]:inline"
+              >
                 <RoomMessageMarkdown
                   content={content}
                   markdownClassName={ROOM_QUOTE_MARKDOWN_CLASSNAME}

--- a/apps/web/src/app/(app)/chat/components/pick-latest-pinned-message.ts
+++ b/apps/web/src/app/(app)/chat/components/pick-latest-pinned-message.ts
@@ -1,0 +1,8 @@
+import type { ChatRoomPinnedMessageListItem } from "@/lib/clients/generated/core";
+
+export function pickLatestPinnedMessage(
+  items: readonly ChatRoomPinnedMessageListItem[],
+): ChatRoomPinnedMessageListItem | null {
+  const loadable = items.find((item) => item.message != null);
+  return loadable ?? items[0] ?? null;
+}

--- a/apps/web/src/app/(app)/chat/components/room-shell-layout.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-shell-layout.tsx
@@ -42,6 +42,8 @@ interface RoomShellLayoutProps {
   rootClassName?: string;
   beforeMain?: ReactNode;
   desktopHeader?: ReactNode | null;
+  /** Sits under the header, outside the message scroller (e.g. latest pin). */
+  belowHeader?: ReactNode;
   reserveDesktopHeader?: boolean;
   /**
    * Wrap header + scroller + composer (e.g. RoomFileDropZone).
@@ -70,6 +72,7 @@ export function RoomShellLayout({
   rootClassName,
   beforeMain,
   desktopHeader = null,
+  belowHeader = null,
   reserveDesktopHeader = true,
   wrapColumn,
   listScrollerRef,
@@ -91,6 +94,7 @@ export function RoomShellLayout({
   const columnBody = (
     <>
       {header}
+      {belowHeader}
       <div ref={listScrollerRef} className={ROOM_SHELL_SCROLLER_CLASSNAME}>
         <div
           ref={listContentRef}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/app/chat/actions";
 import { chatMobileHeightShellClass } from "@/app/chat/components/chat-mobile-tab-registry";
 import DaySeparator from "@/app/chat/components/day-separator";
+import { LatestPinnedMessageBanner } from "@/app/chat/components/latest-pinned-message-banner";
 import {
   PinnedMessagesHeaderButton,
   PinnedMessagesPanel,
@@ -700,6 +701,9 @@ export function RoomsClient({
     setPendingThreadQuote(null);
     setThreadListOpen(false);
     setRosterOpen(false);
+    setPinnedOpen(false);
+    setPinnedListGeneration(0);
+    setPinnedMessageIds(new Set());
     setThreadOpenedFromList(false);
     setEditSession(null);
     threadLoadGenerationRef.current += 1;
@@ -2020,17 +2024,21 @@ export function RoomsClient({
     setRosterOpen(true);
   }
 
-  function handleTogglePinned() {
-    if (pinnedOpen) {
-      setPinnedOpen(false);
-      return;
-    }
+  function openPinnedPanel() {
     if (threadParentMessage) {
       closeThreadSidePanel();
     }
     setThreadListOpen(false);
     setRosterOpen(false);
     setPinnedOpen(true);
+  }
+
+  function handleTogglePinned() {
+    if (pinnedOpen) {
+      setPinnedOpen(false);
+      return;
+    }
+    openPinnedPanel();
   }
 
   function applyPinnedMutation(messageId: string, pinned: boolean) {
@@ -2966,6 +2974,30 @@ export function RoomsClient({
           // useEffect). First real chrome frame = title + composer together.
           desktopHeader={
             !mobileHeaderPortaled && roomHeaderChrome ? roomHeaderChrome : null
+          }
+          belowHeader={
+            selectedRoom.kind === "channel" &&
+            ((selectedRoom.pinnedMessageCount ?? 0) > 0 ||
+              pinnedListGeneration > 0 ||
+              pinnedMessageIds.size > 0) ? (
+              <LatestPinnedMessageBanner
+                roomId={selectedRoom.id}
+                listGeneration={pinnedListGeneration}
+                onJump={(messageId) => {
+                  void handleJumpToPinnedMessage(messageId);
+                }}
+                onOpenAll={openPinnedPanel}
+                onIdsLoaded={handlePinnedIdsLoaded}
+                labels={{
+                  latest: t("PinnedMessages.latest"),
+                  jumpToLatest: (author) =>
+                    t("PinnedMessages.jumpToLatest", { author }),
+                  viewAll: t("PinnedMessages.viewAll"),
+                  count: (count) => t("PinnedMessages.count", { count }),
+                  couldNotLoad: t("PinnedMessages.couldNotLoad"),
+                }}
+              />
+            ) : null
           }
           wrapColumn={(columnBody) => (
             <RoomFileDropZone

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2988,6 +2988,11 @@ export function RoomsClient({
                 }}
                 onOpenAll={openPinnedPanel}
                 onIdsLoaded={handlePinnedIdsLoaded}
+                coworkersById={coworkersById}
+                coworkersBySlug={coworkersBySlug}
+                usersById={usersById}
+                usersBySlug={usersBySlug}
+                channelLinks={channelLinks}
                 labels={{
                   latest: t("PinnedMessages.latest"),
                   jumpToLatest: (author) =>

--- a/apps/web/src/lib/services/chat-room.service.ts
+++ b/apps/web/src/lib/services/chat-room.service.ts
@@ -307,6 +307,7 @@ export const chatRoomService = (() => {
   ): Promise<{
     items: ChatRoomPinnedMessageListItem[];
     nextCursor: string | null;
+    total: number;
   }> {
     const response = await coreClient.getChatRoomPinnedMessages(roomId, {
       cursor: options?.cursor,
@@ -315,6 +316,7 @@ export const chatRoomService = (() => {
     return {
       items: response.data,
       nextCursor: response.meta?.pagination?.nextCursor ?? null,
+      total: response.meta?.pagination?.total ?? response.data.length,
     };
   }
 


### PR DESCRIPTION
## Summary

Channels already had a pin rail. This puts the **newest pin under the room header** so it is visible without opening that rail.

- One-line ticket strip: author + snippet, primary accent, “Latest pin” kicker
- Click jumps to the message in the transcript
- If there is more than one pin, a count chip opens the existing pins panel
- Channels only. Directs never show it. Empty channels stay clean
- Live pin/unpin refreshes the strip without a skeleton flash

## Verification

- `pnpm --filter web exec vitest run` on the new banner/picker tests and `rooms-client-room-header`
- Husky `pnpm check && pnpm typecheck` on commit
- Browser: local Web did not stay healthy in this worktree (portless 502, Next EMFILE / `.next/dev` deleted). Could not walk the strip in a real channel here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel rooms now display a banner highlighting the latest pinned message.
  * Jump directly to the latest pinned message or open the complete pinned-message list.
  * Pinned-message lists now show the total number of pins.
  * Added English, German, and Spanish translations for pinned-message actions.

* **Bug Fixes**
  * Improved handling of deleted or unavailable pinned messages when selecting the latest pin.

* **Tests**
  * Added coverage for banner loading, navigation, room changes, empty lists, and deleted messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->