### PR TITLE
perf(chat): skip idle Ably presence heartbeats

### DIFF
--- a/apps/web/src/lib/ably/__tests__/should-publish-org-presence.test.ts
+++ b/apps/web/src/lib/ably/__tests__/should-publish-org-presence.test.ts
@@ -9,10 +9,9 @@ import {
 const MIN_INTERVAL_MS = 240_000;
 
 describe("shouldPublishOrgPresenceUpdate", () => {
-  it("refreshes lastActiveAt inside the shared online window", () => {
-    expect(ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS).toBe(MIN_INTERVAL_MS);
-    expect(ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS).toBeLessThan(
-      CHAT_PRESENCE_ONLINE_WINDOW_MS,
+  it("refreshes lastActiveAt one minute inside the shared online window", () => {
+    expect(ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS).toBe(
+      CHAT_PRESENCE_ONLINE_WINDOW_MS - 60_000,
     );
   });
 

--- a/apps/web/src/lib/ably/__tests__/should-publish-org-presence.test.ts
+++ b/apps/web/src/lib/ably/__tests__/should-publish-org-presence.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS,
   shouldPublishOrgPresenceUpdate,
-} from "../should-publish-org-presence";
+} from "@/lib/ably/should-publish-org-presence";
 
 const MIN_INTERVAL_MS = 240_000;
 

--- a/apps/web/src/lib/ably/__tests__/should-publish-org-presence.test.ts
+++ b/apps/web/src/lib/ably/__tests__/should-publish-org-presence.test.ts
@@ -1,0 +1,111 @@
+import { CHAT_PRESENCE_ONLINE_WINDOW_MS } from "@sokosumi/utils";
+import { describe, expect, it } from "vitest";
+
+import {
+  ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS,
+  shouldPublishOrgPresenceUpdate,
+} from "../should-publish-org-presence";
+
+const MIN_INTERVAL_MS = 240_000;
+
+describe("shouldPublishOrgPresenceUpdate", () => {
+  it("refreshes lastActiveAt inside the shared online window", () => {
+    expect(ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS).toBe(MIN_INTERVAL_MS);
+    expect(ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS).toBeLessThan(
+      CHAT_PRESENCE_ONLINE_WINDOW_MS,
+    );
+  });
+
+  const lastPublished = { lastActiveAt: 1_000_000, visible: true };
+
+  it("skips when lastActiveAt and visible are unchanged", () => {
+    expect(
+      shouldPublishOrgPresenceUpdate({
+        force: false,
+        next: lastPublished,
+        lastPublished,
+        lastPublishedAt: 1_000_000,
+        now: 1_000_000 + 30_000,
+        minIntervalMs: MIN_INTERVAL_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips idle ticks after the min interval when the payload is unchanged", () => {
+    expect(
+      shouldPublishOrgPresenceUpdate({
+        force: false,
+        next: lastPublished,
+        lastPublished,
+        lastPublishedAt: 1_000_000,
+        now: 1_000_000 + MIN_INTERVAL_MS,
+        minIntervalMs: MIN_INTERVAL_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it("publishes when force is set even if the payload is unchanged", () => {
+    expect(
+      shouldPublishOrgPresenceUpdate({
+        force: true,
+        next: lastPublished,
+        lastPublished,
+        lastPublishedAt: 1_000_000,
+        now: 1_000_000 + 1_000,
+        minIntervalMs: MIN_INTERVAL_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it("publishes when nothing has been published yet", () => {
+    expect(
+      shouldPublishOrgPresenceUpdate({
+        force: false,
+        next: lastPublished,
+        lastPublished: null,
+        lastPublishedAt: 0,
+        now: 1_000_000,
+        minIntervalMs: MIN_INTERVAL_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it("publishes immediately when visible changes", () => {
+    expect(
+      shouldPublishOrgPresenceUpdate({
+        force: false,
+        next: { lastActiveAt: 1_000_000, visible: false },
+        lastPublished,
+        lastPublishedAt: 1_000_000,
+        now: 1_000_000 + 1_000,
+        minIntervalMs: MIN_INTERVAL_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips lastActiveAt refresh inside the min interval", () => {
+    expect(
+      shouldPublishOrgPresenceUpdate({
+        force: false,
+        next: { lastActiveAt: 1_000_000 + 60_000, visible: true },
+        lastPublished,
+        lastPublishedAt: 1_000_000,
+        now: 1_000_000 + 60_000,
+        minIntervalMs: MIN_INTERVAL_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it("publishes lastActiveAt refresh after the min interval", () => {
+    expect(
+      shouldPublishOrgPresenceUpdate({
+        force: false,
+        next: { lastActiveAt: 1_000_000 + MIN_INTERVAL_MS, visible: true },
+        lastPublished,
+        lastPublishedAt: 1_000_000,
+        now: 1_000_000 + MIN_INTERVAL_MS,
+        minIntervalMs: MIN_INTERVAL_MS,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
@@ -223,6 +223,32 @@ describe("useOrgPresencePublisher", () => {
     });
   });
 
+  it("retries a failed org on the next local tick instead of treating partial success as done", async () => {
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    authorizeMock.mockResolvedValue(tokenWithOrgs("org_1", "org_2"));
+    const failedOrg = channelFor("presence:org_org_2");
+    failedOrg.presence.update.mockRejectedValue(new Error("channel denied"));
+    failedOrg.presence.enter.mockRejectedValue(new Error("channel denied"));
+
+    try {
+      renderHook(() => useOrgPresencePublisher());
+      await flushEffects();
+
+      const okOrg = channelFor("presence:org_org_1").presence;
+      expect(okOrg.update).toHaveBeenCalledTimes(1);
+      expect(failedOrg.presence.update).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+      expect(failedOrg.presence.update).toHaveBeenCalledTimes(2);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("force-publishes on reconnect even when the payload is unchanged", async () => {
     renderHook(() => useOrgPresencePublisher());
     await flushEffects();

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
@@ -1,0 +1,190 @@
+import type { ChatPresenceMemberData } from "@sokosumi/utils";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS } from "../should-publish-org-presence";
+
+const { authorizeMock, getMock, channelsByName, ablyClient } = vi.hoisted(
+  () => {
+    const authorize = vi.fn();
+    const get = vi.fn();
+    return {
+      authorizeMock: authorize,
+      getMock: get,
+      channelsByName: new Map<
+        string,
+        {
+          name: string;
+          presence: {
+            update: ReturnType<typeof vi.fn>;
+            enter: ReturnType<typeof vi.fn>;
+            leave: ReturnType<typeof vi.fn>;
+          };
+          detach: ReturnType<typeof vi.fn>;
+        }
+      >(),
+      ablyClient: {
+        auth: { authorize },
+        channels: { get },
+        connection: {
+          on: vi.fn(),
+          off: vi.fn(),
+        },
+      },
+    };
+  },
+);
+
+vi.mock("ably/react", () => ({
+  useAbly: () => ablyClient,
+}));
+
+import { useOrgPresencePublisher } from "../use-org-presence-publisher";
+
+function channelFor(name: string) {
+  let channel = channelsByName.get(name);
+  if (!channel) {
+    channel = {
+      name,
+      presence: {
+        update: vi.fn().mockResolvedValue(undefined),
+        enter: vi.fn().mockResolvedValue(undefined),
+        leave: vi.fn().mockResolvedValue(undefined),
+      },
+      detach: vi.fn().mockResolvedValue(undefined),
+    };
+    channelsByName.set(name, channel);
+  }
+  return channel;
+}
+
+function tokenWithOrgs(...organizationIds: string[]) {
+  const capability: Record<string, string[]> = {};
+  for (const organizationId of organizationIds) {
+    capability[`presence:org_${organizationId}`] = ["presence", "subscribe"];
+  }
+  return { capability: JSON.stringify(capability) };
+}
+
+function connectedHandler(): (() => void) | undefined {
+  const call = ablyClient.connection.on.mock.calls.find(
+    (args) => args[0] === "connected",
+  );
+  return call?.[1] as (() => void) | undefined;
+}
+
+function setDocumentHidden(value: boolean) {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value,
+  });
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("useOrgPresencePublisher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-26T12:00:00.000Z"));
+    setDocumentHidden(false);
+    authorizeMock.mockReset();
+    getMock.mockReset();
+    channelsByName.clear();
+    ablyClient.connection.on.mockReset();
+    ablyClient.connection.off.mockReset();
+    getMock.mockImplementation((name: string) => channelFor(name));
+    authorizeMock.mockResolvedValue(tokenWithOrgs("org_1"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setDocumentHidden(false);
+  });
+
+  it("enters presence once and does not heartbeat an unchanged idle payload", async () => {
+    renderHook(() => useOrgPresencePublisher());
+    await flushEffects();
+
+    const presence = channelFor("presence:org_org_1").presence;
+    expect(presence.update).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(presence.update).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS);
+    });
+    expect(presence.update).toHaveBeenCalledTimes(1);
+    expect(presence.enter).not.toHaveBeenCalled();
+  });
+
+  it("does not publish activity inside the min interval, then flushes lastActiveAt", async () => {
+    renderHook(() => useOrgPresencePublisher());
+    await flushEffects();
+
+    const presence = channelFor("presence:org_org_1").presence;
+    expect(presence.update).toHaveBeenCalledTimes(1);
+    const firstPayload = presence.update.mock.calls[0]?.[0] as
+      | ChatPresenceMemberData
+      | undefined;
+
+    await act(async () => {
+      vi.setSystemTime(Date.now() + 60_000);
+      window.dispatchEvent(new Event("pointerdown"));
+      await Promise.resolve();
+    });
+    expect(presence.update).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS);
+    });
+    expect(presence.update).toHaveBeenCalledTimes(2);
+    const flushed = presence.update.mock.calls[1]?.[0] as
+      | ChatPresenceMemberData
+      | undefined;
+    if (firstPayload == null || flushed == null) {
+      throw new Error("expected presence payloads");
+    }
+    expect(flushed.lastActiveAt).toBeGreaterThan(firstPayload.lastActiveAt);
+  });
+
+  it("publishes immediately when visibility changes", async () => {
+    renderHook(() => useOrgPresencePublisher());
+    await flushEffects();
+
+    const presence = channelFor("presence:org_org_1").presence;
+    expect(presence.update).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      setDocumentHidden(true);
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+    expect(presence.update).toHaveBeenCalledTimes(2);
+    expect(presence.update.mock.calls[1]?.[0]).toMatchObject({
+      visible: false,
+    });
+  });
+
+  it("force-publishes on reconnect even when the payload is unchanged", async () => {
+    renderHook(() => useOrgPresencePublisher());
+    await flushEffects();
+
+    const presence = channelFor("presence:org_org_1").presence;
+    expect(presence.update).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      connectedHandler()?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(presence.update).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
@@ -155,6 +155,56 @@ describe("useOrgPresencePublisher", () => {
     expect(flushed.lastActiveAt).toBeGreaterThan(firstPayload.lastActiveAt);
   });
 
+  it("flushes lastActiveAt on the first 4-min tick after a delayed enter update", async () => {
+    let resolveEnterUpdate: () => void = () => undefined;
+    getMock.mockImplementation((name: string) => {
+      const channel = channelFor(name);
+      channel.presence.update.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveEnterUpdate = resolve;
+          }),
+      );
+      return channel;
+    });
+
+    renderHook(() => useOrgPresencePublisher());
+    await flushEffects();
+
+    const presence = channelFor("presence:org_org_1").presence;
+    expect(presence.update).toHaveBeenCalledTimes(1);
+    const firstPayload = presence.update.mock.calls[0]?.[0] as
+      | ChatPresenceMemberData
+      | undefined;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+      resolveEnterUpdate();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("pointerdown"));
+      await Promise.resolve();
+    });
+    expect(presence.update).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS - 5_000,
+      );
+    });
+    expect(presence.update).toHaveBeenCalledTimes(2);
+    const flushed = presence.update.mock.calls[1]?.[0] as
+      | ChatPresenceMemberData
+      | undefined;
+    if (firstPayload == null || flushed == null) {
+      throw new Error("expected presence payloads");
+    }
+    expect(flushed.lastActiveAt).toBeGreaterThan(firstPayload.lastActiveAt);
+  });
+
   it("publishes immediately when visibility changes", async () => {
     renderHook(() => useOrgPresencePublisher());
     await flushEffects();

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
@@ -2,7 +2,7 @@ import type { ChatPresenceMemberData } from "@sokosumi/utils";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS } from "../should-publish-org-presence";
+import { ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS } from "@/lib/ably/should-publish-org-presence";
 
 const { authorizeMock, getMock, channelsByName, ablyClient } = vi.hoisted(
   () => {
@@ -39,7 +39,7 @@ vi.mock("ably/react", () => ({
   useAbly: () => ablyClient,
 }));
 
-import { useOrgPresencePublisher } from "../use-org-presence-publisher";
+import { useOrgPresencePublisher } from "@/lib/ably/use-org-presence-publisher";
 
 function channelFor(name: string) {
   let channel = channelsByName.get(name);

--- a/apps/web/src/lib/ably/should-publish-org-presence.ts
+++ b/apps/web/src/lib/ably/should-publish-org-presence.ts
@@ -1,0 +1,33 @@
+import type { ChatPresenceMemberData } from "@sokosumi/utils";
+
+/** Refresh lastActiveAt just inside the 5 min Online window (SOK-894). */
+export const ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS = 4 * 60 * 1000;
+
+export interface ShouldPublishOrgPresenceUpdateInput {
+  force: boolean;
+  next: ChatPresenceMemberData;
+  lastPublished: ChatPresenceMemberData | null;
+  lastPublishedAt: number;
+  now: number;
+  minIntervalMs: number;
+}
+
+/**
+ * Idle/unchanged presence must not emit Ably messages. Activity refreshes
+ * lastActiveAt on a throttle just inside the online window. Visibility,
+ * enter, and reconnect force an immediate publish.
+ */
+export function shouldPublishOrgPresenceUpdate(
+  input: ShouldPublishOrgPresenceUpdateInput,
+): boolean {
+  if (input.force || input.lastPublished == null) {
+    return true;
+  }
+  if (input.next.visible !== input.lastPublished.visible) {
+    return true;
+  }
+  if (input.next.lastActiveAt === input.lastPublished.lastActiveAt) {
+    return false;
+  }
+  return input.now - input.lastPublishedAt >= input.minIntervalMs;
+}

--- a/apps/web/src/lib/ably/should-publish-org-presence.ts
+++ b/apps/web/src/lib/ably/should-publish-org-presence.ts
@@ -1,7 +1,14 @@
-import type { ChatPresenceMemberData } from "@sokosumi/utils";
+import {
+  CHAT_PRESENCE_ONLINE_WINDOW_MS,
+  type ChatPresenceMemberData,
+} from "@sokosumi/utils";
 
-/** Refresh lastActiveAt just inside the 5 min Online window (SOK-894). */
-export const ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS = 4 * 60 * 1000;
+/** Slack so a throttled refresh arrives before teammates age you to AFK. */
+const ORG_PRESENCE_PUBLISH_MARGIN_MS = 60_000;
+
+/** Refresh lastActiveAt just inside the shared Online window (SOK-894). */
+export const ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS =
+  CHAT_PRESENCE_ONLINE_WINDOW_MS - ORG_PRESENCE_PUBLISH_MARGIN_MS;
 
 export interface ShouldPublishOrgPresenceUpdateInput {
   force: boolean;

--- a/apps/web/src/lib/ably/use-org-presence-publisher.ts
+++ b/apps/web/src/lib/ably/use-org-presence-publisher.ts
@@ -22,6 +22,9 @@ const ACTIVITY_EVENTS = [
   "touchstart",
 ] as const;
 
+/** Local recheck only; unchanged payloads still do not publish. */
+const PRESENCE_IDLE_TICK_MS = 30_000;
+
 function buildPresenceData(
   lastActiveAt: number,
   visible: boolean,
@@ -33,7 +36,8 @@ function buildPresenceData(
  * Enter Ably Presence on every org channel granted on the token (ADR-0003).
  * Updates lastActiveAt / visible from browser activity and visibility.
  * Unchanged idle presence does not publish; activity refreshes lastActiveAt
- * on a ~4 min throttle. Visibility, enter, and reconnect force publish.
+ * on a ~4 min throttle. A 30s local tick only rechecks; it is not an Ably
+ * message. Visibility, enter, and reconnect force publish.
  * Owns channel attach/detach for presence channels (map only subscribes).
  */
 export function useOrgPresencePublisher(): void {
@@ -102,7 +106,7 @@ export function useOrgPresencePublisher(): void {
       }
 
       if (results.some(Boolean)) {
-        lastPublishedAtRef.current = Date.now();
+        lastPublishedAtRef.current = now;
         lastPublishedRef.current = data;
       }
     }
@@ -198,7 +202,7 @@ export function useOrgPresencePublisher(): void {
 
     const intervalId = window.setInterval(() => {
       void publishPresence(false);
-    }, ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS);
+    }, PRESENCE_IDLE_TICK_MS);
 
     const onConnected = () => {
       void syncChannels();

--- a/apps/web/src/lib/ably/use-org-presence-publisher.ts
+++ b/apps/web/src/lib/ably/use-org-presence-publisher.ts
@@ -10,6 +10,10 @@ import { useEffect, useRef } from "react";
 
 import { organizationIdsFromAblyCapability } from "./organization-ids-from-ably-capability";
 import { safeDetachChannel } from "./safe-detach-channel";
+import {
+  ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS,
+  shouldPublishOrgPresenceUpdate,
+} from "./should-publish-org-presence";
 
 const ACTIVITY_EVENTS = [
   "pointerdown",
@@ -17,10 +21,6 @@ const ACTIVITY_EVENTS = [
   "wheel",
   "touchstart",
 ] as const;
-
-/** Throttle presence.update while active; enter/leave still immediate. */
-const PRESENCE_UPDATE_MIN_INTERVAL_MS = 30_000;
-const PRESENCE_IDLE_TICK_MS = 30_000;
 
 function buildPresenceData(
   lastActiveAt: number,
@@ -32,6 +32,8 @@ function buildPresenceData(
 /**
  * Enter Ably Presence on every org channel granted on the token (ADR-0003).
  * Updates lastActiveAt / visible from browser activity and visibility.
+ * Unchanged idle presence does not publish; activity refreshes lastActiveAt
+ * on a ~4 min throttle. Visibility, enter, and reconnect force publish.
  * Owns channel attach/detach for presence channels (map only subscribes).
  */
 export function useOrgPresencePublisher(): void {
@@ -39,7 +41,7 @@ export function useOrgPresencePublisher(): void {
   const channelsRef = useRef(new Map<string, Ably.RealtimeChannel>());
   const lastActiveAtRef = useRef(Date.now());
   const lastPublishedAtRef = useRef(0);
-  const lastPublishedVisibleRef = useRef<boolean | null>(null);
+  const lastPublishedRef = useRef<ChatPresenceMemberData | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -57,10 +59,14 @@ export function useOrgPresencePublisher(): void {
       const lastActiveAt = lastActiveAtRef.current;
       const data = buildPresenceData(lastActiveAt, visible);
 
-      const shouldPublish =
-        force ||
-        lastPublishedVisibleRef.current !== visible ||
-        now - lastPublishedAtRef.current >= PRESENCE_UPDATE_MIN_INTERVAL_MS;
+      const shouldPublish = shouldPublishOrgPresenceUpdate({
+        force,
+        next: data,
+        lastPublished: lastPublishedRef.current,
+        lastPublishedAt: lastPublishedAtRef.current,
+        now,
+        minIntervalMs: ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS,
+      });
 
       if (!shouldPublish || channels.size === 0) {
         return;
@@ -97,7 +103,7 @@ export function useOrgPresencePublisher(): void {
 
       if (results.some(Boolean)) {
         lastPublishedAtRef.current = Date.now();
-        lastPublishedVisibleRef.current = visible;
+        lastPublishedRef.current = data;
       }
     }
 
@@ -192,7 +198,7 @@ export function useOrgPresencePublisher(): void {
 
     const intervalId = window.setInterval(() => {
       void publishPresence(false);
-    }, PRESENCE_IDLE_TICK_MS);
+    }, ORG_PRESENCE_PUBLISH_MIN_INTERVAL_MS);
 
     const onConnected = () => {
       void syncChannels();

--- a/apps/web/src/lib/ably/use-org-presence-publisher.ts
+++ b/apps/web/src/lib/ably/use-org-presence-publisher.ts
@@ -105,7 +105,7 @@ export function useOrgPresencePublisher(): void {
         return;
       }
 
-      if (results.some(Boolean)) {
+      if (results.length > 0 && results.every(Boolean)) {
         lastPublishedAtRef.current = now;
         lastPublishedRef.current = data;
       }

--- a/docs/adr/0003-ably-presence-for-chat.md
+++ b/docs/adr/0003-ably-presence-for-chat.md
@@ -4,7 +4,7 @@ Chat roster dots mean **reachable** (live client connection), not auth-session f
 
 **Why not session-idle:** Better Auth session rows rarely update while the user is active (cookie cache, no activity heartbeats). Classifying `now - session.updatedAt` made teammates look **offline** despite being in the app. Idle grace alone cannot fix a dead signal.
 
-**Why not Core HTTP heartbeat as source of truth:** Extra store, fan-out, and auth surface. We already use Ably for chat realtime; client enter/update/leave matches industry connection-presence and ~30s freshness.
+**Why not Core HTTP heartbeat as source of truth:** Extra store, fan-out, and auth surface. We already use Ably for chat realtime; client enter/update/leave matches industry connection-presence. Active clients refresh `lastActiveAt` on a ~4 min throttle (inside the 5 min Online window); unchanged idle presence does not publish.
 
 **Shape (product + wire):**
 - **Online** = connected + recent activity; **AFK** = connected but idle (~5m) or tab hidden; **Offline** = no live connection (disconnect grace later, ~30–60s).

--- a/docs/adr/0003-ably-presence-for-chat.md
+++ b/docs/adr/0003-ably-presence-for-chat.md
@@ -4,7 +4,7 @@ Chat roster dots mean **reachable** (live client connection), not auth-session f
 
 **Why not session-idle:** Better Auth session rows rarely update while the user is active (cookie cache, no activity heartbeats). Classifying `now - session.updatedAt` made teammates look **offline** despite being in the app. Idle grace alone cannot fix a dead signal.
 
-**Why not Core HTTP heartbeat as source of truth:** Extra store, fan-out, and auth surface. We already use Ably for chat realtime; client enter/update/leave matches industry connection-presence. Active clients refresh `lastActiveAt` on a ~4 min throttle (inside the 5 min Online window); unchanged idle presence does not publish.
+**Why not Core HTTP heartbeat as source of truth:** Extra store, fan-out, and auth surface. We already use Ably for chat realtime; client enter/update/leave matches industry connection-presence. Active clients refresh `lastActiveAt` on a ~4 min throttle (inside the 5 min Online window); unchanged idle presence does not publish. Teammates reclassify Online → AFK locally every 30s from the last `lastActiveAt`; they do not wait for another Ably message.
 
 **Shape (product + wire):**
 - **Online** = connected + recent activity; **AFK** = connected but idle (~5m) or tab hidden; **Offline** = no live connection (disconnect grace later, ~30–60s).


### PR DESCRIPTION
## Summary

Org presence no longer republishes `{ lastActiveAt, visible }` every 30s when nothing changed. Idle tabs emit no Ably presence messages. While you are active, `lastActiveAt` refreshes on a 4 minute throttle, which stays inside the 5 minute Online window so teammates still see Online until AFK. Visibility, enter, leave, and reconnect still publish immediately. Online/AFK/Offline labels and client-side aggregation are unchanged.

## User-facing impact

Roster dots keep the same labels. Active people stay Online for teammates for the same ~5 minute window. Idle presence stops generating billable Ably messages (the 30s heartbeat was ~99.6% of August volume).

## Out of scope

- Entering only the active org
- `echoMessages`
- Removing `presence.get()` on reconnect

## Verification

- `pnpm --filter web test src/lib/ably/__tests__/should-publish-org-presence.test.ts src/lib/ably/__tests__/use-org-presence-publisher.test.tsx` (12 passed)
- `pnpm --filter web typecheck`
- `pnpm check`
- `pnpm test` (17 turbo tasks successful)

Did not verify in a live Ably session (no message inspector for a 4 minute idle window in this environment).

## Links

- Linear: [SOK-894](https://linear.app/masumi/issue/SOK-894/cut-idle-ably-presence-heartbeats)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter organization presence updates, including immediate publishing for initial, forced, and visibility changes.
  * Throttled activity refreshes while continuing to suppress unchanged idle updates.
  * Improved retry handling and reconnect behavior for presence updates.
* **Bug Fixes**
  * Ensured presence state is updated only after all channel updates succeed.
* **Documentation**
  * Clarified online, AFK, and presence refresh timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->