### PR TITLE
fix(chat): re-pin when pin banner shrinks scroller

### DIFF
--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
@@ -12,26 +12,50 @@ type ResizeObserverCallback = (
 ) => void;
 
 const observerCallbacks = new Set<ResizeObserverCallback>();
+const observerCallbacksByTarget = new Map<
+  Element,
+  Set<ResizeObserverCallback>
+>();
 
 class ResizeObserverMock {
   private readonly callback: ResizeObserverCallback;
+  private readonly observed = new Set<Element>();
 
   constructor(callback: ResizeObserverCallback) {
     this.callback = callback;
     observerCallbacks.add(callback);
   }
 
-  observe(_target: Element) {}
+  observe(target: Element) {
+    this.observed.add(target);
+    let set = observerCallbacksByTarget.get(target);
+    if (!set) {
+      set = new Set();
+      observerCallbacksByTarget.set(target, set);
+    }
+    set.add(this.callback);
+  }
 
   disconnect() {
     observerCallbacks.delete(this.callback);
+    for (const target of this.observed) {
+      observerCallbacksByTarget.get(target)?.delete(this.callback);
+    }
+    this.observed.clear();
   }
 
-  unobserve() {}
+  unobserve(target: Element) {
+    this.observed.delete(target);
+    observerCallbacksByTarget.get(target)?.delete(this.callback);
+  }
 }
 
-function fireResize() {
-  for (const callback of observerCallbacks) {
+function fireResize(target?: Element) {
+  const callbacks =
+    target == null
+      ? observerCallbacks
+      : (observerCallbacksByTarget.get(target) ?? new Set());
+  for (const callback of callbacks) {
     callback([], {} as ResizeObserver);
   }
 }
@@ -107,12 +131,14 @@ function Harness({
 describe("useStickToBottom", () => {
   beforeEach(() => {
     observerCallbacks.clear();
+    observerCallbacksByTarget.clear();
     global.ResizeObserver =
       ResizeObserverMock as unknown as typeof global.ResizeObserver;
   });
 
   afterEach(() => {
     observerCallbacks.clear();
+    observerCallbacksByTarget.clear();
   });
 
   it("pins the viewport on content resize while sticky", () => {
@@ -414,5 +440,71 @@ describe("useStickToBottom", () => {
     });
 
     expect(scroller.scrollTop).toBe(1000 + growth);
+  });
+
+  it("re-pins when the scroller shrinks while sticky", () => {
+    // Latest pin sits outside the scroller. Flex chrome shrinks clientHeight
+    // without growing content, so content ResizeObserver never fires.
+    render(<Harness resetKey="room-1" />);
+    const scroller = screen.getByTestId("scroller");
+    const content = screen.getByTestId("content");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 600,
+    });
+    act(() => {
+      fireResize(content);
+    });
+    expect(scroller.scrollTop).toBe(1000);
+
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 320,
+      scrollTop: 600,
+    });
+    act(() => {
+      fireResize(scroller);
+    });
+
+    expect(scroller.scrollTop).toBe(1000);
+  });
+
+  it("does not re-pin on scroller shrink after the user scrolls away", () => {
+    render(<Harness resetKey="room-1" />);
+    const scroller = screen.getByTestId("scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 200,
+    });
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 320,
+      scrollTop: 200,
+    });
+    act(() => {
+      fireResize(scroller);
+    });
+
+    expect(scroller.scrollTop).toBe(200);
+  });
+
+  it("does not re-pin on scroller shrink when holdOffBottom is set", () => {
+    render(<Harness resetKey="thread-1" holdOffBottom />);
+    const scroller = screen.getByTestId("scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 200,
+    });
+    act(() => {
+      fireResize(scroller);
+    });
+    expect(scroller.scrollTop).toBe(200);
   });
 });

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
+import { type RefObject, useLayoutEffect, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -506,5 +507,48 @@ describe("useStickToBottom", () => {
       fireResize(scroller);
     });
     expect(scroller.scrollTop).toBe(200);
+  });
+
+  it("does not pin from the initial scroller layout observer when holdOffBottom is set", () => {
+    // Child layout effects run before the parent hook's. Attach the node and
+    // seed metrics there so the first handleScrollerResize sees a real bottom
+    // while stickToBottomRef is still true and suppressPinRef is still false.
+    function BindScroller({
+      scrollerRef,
+      contentRef,
+    }: {
+      scrollerRef: RefObject<HTMLDivElement | null>;
+      contentRef: RefObject<HTMLDivElement | null>;
+    }) {
+      const nodeRef = useRef<HTMLDivElement | null>(null);
+      useLayoutEffect(() => {
+        const node = nodeRef.current;
+        if (!node) {
+          return;
+        }
+        setScrollerMetrics(node, {
+          scrollHeight: 1000,
+          clientHeight: 400,
+          scrollTop: 200,
+        });
+        scrollerRef.current = node;
+      }, [scrollerRef]);
+      return (
+        <div ref={nodeRef} data-testid="scroller">
+          <div ref={contentRef} data-testid="content" />
+        </div>
+      );
+    }
+
+    function MountHarness() {
+      const { scrollerRef, contentRef } = useStickToBottom({
+        resetKey: "thread-1",
+        holdOffBottom: true,
+      });
+      return <BindScroller scrollerRef={scrollerRef} contentRef={contentRef} />;
+    }
+
+    render(<MountHarness />);
+    expect(screen.getByTestId("scroller").scrollTop).toBe(200);
   });
 });

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
@@ -18,7 +18,7 @@ const observerCallbacksByTarget = new Map<
   Set<ResizeObserverCallback>
 >();
 
-class ResizeObserverMock {
+class ResizeObserverMock implements ResizeObserver {
   private readonly callback: ResizeObserverCallback;
   private readonly observed = new Set<Element>();
 
@@ -27,7 +27,7 @@ class ResizeObserverMock {
     observerCallbacks.add(callback);
   }
 
-  observe(target: Element) {
+  observe(target: Element, _options?: ResizeObserverOptions) {
     this.observed.add(target);
     let set = observerCallbacksByTarget.get(target);
     if (!set) {
@@ -133,8 +133,7 @@ describe("useStickToBottom", () => {
   beforeEach(() => {
     observerCallbacks.clear();
     observerCallbacksByTarget.clear();
-    global.ResizeObserver =
-      ResizeObserverMock as unknown as typeof global.ResizeObserver;
+    global.ResizeObserver = ResizeObserverMock;
   });
 
   afterEach(() => {

--- a/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
@@ -154,16 +154,25 @@ export function useStickToBottom({
       return;
     }
 
-    function syncMinHeight() {
+    function handleScrollerResize() {
       const node = scrollerRef.current;
       if (!node) {
         return;
       }
       setContentMinHeight(node.clientHeight);
+      // Pin banner / composer live outside the scroller. Shrinking
+      // clientHeight does not grow content, so the content observer never
+      // re-pins and the last message stays clipped.
+      if (holdOffBottomRef.current || suppressPinRef.current) {
+        return;
+      }
+      if (stickToBottomRef.current) {
+        node.scrollTop = node.scrollHeight;
+      }
     }
 
-    syncMinHeight();
-    const observer = new ResizeObserver(syncMinHeight);
+    handleScrollerResize();
+    const observer = new ResizeObserver(handleScrollerResize);
     observer.observe(scroller);
     return () => observer.disconnect();
   }, [resetKey]);

--- a/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
@@ -160,7 +160,7 @@ export function useStickToBottom({
         return;
       }
       setContentMinHeight(node.clientHeight);
-      // Pin banner / composer live outside the scroller. Shrinking
+      // Latest pin sits under the header, outside the scroller. Shrinking
       // clientHeight does not grow content, so the content observer never
       // re-pins and the last message stays clipped.
       if (holdOffBottomRef.current || suppressPinRef.current) {


### PR DESCRIPTION
## Summary

On a Channel with a latest pin under the header, stick-to-bottom left the last message slightly clipped.

The pin sits outside the message scroller. When it takes height, the scroller shrinks without the content growing, so the existing content-resize pin never ran. If you were already at the live edge, the last bubble sat about one banner-height below the fold.

- Re-pin when the **scroller** resizes, not only when content grows
- Leave people who scrolled away (and search jumps) where they are
- Layout-time `holdOffBottom` is locked by a test that fails if that guard is dropped (search jump must not yank on first scroller layout)

Follow-up to the latest-pin-under-header work (#3967).

## Verification

- `pnpm --filter web exec vitest run src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx` — 14 passed (scroller-shrink RED→GREEN, plus layout-time holdOffBottom lock)
- `pnpm test` — full workspace suite green (on the fix commit)
- Husky `pnpm check && pnpm typecheck` on both commits
- Browser: local Web/Core were not healthy in this worktree (`verify-sokosumi doctor` 404). Could not walk a pinned channel here. Reload a Channel at the live edge with a latest pin to confirm the last message is fully visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic scrolling in chat when the available viewing area changes.
  * Preserved users’ manual scroll position instead of unexpectedly returning to the bottom.
  * Ensured “hold off bottom” behavior remains consistent during initial layout and resize events.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->