### PR TITLE
fix(web): use mobile sheet for filter dropdown menu on mobile viewports

### DIFF
--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -135,7 +135,7 @@ export function FilterDropdownMenu({
       </Button>
 
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent side="bottom" className="h-[80vh]">
+        <SheetContent side="bottom" className="h-[80vh] overflow-x-hidden">
           <SheetHeader>
             <SheetTitle>{buttonLabel}</SheetTitle>
           </SheetHeader>
@@ -351,7 +351,7 @@ function FilterDropdownMenuSectionMobile({
   }, [section.allLabel, section.options]);
 
   return (
-    <div className="border-b pb-4 last:border-b-0">
+    <div className="min-w-0 border-b pb-4 last:border-b-0">
       <button
         type="button"
         onClick={onToggle}
@@ -366,7 +366,7 @@ function FilterDropdownMenuSectionMobile({
         </span>
       </button>
       {expanded ? (
-        <div className="mt-2 rounded-md border bg-card p-2">
+        <div className="mt-2 min-w-0 overflow-x-hidden rounded-md border bg-card p-2">
           <Command
             className="**:data-[slot=command-list]:max-h-[40vh]"
             shouldFilter

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -139,7 +139,7 @@ export function FilterDropdownMenu({
           <SheetHeader>
             <SheetTitle>{buttonLabel}</SheetTitle>
           </SheetHeader>
-          <ScrollArea className="h-[calc(80vh-5rem)] pr-4">
+          <ScrollArea className="h-[calc(80vh-5rem)] px-4">
             <div className="mt-4 space-y-4">
               {sections.map((section) => (
                 <FilterDropdownMenuSectionMobile
@@ -355,7 +355,7 @@ function FilterDropdownMenuSectionMobile({
       <button
         type="button"
         onClick={onToggle}
-        className="focus:bg-accent flex w-full items-center gap-2 rounded-md p-3 text-left transition-colors hover:bg-accent"
+        className="focus:bg-accent flex w-full items-center gap-2 rounded-md py-3 text-left transition-colors hover:bg-accent"
       >
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <section.icon className="size-4 text-muted-foreground" aria-hidden />

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -122,6 +122,7 @@ export function FilterDropdownMenu({
         variant="outline"
         size="sm"
         className="relative gap-2 sm:hidden"
+        aria-label={buttonLabel}
         onClick={() => setSheetOpen(true)}
       >
         <ListFilter className="size-4" aria-hidden />
@@ -405,6 +406,20 @@ function FilterDropdownMenuSectionMobile({
                   </CommandItem>
                 );
               })}
+              {section.pagination?.nextCursor ? (
+                <CommandItem
+                  key={`${section.id}-load-more`}
+                  value={`${section.id}-load-more`}
+                  forceMount
+                  onSelect={() => {
+                    section.pagination?.onLoadMore();
+                  }}
+                  disabled={section.pagination.isLoadingMore}
+                  className="text-muted-foreground justify-center text-xs"
+                >
+                  {section.pagination.loadMoreLabel}
+                </CommandItem>
+              ) : null}
             </CommandList>
           </Command>
         </div>

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -21,6 +21,13 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 
 export interface FilterDropdownMenuOption {
@@ -67,38 +74,92 @@ export function FilterDropdownMenu({
   sections,
   showActiveIndicator = false,
 }: FilterDropdownMenuProps) {
-  const [open, setOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [expandedSection, setExpandedSection] = useState<string | null>(null);
 
   if (sections.length === 0) {
     return null;
   }
 
+  const handleClose = () => {
+    setDropdownOpen(false);
+    setSheetOpen(false);
+    setExpandedSection(null);
+  };
+
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="relative gap-2">
-          <ListFilter className="size-4" aria-hidden />
-          <span className="hidden sm:inline">{buttonLabel}</span>
-          {showActiveIndicator ? (
-            <span
-              aria-hidden
-              className="absolute top-1 right-1 size-1.5 rounded-full bg-primary ring-2 ring-background"
+    <>
+      {/* Desktop dropdown - hidden on mobile */}
+      <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
+        <DropdownMenuTrigger asChild className="hidden sm:flex">
+          <Button variant="outline" size="sm" className="relative gap-2">
+            <ListFilter className="size-4" aria-hidden />
+            <span>{buttonLabel}</span>
+            {showActiveIndicator ? (
+              <span
+                aria-hidden
+                className="absolute top-1 right-1 size-1.5 rounded-full bg-primary ring-2 ring-background"
+              />
+            ) : null}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-64">
+          {sections.map((section) => (
+            <FilterDropdownMenuSectionItem
+              key={section.id}
+              section={section}
+              searchPlaceholder={searchPlaceholder}
+              emptyResultsLabel={emptyResultsLabel}
+              onSelect={handleClose}
             />
-          ) : null}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-64">
-        {sections.map((section) => (
-          <FilterDropdownMenuSectionItem
-            key={section.id}
-            section={section}
-            searchPlaceholder={searchPlaceholder}
-            emptyResultsLabel={emptyResultsLabel}
-            onSelect={() => setOpen(false)}
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Mobile sheet - visible only on mobile */}
+      <Button
+        variant="outline"
+        size="sm"
+        className="relative gap-2 sm:hidden"
+        onClick={() => setSheetOpen(true)}
+      >
+        <ListFilter className="size-4" aria-hidden />
+        {showActiveIndicator ? (
+          <span
+            aria-hidden
+            className="absolute top-1 right-1 size-1.5 rounded-full bg-primary ring-2 ring-background"
           />
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+        ) : null}
+      </Button>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent side="bottom" className="h-[80vh]">
+          <SheetHeader>
+            <SheetTitle>{buttonLabel}</SheetTitle>
+          </SheetHeader>
+          <ScrollArea className="h-[calc(80vh-5rem)] pr-4">
+            <div className="mt-4 space-y-4">
+              {sections.map((section) => (
+                <FilterDropdownMenuSectionMobile
+                  key={section.id}
+                  section={section}
+                  searchPlaceholder={searchPlaceholder}
+                  emptyResultsLabel={emptyResultsLabel}
+                  expanded={expandedSection === section.id}
+                  onToggle={() =>
+                    setExpandedSection(
+                      expandedSection === section.id ? null : section.id,
+                    )
+                  }
+                  onSelect={handleClose}
+                />
+              ))}
+            </div>
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }
 
@@ -249,5 +310,105 @@ function FilterDropdownMenuOptionAvatar({
         {fallback}
       </AvatarFallback>
     </Avatar>
+  );
+}
+
+interface FilterDropdownMenuSectionMobileProps {
+  section: FilterDropdownMenuSection;
+  searchPlaceholder: string;
+  emptyResultsLabel: string;
+  expanded: boolean;
+  onToggle: () => void;
+  onSelect: () => void;
+}
+
+function FilterDropdownMenuSectionMobile({
+  section,
+  searchPlaceholder,
+  emptyResultsLabel,
+  expanded,
+  onToggle,
+  onSelect,
+}: FilterDropdownMenuSectionMobileProps) {
+  const selectedOption = useMemo(
+    () =>
+      section.options.find((option) => option.value === section.value) ?? null,
+    [section.options, section.value],
+  );
+  const optionItems = useMemo(() => {
+    if (!section.allLabel) {
+      return section.options;
+    }
+
+    return [
+      {
+        value: ALL_FILTER_VALUE,
+        label: section.allLabel,
+      },
+      ...section.options,
+    ];
+  }, [section.allLabel, section.options]);
+
+  return (
+    <div className="border-b pb-4 last:border-b-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="focus:bg-accent flex w-full items-center gap-2 rounded-md p-3 text-left transition-colors hover:bg-accent"
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <section.icon className="size-4 text-muted-foreground" aria-hidden />
+          <span className="truncate font-medium">{section.label}</span>
+        </div>
+        <span className="max-w-28 truncate text-right text-xs text-muted-foreground">
+          {selectedOption?.label ?? section.allLabel}
+        </span>
+      </button>
+      {expanded ? (
+        <div className="mt-2 rounded-md border bg-card p-2">
+          <Command
+            className="**:data-[slot=command-list]:max-h-[40vh]"
+            shouldFilter
+          >
+            <CommandInput autoFocus placeholder={searchPlaceholder} />
+            <CommandList>
+              <CommandEmpty>{emptyResultsLabel}</CommandEmpty>
+              {optionItems.map((option) => {
+                const isAllOption = option.value === ALL_FILTER_VALUE;
+                const isSelected = isAllOption
+                  ? section.value === null
+                  : option.value === section.value;
+                const filterKeywords = [
+                  option.label,
+                  ...(option.searchKeywords ?? []),
+                ];
+
+                return (
+                  <CommandItem
+                    key={option.value}
+                    value={option.value}
+                    keywords={filterKeywords}
+                    onSelect={() => {
+                      section.onChange(isAllOption ? null : option.value);
+                      onSelect();
+                    }}
+                  >
+                    <FilterDropdownMenuOptionAvatar option={option} />
+                    <span className="flex-1 truncate">{option.label}</span>
+                    <Check
+                      className={cn(
+                        "size-4",
+                        isSelected ? "opacity-100" : "opacity-0",
+                      )}
+                      aria-hidden
+                    />
+                  </CommandItem>
+                );
+              })}
+            </CommandList>
+          </Command>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -355,7 +355,7 @@ function FilterDropdownMenuSectionMobile({
       <button
         type="button"
         onClick={onToggle}
-        className="focus:bg-accent flex w-full items-center gap-2 rounded-md py-3 text-left transition-colors hover:bg-accent"
+        className="focus:bg-accent flex w-full items-center gap-2 rounded-md px-3 py-3 text-left transition-colors hover:bg-accent"
       >
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <section.icon className="size-4 text-muted-foreground" aria-hidden />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #3890 merged, on mobile viewports the filter dropdown submenu (Agent/Project lists) is clipped by the viewport, making labels unusable even though checkmarks are visible.

## Solution

- **Mobile (< sm breakpoint)**: Use a Sheet from bottom instead of nested dropdown
- **Desktop (>= sm breakpoint)**: Keep existing DropdownMenu behavior
- Sheet contains expandable in-place panels for each filter section
- Preserves pagination/load-more/search behavior in Command components
- Full-width mobile layout ensures content stays inside viewport
- Mobile filter trigger exposes `aria-label={buttonLabel}` for assistive tech

## Testing

- TypeScript type check passes
- Biome check passes
- Relevant web tests pass (`tasks-view-filters.test.tsx`, `jobs-view-filters.test.tsx`, `history-view-filters.test.tsx`)

## Review feedback addressed

- **P1**: Restored load-more pagination in mobile `CommandList` (matches desktop)
- **P2**: Added accessible name to mobile filter trigger via `aria-label`

---

Related: masumi-network/sokosumi#3890
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f97122fa-2c6f-4700-8006-29c055750909?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f97122fa-2c6f-4700-8006-29c055750909&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

