### PR TITLE
perf(chat): enter presence only in active org

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,8 +173,8 @@ _Avoid_: Announcement (a use of this), pinned room, thread pin
 ### Chat presence
 
 **Presence**:
-Whether a human participant is currently reachable on the product — they have at least one live client connection. App-global (any Sokosumi surface with a live connection), not room-scoped. Multi-device: any connected device makes the person reachable (aggregate by user, not by single connection id).
-_Avoid_: Session freshness, last seen (that is a separate timestamp), membership, Ably channel subscribe alone without a presence signal, equating one connection id with one human
+Whether a human participant is currently reachable in the **active organization** — they have at least one live client connection on that workspace. App-shell (any Sokosumi surface with a live connection, not chat-page-only), not room-scoped. Other organizations see Offline. Multi-device: any connected device in that organization makes the person reachable (aggregate by user, not by single connection id).
+_Avoid_: Session freshness, last seen (that is a separate timestamp), membership, Ably channel subscribe alone without a presence signal, equating one connection id with one human, treating presence as reachable in every org at once
 
 **Online**:
 Presence state: reachable and recently active in a connected client.

--- a/apps/web/src/contexts/__tests__/org-presence-provider.test.tsx
+++ b/apps/web/src/contexts/__tests__/org-presence-provider.test.tsx
@@ -26,6 +26,7 @@ import {
   OrgPresenceProvider,
   useMemberPresence,
 } from "@/contexts/org-presence-provider";
+import { useOrgPresencePublisher } from "@/lib/ably/use-org-presence-publisher";
 
 function PresenceProbe({
   userId,
@@ -41,6 +42,27 @@ function PresenceProbe({
 describe("OrgPresenceProvider", () => {
   beforeEach(() => {
     lazyAblyProviderMock.mockClear();
+    vi.mocked(useOrgPresencePublisher).mockClear();
+  });
+
+  it("passes the active organization to the presence publisher", () => {
+    render(
+      <OrgPresenceProvider organizationId="org_1">
+        <div />
+      </OrgPresenceProvider>,
+    );
+
+    expect(useOrgPresencePublisher).toHaveBeenCalledWith("org_1");
+  });
+
+  it("passes null to the presence publisher for a personal workspace", () => {
+    render(
+      <OrgPresenceProvider organizationId={null}>
+        <div />
+      </OrgPresenceProvider>,
+    );
+
+    expect(useOrgPresencePublisher).toHaveBeenCalledWith(null);
   });
 
   it("keeps paint-critical children outside the LazyAbly island", () => {

--- a/apps/web/src/contexts/org-presence-provider.tsx
+++ b/apps/web/src/contexts/org-presence-provider.tsx
@@ -20,8 +20,12 @@ const OrgPresenceMapContext = createContext<Map<
   ChatPresenceState
 > | null>(null);
 
-function OrgPresencePublisherBridge() {
-  useOrgPresencePublisher();
+function OrgPresencePublisherBridge({
+  organizationId,
+}: {
+  organizationId: string | null;
+}) {
+  useOrgPresencePublisher(organizationId);
   return null;
 }
 
@@ -92,7 +96,7 @@ export function OrgPresenceProvider({
     <OrgPresenceMapContext value={presenceByUserId}>
       {children}
       <LazyAblyProvider>
-        <OrgPresencePublisherBridge />
+        <OrgPresencePublisherBridge organizationId={organizationId} />
         <OrgPresenceMapSync
           organizationId={organizationId}
           onMapChange={handleMapChange}

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
@@ -107,7 +107,7 @@ describe("useOrgPresencePublisher", () => {
   });
 
   it("enters presence once and does not heartbeat an unchanged idle payload", async () => {
-    renderHook(() => useOrgPresencePublisher());
+    renderHook(() => useOrgPresencePublisher("org_1"));
     await flushEffects();
 
     const presence = channelFor("presence:org_org_1").presence;
@@ -126,7 +126,7 @@ describe("useOrgPresencePublisher", () => {
   });
 
   it("does not publish activity inside the min interval, then flushes lastActiveAt", async () => {
-    renderHook(() => useOrgPresencePublisher());
+    renderHook(() => useOrgPresencePublisher("org_1"));
     await flushEffects();
 
     const presence = channelFor("presence:org_org_1").presence;
@@ -168,7 +168,7 @@ describe("useOrgPresencePublisher", () => {
       return channel;
     });
 
-    renderHook(() => useOrgPresencePublisher());
+    renderHook(() => useOrgPresencePublisher("org_1"));
     await flushEffects();
 
     const presence = channelFor("presence:org_org_1").presence;
@@ -206,7 +206,7 @@ describe("useOrgPresencePublisher", () => {
   });
 
   it("publishes immediately when visibility changes", async () => {
-    renderHook(() => useOrgPresencePublisher());
+    renderHook(() => useOrgPresencePublisher("org_1"));
     await flushEffects();
 
     const presence = channelFor("presence:org_org_1").presence;
@@ -223,21 +223,18 @@ describe("useOrgPresencePublisher", () => {
     });
   });
 
-  it("retries a failed org on the next local tick instead of treating partial success as done", async () => {
+  it("retries a failed active org on the next local tick instead of treating a failed enter as done", async () => {
     const errorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    authorizeMock.mockResolvedValue(tokenWithOrgs("org_1", "org_2"));
-    const failedOrg = channelFor("presence:org_org_2");
+    const failedOrg = channelFor("presence:org_org_1");
     failedOrg.presence.update.mockRejectedValue(new Error("channel denied"));
     failedOrg.presence.enter.mockRejectedValue(new Error("channel denied"));
 
     try {
-      renderHook(() => useOrgPresencePublisher());
+      renderHook(() => useOrgPresencePublisher("org_1"));
       await flushEffects();
 
-      const okOrg = channelFor("presence:org_org_1").presence;
-      expect(okOrg.update).toHaveBeenCalledTimes(1);
       expect(failedOrg.presence.update).toHaveBeenCalledTimes(1);
 
       await act(async () => {
@@ -249,8 +246,26 @@ describe("useOrgPresencePublisher", () => {
     }
   });
 
+  it("enters only the active organization even when the token grants more", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("org_1", "org_2"));
+    renderHook(() => useOrgPresencePublisher("org_1"));
+    await flushEffects();
+
+    expect(getMock).toHaveBeenCalledWith("presence:org_org_1");
+    expect(
+      channelFor("presence:org_org_1").presence.update,
+    ).toHaveBeenCalledTimes(1);
+    expect(getMock).not.toHaveBeenCalledWith("presence:org_org_2");
+    expect(
+      channelFor("presence:org_org_2").presence.update,
+    ).not.toHaveBeenCalled();
+    expect(
+      channelFor("presence:org_org_2").presence.enter,
+    ).not.toHaveBeenCalled();
+  });
+
   it("force-publishes on reconnect even when the payload is unchanged", async () => {
-    renderHook(() => useOrgPresencePublisher());
+    renderHook(() => useOrgPresencePublisher("org_1"));
     await flushEffects();
 
     const presence = channelFor("presence:org_org_1").presence;
@@ -262,5 +277,64 @@ describe("useOrgPresencePublisher", () => {
       await Promise.resolve();
     });
     expect(presence.update).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the previous organization and enters the next on workspace switch", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("org_1", "org_2"));
+    const { rerender } = renderHook(
+      ({ organizationId }: { organizationId: string | null }) =>
+        useOrgPresencePublisher(organizationId),
+      { initialProps: { organizationId: "org_1" } },
+    );
+    await flushEffects();
+
+    const org1 = channelFor("presence:org_org_1");
+    expect(org1.presence.update).toHaveBeenCalledTimes(1);
+    expect(getMock).not.toHaveBeenCalledWith("presence:org_org_2");
+
+    rerender({ organizationId: "org_2" });
+    await flushEffects();
+
+    expect(org1.presence.leave).toHaveBeenCalled();
+    expect(org1.detach).toHaveBeenCalled();
+    expect(getMock).toHaveBeenCalledWith("presence:org_org_2");
+    expect(
+      channelFor("presence:org_org_2").presence.update,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not enter presence in a personal workspace and leaves on switch", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("org_1"));
+    const { rerender } = renderHook<void, { organizationId: string | null }>(
+      ({ organizationId }) => useOrgPresencePublisher(organizationId),
+      { initialProps: { organizationId: null } },
+    );
+    await flushEffects();
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(authorizeMock).not.toHaveBeenCalled();
+
+    rerender({ organizationId: "org_1" });
+    await flushEffects();
+    const org1 = channelFor("presence:org_org_1");
+    expect(org1.presence.update).toHaveBeenCalledTimes(1);
+
+    rerender({ organizationId: null });
+    await flushEffects();
+    expect(org1.presence.leave).toHaveBeenCalled();
+  });
+
+  it("does not enter the active organization when it is not granted on the token", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("org_2"));
+    renderHook(() => useOrgPresencePublisher("org_1"));
+    await flushEffects();
+
+    expect(getMock).not.toHaveBeenCalledWith("presence:org_org_1");
+    expect(
+      channelFor("presence:org_org_1").presence.update,
+    ).not.toHaveBeenCalled();
+    expect(
+      channelFor("presence:org_org_1").presence.enter,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
@@ -360,7 +360,50 @@ describe("useOrgPresencePublisher", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(org1.presence.update).toHaveBeenCalledTimes(2);
+    expect(org1.presence.update.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("does not enter the previous organization if authorize resolves after a workspace switch", async () => {
+    const authResolvers: Array<(value: unknown) => void> = [];
+    authorizeMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          authResolvers.push(resolve);
+        }),
+    );
+
+    const { rerender } = renderHook<void, { organizationId: string | null }>(
+      ({ organizationId }) => useOrgPresencePublisher(organizationId),
+      { initialProps: { organizationId: "org_1" } },
+    );
+    await flushEffects();
+    expect(authResolvers).toHaveLength(1);
+    expect(getMock).not.toHaveBeenCalled();
+
+    rerender({ organizationId: "org_2" });
+    await flushEffects();
+
+    await act(async () => {
+      authResolvers[0]?.(tokenWithOrgs("org_1", "org_2"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getMock).not.toHaveBeenCalledWith("presence:org_org_1");
+    expect(
+      channelFor("presence:org_org_1").presence.update,
+    ).not.toHaveBeenCalled();
+    expect(
+      channelFor("presence:org_org_1").presence.enter,
+    ).not.toHaveBeenCalled();
+    expect(getMock).toHaveBeenCalledWith("presence:org_org_2");
+    expect(channelFor("presence:org_org_2").presence.update).toHaveBeenCalled();
+
+    await act(async () => {
+      authResolvers[1]?.(tokenWithOrgs("org_1", "org_2"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getMock).not.toHaveBeenCalledWith("presence:org_org_1");
   });
 
   it("does not enter the active organization when it is not granted on the token", async () => {

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-publisher.test.tsx
@@ -324,6 +324,45 @@ describe("useOrgPresencePublisher", () => {
     expect(org1.presence.leave).toHaveBeenCalled();
   });
 
+  it("waits for leave to settle before re-entering the same organization", async () => {
+    let resolveLeave: () => void = () => undefined;
+    getMock.mockImplementation((name: string) => {
+      const channel = channelFor(name);
+      channel.presence.leave.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveLeave = resolve;
+          }),
+      );
+      return channel;
+    });
+
+    const { rerender } = renderHook<void, { organizationId: string | null }>(
+      ({ organizationId }) => useOrgPresencePublisher(organizationId),
+      { initialProps: { organizationId: "org_1" } },
+    );
+    await flushEffects();
+
+    const org1 = channelFor("presence:org_org_1");
+    expect(org1.presence.update).toHaveBeenCalledTimes(1);
+
+    rerender({ organizationId: null });
+    await flushEffects();
+    expect(org1.presence.leave).toHaveBeenCalledTimes(1);
+    expect(org1.presence.update).toHaveBeenCalledTimes(1);
+
+    rerender({ organizationId: "org_1" });
+    await flushEffects();
+    expect(org1.presence.update).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveLeave();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(org1.presence.update).toHaveBeenCalledTimes(2);
+  });
+
   it("does not enter the active organization when it is not granted on the token", async () => {
     authorizeMock.mockResolvedValue(tokenWithOrgs("org_2"));
     renderHook(() => useOrgPresencePublisher("org_1"));

--- a/apps/web/src/lib/ably/use-org-presence-publisher.ts
+++ b/apps/web/src/lib/ably/use-org-presence-publisher.ts
@@ -33,23 +33,27 @@ function buildPresenceData(
 }
 
 /**
- * Enter Ably Presence on every org channel granted on the token (ADR-0003).
- * Updates lastActiveAt / visible from browser activity and visibility.
- * Unchanged idle presence does not publish; activity refreshes lastActiveAt
- * on a ~4 min throttle. A 30s local tick only rechecks; it is not an Ably
- * message. Visibility, enter, and reconnect force publish.
+ * Enter Ably Presence only on the active organization (ADR-0003). Other orgs
+ * on the token stay offline. Updates lastActiveAt / visible from browser
+ * activity and visibility. Unchanged idle presence does not publish; activity
+ * refreshes lastActiveAt on a ~4 min throttle. A 30s local tick only rechecks;
+ * it is not an Ably message. Visibility, enter, and reconnect force publish.
  * Owns channel attach/detach for presence channels (map only subscribes).
  */
-export function useOrgPresencePublisher(): void {
+export function useOrgPresencePublisher(organizationId: string | null): void {
   const ably = useAbly();
-  const channelsRef = useRef(new Map<string, Ably.RealtimeChannel>());
   const lastActiveAtRef = useRef(Date.now());
   const lastPublishedAtRef = useRef(0);
   const lastPublishedRef = useRef<ChatPresenceMemberData | null>(null);
 
   useEffect(() => {
+    if (organizationId == null) {
+      return;
+    }
+
+    const activeOrganizationId = organizationId;
     let cancelled = false;
-    const channels = channelsRef.current;
+    const channels = new Map<string, Ably.RealtimeChannel>();
     /** Coalesce mount + connected so authorize never overlaps. */
     let syncInFlight = false;
     let syncQueued = false;
@@ -128,11 +132,12 @@ export function useOrgPresencePublisher(): void {
         return;
       }
 
-      const organizationIds =
+      const grantedIds =
         organizationIdsFromAblyCapability(tokenDetails?.capability) ?? [];
-      const nextNames = new Set(
-        organizationIds.map((id) => makeOrgPresenceChannelName(id)),
-      );
+      const nextNames = new Set<string>();
+      if (grantedIds.includes(activeOrganizationId)) {
+        nextNames.add(makeOrgPresenceChannelName(activeOrganizationId));
+      }
 
       for (const [name, channel] of channels) {
         if (cancelled) {
@@ -153,10 +158,13 @@ export function useOrgPresencePublisher(): void {
         return;
       }
 
-      // Ensure every granted org channel is tracked, then force enter/update on
-      // all of them. Skipping already-tracked channels leaves self offline after
-      // hard reconnect (Ably only auto-restores presence on resume).
+      // Ensure the active org channel is tracked, then force enter/update.
+      // Skipping an already-tracked channel leaves self offline after hard
+      // reconnect (Ably only auto-restores presence on resume).
       for (const name of nextNames) {
+        if (cancelled) {
+          return;
+        }
         if (!channels.has(name)) {
           channels.set(name, ably.channels.get(name));
         }
@@ -226,5 +234,5 @@ export function useOrgPresencePublisher(): void {
       }
       channels.clear();
     };
-  }, [ably]);
+  }, [ably, organizationId]);
 }

--- a/apps/web/src/lib/ably/use-org-presence-publisher.ts
+++ b/apps/web/src/lib/ably/use-org-presence-publisher.ts
@@ -45,13 +45,13 @@ export function useOrgPresencePublisher(organizationId: string | null): void {
   const lastActiveAtRef = useRef(Date.now());
   const lastPublishedAtRef = useRef(0);
   const lastPublishedRef = useRef<ChatPresenceMemberData | null>(null);
+  const organizationIdRef = useRef(organizationId);
+  organizationIdRef.current = organizationId;
+  const syncRef = useRef<() => void>(() => undefined);
 
+  // Workspace switch must leave-then-enter on the same effect. Remounting
+  // fire-and-forgets leave and can wipe a later re-enter of the same channel.
   useEffect(() => {
-    if (organizationId == null) {
-      return;
-    }
-
-    const activeOrganizationId = organizationId;
     let cancelled = false;
     const channels = new Map<string, Ably.RealtimeChannel>();
     /** Coalesce mount + connected so authorize never overlaps. */
@@ -119,24 +119,27 @@ export function useOrgPresencePublisher(organizationId: string | null): void {
       if (cancelled) {
         return;
       }
-      let tokenDetails: Ably.TokenDetails | null = null;
-      try {
-        tokenDetails = await ably.auth.authorize();
-      } catch (error) {
-        if (!cancelled) {
-          console.error("Ably authorize for presence failed:", error);
-        }
-        return;
-      }
-      if (cancelled) {
-        return;
-      }
-
-      const grantedIds =
-        organizationIdsFromAblyCapability(tokenDetails?.capability) ?? [];
+      const activeOrganizationId = organizationIdRef.current;
       const nextNames = new Set<string>();
-      if (grantedIds.includes(activeOrganizationId)) {
-        nextNames.add(makeOrgPresenceChannelName(activeOrganizationId));
+      if (activeOrganizationId != null) {
+        let tokenDetails: Ably.TokenDetails | null = null;
+        try {
+          tokenDetails = await ably.auth.authorize();
+        } catch (error) {
+          if (!cancelled) {
+            console.error("Ably authorize for presence failed:", error);
+          }
+        }
+        if (cancelled) {
+          return;
+        }
+        if (tokenDetails != null) {
+          const grantedIds =
+            organizationIdsFromAblyCapability(tokenDetails.capability) ?? [];
+          if (grantedIds.includes(activeOrganizationId)) {
+            nextNames.add(makeOrgPresenceChannelName(activeOrganizationId));
+          }
+        }
       }
 
       for (const [name, channel] of channels) {
@@ -200,7 +203,9 @@ export function useOrgPresencePublisher(organizationId: string | null): void {
       void publishPresence(true);
     }
 
-    void syncChannels();
+    syncRef.current = () => {
+      void syncChannels();
+    };
 
     for (const event of ACTIVITY_EVENTS) {
       window.addEventListener(event, handleActivity, { passive: true });
@@ -220,6 +225,7 @@ export function useOrgPresencePublisher(organizationId: string | null): void {
     return () => {
       cancelled = true;
       syncQueued = false;
+      syncRef.current = () => undefined;
       for (const event of ACTIVITY_EVENTS) {
         window.removeEventListener(event, handleActivity);
       }
@@ -234,5 +240,9 @@ export function useOrgPresencePublisher(organizationId: string | null): void {
       }
       channels.clear();
     };
+  }, [ably]);
+
+  useEffect(() => {
+    syncRef.current();
   }, [ably, organizationId]);
 }

--- a/apps/web/src/lib/ably/use-org-presence-publisher.ts
+++ b/apps/web/src/lib/ably/use-org-presence-publisher.ts
@@ -115,33 +115,7 @@ export function useOrgPresencePublisher(organizationId: string | null): void {
       }
     }
 
-    async function runSyncOnce(): Promise<void> {
-      if (cancelled) {
-        return;
-      }
-      const activeOrganizationId = organizationIdRef.current;
-      const nextNames = new Set<string>();
-      if (activeOrganizationId != null) {
-        let tokenDetails: Ably.TokenDetails | null = null;
-        try {
-          tokenDetails = await ably.auth.authorize();
-        } catch (error) {
-          if (!cancelled) {
-            console.error("Ably authorize for presence failed:", error);
-          }
-        }
-        if (cancelled) {
-          return;
-        }
-        if (tokenDetails != null) {
-          const grantedIds =
-            organizationIdsFromAblyCapability(tokenDetails.capability) ?? [];
-          if (grantedIds.includes(activeOrganizationId)) {
-            nextNames.add(makeOrgPresenceChannelName(activeOrganizationId));
-          }
-        }
-      }
-
+    async function leaveChannelsNotIn(nextNames: Set<string>): Promise<void> {
       for (const [name, channel] of channels) {
         if (cancelled) {
           return;
@@ -156,6 +130,49 @@ export function useOrgPresencePublisher(organizationId: string | null): void {
           channels.delete(name);
         }
       }
+    }
+
+    async function runSyncOnce(): Promise<void> {
+      if (cancelled) {
+        return;
+      }
+      const keepBeforeAuthorize = new Set<string>();
+      const organizationIdBeforeAuthorize = organizationIdRef.current;
+      if (organizationIdBeforeAuthorize != null) {
+        keepBeforeAuthorize.add(
+          makeOrgPresenceChannelName(organizationIdBeforeAuthorize),
+        );
+      }
+      await leaveChannelsNotIn(keepBeforeAuthorize);
+      if (cancelled) {
+        return;
+      }
+
+      const nextNames = new Set<string>();
+      if (organizationIdRef.current != null) {
+        let tokenDetails: Ably.TokenDetails | null = null;
+        try {
+          tokenDetails = await ably.auth.authorize();
+        } catch (error) {
+          if (!cancelled) {
+            console.error("Ably authorize for presence failed:", error);
+          }
+        }
+        if (cancelled) {
+          return;
+        }
+        // Switch during authorize must not enter the org captured at start.
+        const currentOrganizationId = organizationIdRef.current;
+        if (tokenDetails != null && currentOrganizationId != null) {
+          const grantedIds =
+            organizationIdsFromAblyCapability(tokenDetails.capability) ?? [];
+          if (grantedIds.includes(currentOrganizationId)) {
+            nextNames.add(makeOrgPresenceChannelName(currentOrganizationId));
+          }
+        }
+      }
+
+      await leaveChannelsNotIn(nextNames);
 
       if (cancelled) {
         return;

--- a/docs/adr/0003-ably-presence-for-chat.md
+++ b/docs/adr/0003-ably-presence-for-chat.md
@@ -13,4 +13,4 @@ Chat roster dots mean **reachable** (live client connection), not auth-session f
 - App shell owns the Ably connection for always-on presence; room message channel subs stay chat-scoped.
 - UI: `presence.get()` for first paint + live presence events; **do not** use `Session.updatedAt` for green dots. Last seen (members table) stays a separate concept.
 
-**Rejected:** session-touch hacks; room-scoped “in channel” as Online; chat-page-only connection (breaks app-global reachable); pure offline/online without AFK for v1 product labels (hybrid kept).
+**Rejected:** session-touch hacks; room-scoped “in channel” as Online; chat-page-only connection (breaks app-shell presence — you would look Offline off the chat page); pure offline/online without AFK for v1 product labels (hybrid kept).

--- a/docs/adr/0003-ably-presence-for-chat.md
+++ b/docs/adr/0003-ably-presence-for-chat.md
@@ -8,8 +8,8 @@ Chat roster dots mean **reachable** (live client connection), not auth-session f
 
 **Shape (product + wire):**
 - **Online** = connected + recent activity; **AFK** = connected but idle (~5m) or tab hidden; **Offline** = no live connection (disconnect grace later, ~30–60s).
-- Visibility: **same organization only**. Enter presence on **every org** the user belongs to. No human presence dots in personal workspace. Coworkers stay always-online for v1.
-- Channel: `presence:org_{orgId}`. Token grants **`presence` + `subscribe`** on those channels (enter/update/leave needs `presence`; `presence.get` + presence events need `subscribe`). Multi-device: `clientId = userId:instanceId`, aggregate any member with that userId.
+- Visibility: **same organization only**. Enter presence only on the **active organization**; other orgs see Offline. Leave the previous org on workspace switch. No human presence dots in personal workspace. Coworkers stay always-online for v1.
+- Channel: `presence:org_{orgId}`. Token still grants **`presence` + `subscribe`** on every membership org so workspace switch does not wait on re-auth; the client enters only the active org. Enter/update/leave needs `presence`; `presence.get` + presence events need `subscribe`. Multi-device: `clientId = userId:instanceId`, aggregate any member with that userId.
 - App shell owns the Ably connection for always-on presence; room message channel subs stay chat-scoped.
 - UI: `presence.get()` for first paint + live presence events; **do not** use `Session.updatedAt` for green dots. Last seen (members table) stays a separate concept.
 


### PR DESCRIPTION
## Summary

Logged-in tabs now enter Ably presence only on the **active organization**. Other membership orgs see Offline. Switching workspaces leaves the previous org and enters the next. Personal workspace does not enter. Token grants are unchanged so workspace switch does not wait on re-auth.

Workspace switch keeps one publisher effect and **awaits leave before re-enter** on the same Ably channel, so a delayed leave cannot wipe presence when you return to an org. If `authorize()` is still in flight, the publisher leaves non-matching channels first and re-reads the active org after the token returns, so the previous org is not entered.

ADR-0003 and `CONTEXT.md` now describe this as reachable in the active organization, not every org at once.

## User-facing impact

You look Online/AFK only in the workspace you are viewing. Teammates in other organizations see you Offline. Roster labels and AFK timing are unchanged. Presence messages are no longer multiplied by org membership.

## Out of scope

- AFK timing
- Chat-page-only connections
- Shrinking token presence grants

## Verification

- `pnpm --filter web test src/lib/ably/__tests__/use-org-presence-publisher.test.tsx src/contexts/__tests__/org-presence-provider.test.tsx src/lib/ably/__tests__/use-org-presence-map.test.tsx` (28 passed)
- `pnpm --filter web typecheck`
- `pnpm check`

Did not verify in a live Ably session (this worktree has no `.env`; local Ably keys are unconfigured). Worth an org ↔ personal ↔ org pass on preview with real keys.

## Links

- Linear: [SOK-895](https://linear.app/masumi/issue/SOK-895/enter-ably-presence-only-in-the-active-organization)