### PR TITLE
fix(web): stop echoing own Ably messages

### DIFF
--- a/apps/web/src/lib/ably/__tests__/realtime-singleton.client.test.ts
+++ b/apps/web/src/lib/ably/__tests__/realtime-singleton.client.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { RealtimeMock } = vi.hoisted(() => ({
+  RealtimeMock: vi.fn(function Realtime(this: Record<string, unknown>) {
+    return this;
+  }),
+}));
+
+vi.mock("ably", () => ({
+  default: {
+    Realtime: RealtimeMock,
+  },
+}));
+
+vi.mock("../ably-client-instance-id", () => ({
+  getOrCreateAblyClientInstanceId: () => "inst_test01",
+}));
+
+import { getAblyRealtimeClient } from "../realtime-singleton.client";
+
+describe("getAblyRealtimeClient", () => {
+  beforeEach(() => {
+    globalThis.__sokosumiAblyRealtimeClient = undefined;
+    RealtimeMock.mockClear();
+  });
+
+  it("does not echo the publisher's own messages back on the shared client", () => {
+    getAblyRealtimeClient();
+
+    expect(RealtimeMock).toHaveBeenCalledWith({
+      authUrl: "/api/ably/auth",
+      authMethod: "POST",
+      authParams: {
+        clientInstanceId: "inst_test01",
+      },
+      echoMessages: false,
+    });
+  });
+});

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-map.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-map.test.tsx
@@ -129,6 +129,73 @@ describe("useOrgPresenceMap", () => {
     });
   });
 
+  it("includes self from presence.get without an echoed enter", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("active_org"));
+    channelFor("presence:org_active_org").presence.get.mockResolvedValue([
+      {
+        clientId: "user_self:instanceA1",
+        data: { lastActiveAt: Date.now(), visible: true },
+      },
+    ]);
+
+    const { result } = renderHook(() => useOrgPresenceMap("active_org"));
+
+    await waitFor(() => {
+      expect(result.current.get("user_self")).toBe("online");
+    });
+  });
+
+  it("classifies self as AFK from presence.get when the tab is hidden", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("active_org"));
+    channelFor("presence:org_active_org").presence.get.mockResolvedValue([
+      {
+        clientId: "user_self:instanceA1",
+        data: { lastActiveAt: Date.now(), visible: false },
+      },
+    ]);
+
+    const { result } = renderHook(() => useOrgPresenceMap("active_org"));
+
+    await waitFor(() => {
+      expect(result.current.get("user_self")).toBe("afk");
+    });
+  });
+
+  it("maps own enter and update into the roster without echo", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("active_org"));
+
+    const { result } = renderHook(() => useOrgPresenceMap("active_org"));
+    const channel = channelFor("presence:org_active_org");
+
+    await waitFor(() => {
+      expect(channel.presence.subscribe).toHaveBeenCalled();
+    });
+
+    function handlerFor(action: "enter" | "update") {
+      return channel.presence.subscribe.mock.calls.find(
+        (args) => args[0] === action,
+      )?.[1] as
+        | ((message: { clientId: string; data: object }) => void)
+        | undefined;
+    }
+
+    handlerFor("enter")?.({
+      clientId: "user_self:instanceA1",
+      data: { lastActiveAt: Date.now(), visible: true },
+    });
+    await waitFor(() => {
+      expect(result.current.get("user_self")).toBe("online");
+    });
+
+    handlerFor("update")?.({
+      clientId: "user_self:instanceA1",
+      data: { lastActiveAt: Date.now(), visible: false },
+    });
+    await waitFor(() => {
+      expect(result.current.get("user_self")).toBe("afk");
+    });
+  });
+
   it("does not attach when authorize fails", async () => {
     authorizeMock.mockRejectedValue(new Error("token refresh failed"));
 

--- a/apps/web/src/lib/ably/realtime-singleton.client.ts
+++ b/apps/web/src/lib/ably/realtime-singleton.client.ts
@@ -29,6 +29,7 @@ export function getAblyRealtimeClient(): Ably.Realtime {
     authParams: {
       clientInstanceId,
     },
+    echoMessages: false,
   });
   setGlobalAblyRealtimeClient(realtimeClient);
   return realtimeClient;


### PR DESCRIPTION
## Summary

Stops the shared Ably Realtime client from echoing the publisher’s own messages (`echoMessages: false`). That extra outbound was billable (~one extra message per presence publish).

Own Online/AFK still comes from `presence.get` on hydrate and from enter/update handlers, not from echo. All Ably islands share this singleton.

## Linear

[SOK-896](https://linear.app/masumi/issue/SOK-896/stop-echoing-own-ably-messages-to-the-publisher)

## Verification

- `pnpm --filter web exec vitest run src/lib/ably/__tests__/realtime-singleton.client.test.ts src/lib/ably/__tests__/use-org-presence-map.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm test`
- Husky `pnpm check && pnpm typecheck` on commit

Browser presence against live Ably was not exercised here (local keys are typically placeholders). Confirm self still shows Online/AFK in an org workspace before merge if a realtime environment is available.