### PR TITLE
fix: disallow crawling of app and API hosts

### DIFF
--- a/apps/core/src/index.test.ts
+++ b/apps/core/src/index.test.ts
@@ -126,6 +126,18 @@ describe("core index", () => {
     serveMock.mockImplementation(() => undefined);
   });
 
+  it("serves robots.txt that disallows all crawlers", async () => {
+    const fetchHandler = await loadFetchHandler();
+
+    const response = await fetchHandler(
+      new Request("http://localhost/robots.txt"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toMatch(/text\/plain/);
+    expect(await response.text()).toBe("User-Agent: *\nDisallow: /\n");
+  });
+
   it("does not generate llms markdown during startup and still serves docs routes", async () => {
     createMarkdownFromOpenApiMock.mockResolvedValue("# llms");
 

--- a/apps/core/src/index.test.ts
+++ b/apps/core/src/index.test.ts
@@ -138,6 +138,25 @@ describe("core index", () => {
     expect(await response.text()).toBe("User-Agent: *\nDisallow: /\n");
   });
 
+  it("still serves robots.txt during maintenance", async () => {
+    getEnvMock.mockReturnValue({
+      NODE_ENV: "development",
+      PORT: 8787,
+      MAINTENANCE_MODE: true,
+    });
+
+    const fetchHandler = await loadFetchHandler();
+
+    const robotsResponse = await fetchHandler(
+      new Request("http://localhost/robots.txt"),
+    );
+    expect(robotsResponse.status).toBe(200);
+    expect(await robotsResponse.text()).toBe("User-Agent: *\nDisallow: /\n");
+
+    const otherResponse = await fetchHandler(new Request("http://localhost/"));
+    expect(otherResponse.status).toBe(503);
+  });
+
   it("does not generate llms markdown during startup and still serves docs routes", async () => {
     createMarkdownFromOpenApiMock.mockResolvedValue("# llms");
 

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -102,6 +102,8 @@ async function getLlmsMarkdown(): Promise<string> {
   return await llmsMarkdownPromise;
 }
 
+app.get("/robots.txt", (c) => c.text("User-Agent: *\nDisallow: /\n"));
+
 /**
  * Register a route to serve the Markdown for LLMs
  *

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -102,8 +102,6 @@ async function getLlmsMarkdown(): Promise<string> {
   return await llmsMarkdownPromise;
 }
 
-app.get("/robots.txt", (c) => c.text("User-Agent: *\nDisallow: /\n"));
-
 /**
  * Register a route to serve the Markdown for LLMs
  *
@@ -117,6 +115,8 @@ app.get("/llms.txt", async (c) => {
 });
 
 // Mount OpenAPI router at root - THIS IS IMPORTANT SO YOU CAN HAVE BOTH
+// robots.txt lives on mainApp so crawlers still get Disallow during maintenance.
+mainApp.get("/robots.txt", (c) => c.text("User-Agent: *\nDisallow: /\n"));
 mainApp.route("/", app);
 
 serve(

--- a/apps/web/src/app/__tests__/layout-robots-metadata.test.ts
+++ b/apps/web/src/app/__tests__/layout-robots-metadata.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("root layout robots metadata", () => {
+  it("always noindexes and is not gated on Mainnet", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "../layout.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("index: false");
+    expect(source).toContain("follow: false");
+    expect(source).not.toContain("isMainnet");
+    expect(source).not.toMatch(/NEXT_PUBLIC_NETWORK === ["']Mainnet["']/);
+  });
+});

--- a/apps/web/src/app/__tests__/robots.test.ts
+++ b/apps/web/src/app/__tests__/robots.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Pin Mainnet so a network-gated Allow: / cannot sneak back in.
+vi.mock("@/config/env.public", () => ({
+  getEnvPublicConfig: () => ({ NEXT_PUBLIC_NETWORK: "Mainnet" }),
+}));
+
+import robots from "../robots";
+
+describe("web robots.txt", () => {
+  it("disallows all crawlers, including on Mainnet", () => {
+    expect(robots()).toEqual({
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    });
+  });
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -38,15 +38,11 @@ export const viewport: Viewport = {
 };
 
 export function generateMetadata(): Metadata {
-  const isMainnet = getEnvPublicConfig().NEXT_PUBLIC_NETWORK === "Mainnet";
-
   return {
-    ...(!isMainnet && {
-      robots: {
-        index: false,
-        follow: false,
-      },
-    }),
+    robots: {
+      index: false,
+      follow: false,
+    },
     other: {
       ...Sentry.getTraceData(),
     },

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,23 +1,10 @@
 import type { MetadataRoute } from "next";
 
-import { getEnvPublicConfig } from "@/config/env.public";
-
 export default function robots(): MetadataRoute.Robots {
-  const isMainnet = getEnvPublicConfig().NEXT_PUBLIC_NETWORK === "Mainnet";
-  if (!isMainnet) {
-    return {
-      rules: {
-        userAgent: "*",
-        disallow: "/",
-      },
-    };
-  }
-
-  // Mainnet environment - allow all crawlers
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      disallow: "/",
     },
   };
 }


### PR DESCRIPTION
## Summary

Search crawlers could index the product app and API.

- `app.sokosumi.com/robots.txt` served `Allow: /` on Mainnet.
- `api.sokosumi.com/robots.txt` and `api.preprod.sokosumi.com/robots.txt` 404, which crawlers treat as allow-all.
- `preprod.sokosumi.com` already served `Disallow: /`.

Web now always returns `Disallow: /`. Root HTML metadata always sets `noindex, nofollow`, including Mainnet. Core serves `GET /robots.txt` with the same disallow body from `mainApp`, so it stays available during maintenance.

`www.sokosumi.com` is a separate marketing site and is unchanged.

## User-facing impact

App and API hosts should stop being crawled after this deploys. Public share pages under `/share/` are also blocked by `robots.txt` and inherit root `noindex`, matching the whole-host policy.

## Verification

- `pnpm --filter web exec vitest run src/app/__tests__/robots.test.ts src/app/__tests__/layout-robots-metadata.test.ts`
- `pnpm --filter core exec vitest run src/index.test.ts`
- Husky `pnpm check && pnpm typecheck` on commit

Live hosts still serve the old files until this ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/robots.txt` endpoint that blocks search engine crawlers.
  * The crawler restriction remains active during maintenance mode.

* **Bug Fixes**
  * Disabled page indexing and link following across all environments.
  * Removed environment-specific behavior that previously allowed crawling in some deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->