### PR TITLE
feat(masumi): read the x402 spend cap off the API key

### DIFF
--- a/packages/masumi/src/clients/index.ts
+++ b/packages/masumi/src/clients/index.ts
@@ -11,6 +11,7 @@ export {
 export type {
   X402AvailableNetwork,
   X402Budget,
+  X402KeySpendCaps,
   X402PayFailure,
   X402PayInput,
   X402SignedPayment,

--- a/packages/masumi/src/clients/masumi-payment-x402.ts
+++ b/packages/masumi/src/clients/masumi-payment-x402.ts
@@ -441,8 +441,9 @@ export function createX402PaymentMethods(
      * Non-`eip155:` rows are dropped: those are the Cardano rail's credits on
      * the same shared ledger and must never make an EVM pair look payable. A
      * non-numeric amount contributes nothing to its unit's sum, so a unit
-     * whose only row is unparsable reads as zero and its pair is delisted —
-     * fail closed, since a malformed amount is not evidence of funding.
+     * whose only row is unparsable reads as zero and its pair is delisted.
+     * That is the fail-closed direction: a malformed amount is not evidence
+     * of funding.
      */
     async getX402KeySpendCaps(
       options: PaymentClientRequestOptions = {},

--- a/packages/masumi/src/clients/masumi-payment-x402.ts
+++ b/packages/masumi/src/clients/masumi-payment-x402.ts
@@ -115,6 +115,21 @@ const x402BudgetSchema: z.ZodType<X402Budget> = z.object({
   updatedAt: nodeDateSchema,
 });
 
+/**
+ * One `RemainingUsageCredits` row from `GET /api-key-status`.
+ *
+ * Shape only. The node really can hold an `amount` that is not a base-unit
+ * integer, and such a row is judged per unit below (it ends grandfathering
+ * but adds nothing to its unit's sum) rather than failing the whole read, so
+ * the digit check deliberately stays out of this schema. Validating the shape
+ * here is what keeps an absent or version-skewed array from reading as "this
+ * key holds no credits".
+ */
+const apiKeyUsageCreditSchema = z.object({
+  unit: z.string(),
+  amount: z.string(),
+});
+
 const x402WalletSchema: z.ZodType<X402Wallet> = z.object({
   id: z.string().min(1),
   networkId: z.string().min(1),
@@ -446,14 +461,24 @@ export function createX402PaymentMethods(
             "api-key-status returned no usageLimited flag; refusing to judge x402 spend caps",
           );
         }
-        const rows = Array.isArray(status.RemainingUsageCredits)
-          ? status.RemainingUsageCredits
-          : [];
+        // Zod, like every other node read here, and for the same reason the
+        // flag above is guarded: `RemainingUsageCredits` is required, so an
+        // absent or malformed array is version skew, never "this key holds no
+        // credits". Reading it as an empty list would set
+        // `grandfatheredUncapped` on a usageLimited key and mark every pair
+        // ready that the node would then refuse with a 402.
+        const creditRows = z
+          .array(apiKeyUsageCreditSchema)
+          .safeParse(status.RemainingUsageCredits);
+        if (!creditRows.success) {
+          return err(
+            "api-key-status returned no usable RemainingUsageCredits array; refusing to judge x402 spend caps",
+          );
+        }
         const creditsByUnit = new Map<string, bigint>();
         let sawEvmRow = false;
-        for (const row of rows) {
-          const unit =
-            typeof row?.unit === "string" ? row.unit.toLowerCase() : "";
+        for (const row of creditRows.data) {
+          const unit = row.unit.toLowerCase();
           if (!unit.startsWith("eip155:")) {
             continue;
           }
@@ -462,7 +487,7 @@ export function createX402PaymentMethods(
           // rows, it does not parse them. Reading that as still-grandfathered
           // would call a hard-capped key uncapped.
           sawEvmRow = true;
-          if (typeof row.amount !== "string" || !/^\d+$/.test(row.amount)) {
+          if (!/^\d+$/.test(row.amount)) {
             continue;
           }
           creditsByUnit.set(

--- a/packages/masumi/src/clients/masumi-payment-x402.ts
+++ b/packages/masumi/src/clients/masumi-payment-x402.ts
@@ -36,6 +36,33 @@ export type X402AvailableNetwork =
 export type X402Budget =
   GetX402BudgetsResponses["200"]["data"]["Budgets"][number];
 
+/**
+ * The calling key's x402 spend cap, read from `GET /api-key-status`.
+ *
+ * The node caps x402 spend on the API KEY, never on a wallet: one credit
+ * ledger per key, keyed by `eip155:<chainId>:<asset>` units, gated by
+ * `usageLimited` (masumi ADR 0016). The unit string is byte-identical to the
+ * `<caip2Network>:<asset>` pair key Core composes readiness on, so a cap
+ * lookup is a plain map get.
+ */
+export interface X402KeySpendCaps {
+  /** The node enforces a cap only when true. */
+  usageLimited: boolean;
+  /**
+   * Remaining credit per lowercased `eip155:<chainId>:<asset>` unit, summed
+   * across rows: nothing enforces one row per (key, unit) on the node, so a
+   * split ledger must be judged by its total, exactly as the node's own
+   * debit path does.
+   */
+  creditsByUnit: ReadonlyMap<string, bigint>;
+  /**
+   * The key is `usageLimited` but holds NO `eip155:` row at all, so the node
+   * grandfathers it to uncapped x402 spend and warns per payment. Distinct
+   * from "capped at zero": this key can pay, a zero-credit one cannot.
+   */
+  grandfatheredUncapped: boolean;
+}
+
 /** One managed EVM wallet visible to the calling key (`GET /x402/wallets`). */
 export type X402Wallet =
   GetX402WalletsResponses["200"]["data"]["Wallets"][number];
@@ -383,6 +410,76 @@ export function createX402PaymentMethods(
   }
 
   return {
+    /**
+     * The calling key's x402 spend cap.
+     *
+     * Reads the SAME memoized `GET /api-key-status` every other scoped call
+     * here already resolves, so this costs no extra request. It supersedes
+     * `GET /x402/budgets`: masumi ADR 0016 makes per-key usage credits the
+     * only x402 spend cap and removes per-wallet budgets from the node.
+     *
+     * Scoping is structural rather than filtered. `api-key-status` answers
+     * for the CALLING key only, so there is no foreign-row hazard of the kind
+     * the budgets read defended against with an explicit `apiKeyId` query
+     * filter plus a re-filter of the response.
+     *
+     * Non-`eip155:` rows are dropped: those are the Cardano rail's credits on
+     * the same shared ledger and must never make an EVM pair look payable. A
+     * non-numeric amount contributes nothing to its unit's sum, so a unit
+     * whose only row is unparsable reads as zero and its pair is delisted —
+     * fail closed, since a malformed amount is not evidence of funding.
+     */
+    async getX402KeySpendCaps(
+      options: PaymentClientRequestOptions = {},
+    ): Promise<Result<X402KeySpendCaps, string>> {
+      try {
+        const statusResult = await resolveApiKeyStatus(options);
+        if (statusResult.isErr()) {
+          return err(statusResult.error);
+        }
+        const status = statusResult.value;
+        // Version-skew guard, same posture as the wallet listing's strict
+        // flag read: a node answering 200 without the flag must not read as
+        // "uncapped" and mark pairs ready that a capped key cannot pay.
+        if (typeof status?.usageLimited !== "boolean") {
+          return err(
+            "api-key-status returned no usageLimited flag; refusing to judge x402 spend caps",
+          );
+        }
+        const rows = Array.isArray(status.RemainingUsageCredits)
+          ? status.RemainingUsageCredits
+          : [];
+        const creditsByUnit = new Map<string, bigint>();
+        let sawEvmRow = false;
+        for (const row of rows) {
+          const unit =
+            typeof row?.unit === "string" ? row.unit.toLowerCase() : "";
+          if (!unit.startsWith("eip155:")) {
+            continue;
+          }
+          // Any eip155 row at all ends grandfathering on the node, including
+          // one this loop then drops as unparsable: the node COUNTS those
+          // rows, it does not parse them. Reading that as still-grandfathered
+          // would call a hard-capped key uncapped.
+          sawEvmRow = true;
+          if (typeof row.amount !== "string" || !/^\d+$/.test(row.amount)) {
+            continue;
+          }
+          creditsByUnit.set(
+            unit,
+            (creditsByUnit.get(unit) ?? 0n) + BigInt(row.amount),
+          );
+        }
+        return ok({
+          usageLimited: status.usageLimited,
+          creditsByUnit,
+          grandfatheredUncapped: status.usageLimited && !sawEvmRow,
+        });
+      } catch (error) {
+        return err(String(error) || "Failed to get x402 key spend caps");
+      }
+    },
+
     /**
      * x402 EVM chains the node reports accessible for this environment.
      * Filtered node-side to the client's environment: the Cardano

--- a/packages/masumi/src/clients/masumi-payment-x402.ts
+++ b/packages/masumi/src/clients/masumi-payment-x402.ts
@@ -83,7 +83,20 @@ export interface X402WalletBalanceInput {
 // the pipeline could never bind.
 const caip2EvmNetworkSchema = z.string().regex(CAIP2_EVM_NETWORK_PATTERN);
 const evmAddressSchema = z.string().regex(EVM_ADDRESS_PATTERN);
-const baseUnitAmountSchema = z.string().regex(/^\d+$/);
+/**
+ * Digit ceiling for any base-unit amount the node reports.
+ *
+ * An EVM balance cannot exceed max uint256, which is 78 digits, so 80 clears
+ * every real value with room to spare. The bound is not cosmetic: `BigInt()`
+ * is superlinear in digit count, so an unbounded digit string from the far
+ * side is CPU the sync worker spends on a value that cannot be a balance.
+ */
+const MAX_BASE_UNIT_DIGITS = 80;
+
+const baseUnitAmountSchema = z
+  .string()
+  .regex(/^\d+$/)
+  .max(MAX_BASE_UNIT_DIGITS);
 const assetDecimalsSchema = z.number().int().min(0).max(255);
 const nodeDateSchema = z.union([
   z.date(),
@@ -129,6 +142,16 @@ const apiKeyUsageCreditSchema = z.object({
   unit: z.string(),
   amount: z.string(),
 });
+
+/**
+ * Row ceiling for `RemainingUsageCredits`.
+ *
+ * One row is one `<caip2Network>:<asset>` unit the key holds credit in, so a
+ * real key has a handful. Thousands is version skew or a node fault, and the
+ * loop below turns every row into a `BigInt`. Refusing the read fails closed,
+ * which is the same direction every other guard here takes.
+ */
+const MAX_USAGE_CREDIT_ROWS = 1_000;
 
 const x402WalletSchema: z.ZodType<X402Wallet> = z.object({
   id: z.string().min(1),
@@ -470,6 +493,7 @@ export function createX402PaymentMethods(
         // ready that the node would then refuse with a 402.
         const creditRows = z
           .array(apiKeyUsageCreditSchema)
+          .max(MAX_USAGE_CREDIT_ROWS)
           .safeParse(status.RemainingUsageCredits);
         if (!creditRows.success) {
           return err(
@@ -488,7 +512,14 @@ export function createX402PaymentMethods(
           // rows, it does not parse them. Reading that as still-grandfathered
           // would call a hard-capped key uncapped.
           sawEvmRow = true;
-          if (!/^\d+$/.test(row.amount)) {
+          // Length first: an over-long amount is dropped exactly like an
+          // unparsable one, so its unit reads as zero and the pair delists.
+          // Checking before BigInt is the point, since that is the
+          // superlinear call.
+          if (
+            row.amount.length > MAX_BASE_UNIT_DIGITS ||
+            !/^\d+$/.test(row.amount)
+          ) {
             continue;
           }
           creditsByUnit.set(

--- a/packages/masumi/src/clients/masumi-payment.client.x402.test.ts
+++ b/packages/masumi/src/clients/masumi-payment.client.x402.test.ts
@@ -53,6 +53,24 @@ function budget(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function keyStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "apikey_own",
+    canAdmin: true,
+    usageLimited: false,
+    RemainingUsageCredits: [] as { unit: string; amount: string }[],
+    ...overrides,
+  };
+}
+
+function statusResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    data: { status: "success", data: keyStatus(overrides) },
+    error: undefined,
+    response: { status: 200 },
+  };
+}
+
 function purchasingWallet(overrides: Record<string, unknown> = {}) {
   return {
     id: "wallet_1",
@@ -397,6 +415,135 @@ describe("getX402Budgets", () => {
 
     expect(result.isErr()).toBe(true);
     expect(result.isErr() && result.error).toMatch(/socket hang up/);
+  });
+});
+
+describe("getX402KeySpendCaps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sums credits per eip155 unit and lowercases the unit", async () => {
+    // Nothing on the node enforces one row per (key, unit), and its own debit
+    // path judges the SUM, so a split ledger must not read as the first row.
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({
+        usageLimited: true,
+        RemainingUsageCredits: [
+          { unit: `eip155:84532:${USDC_BASE_SEPOLIA}`, amount: "400000" },
+          {
+            unit: `eip155:84532:${USDC_BASE_SEPOLIA.toLowerCase()}`,
+            amount: "600000",
+          },
+        ],
+      }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    expect(result.isOk()).toBe(true);
+    const caps = result.isOk() ? result.value : null;
+    expect(caps?.usageLimited).toBe(true);
+    expect(caps?.grandfatheredUncapped).toBe(false);
+    expect(
+      caps?.creditsByUnit.get(
+        `eip155:84532:${USDC_BASE_SEPOLIA.toLowerCase()}`,
+      ),
+    ).toBe(1000000n);
+  });
+
+  it("drops the Cardano rail's rows from the same shared ledger", async () => {
+    // lovelace and native-asset units live on the SAME UnitValue ledger. A
+    // Cardano-funded key must never make an EVM pair look payable.
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({
+        usageLimited: true,
+        RemainingUsageCredits: [
+          { unit: "lovelace", amount: "5000000" },
+          { unit: `eip155:84532:${USDC_BASE_SEPOLIA}`, amount: "1" },
+        ],
+      }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    const caps = result.isOk() ? result.value : null;
+    expect(caps?.creditsByUnit.size).toBe(1);
+    expect(caps?.creditsByUnit.has("lovelace")).toBe(false);
+  });
+
+  it("reports a usage-limited key with no eip155 row as grandfathered uncapped", async () => {
+    // The node keeps such a key payable and only warns, so calling it capped
+    // would hide agents the node would settle.
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({
+        usageLimited: true,
+        RemainingUsageCredits: [{ unit: "lovelace", amount: "5000000" }],
+      }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    expect(result.isOk() && result.value.grandfatheredUncapped).toBe(true);
+  });
+
+  it("ends grandfathering on an eip155 row it cannot parse", async () => {
+    // The node COUNTS eip155 rows to decide grandfathering, it does not parse
+    // them. Reading an unparsable row as "still grandfathered" would call a
+    // hard-capped key uncapped and mark an unpayable pair ready.
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({
+        usageLimited: true,
+        RemainingUsageCredits: [
+          { unit: `eip155:84532:${USDC_BASE_SEPOLIA}`, amount: "not-a-number" },
+        ],
+      }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    const caps = result.isOk() ? result.value : null;
+    expect(caps?.grandfatheredUncapped).toBe(false);
+    expect(caps?.creditsByUnit.size).toBe(0);
+  });
+
+  it("reports an unlimited key as uncapped and not grandfathered", async () => {
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({ usageLimited: false }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    const caps = result.isOk() ? result.value : null;
+    expect(caps?.usageLimited).toBe(false);
+    expect(caps?.grandfatheredUncapped).toBe(false);
+  });
+
+  it("fails closed when the node answers 200 without the usageLimited flag", async () => {
+    // Version skew must not read as "uncapped" and mark pairs ready that a
+    // capped key cannot actually pay.
+    getApiKeyStatusMock.mockResolvedValue({
+      data: { status: "success", data: { id: "apikey_own" } },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error).toContain("usageLimited");
+  });
+
+  it("propagates a failed key-status resolution", async () => {
+    getApiKeyStatusMock.mockResolvedValue({
+      data: undefined,
+      error: { error: { message: "unauthorized" } },
+      response: { status: 401 },
+    });
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    expect(result.isErr()).toBe(true);
   });
 });
 

--- a/packages/masumi/src/clients/masumi-payment.client.x402.test.ts
+++ b/packages/masumi/src/clients/masumi-payment.client.x402.test.ts
@@ -519,6 +519,42 @@ describe("getX402KeySpendCaps", () => {
     expect(caps?.grandfatheredUncapped).toBe(false);
   });
 
+  it("fails closed when the node answers 200 without the credit rows", async () => {
+    // RemainingUsageCredits is required, so an absent array is version skew,
+    // never "this key holds no credits". Reading it as empty would call a
+    // usage-limited key grandfathered and mark every pair ready.
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({
+        usageLimited: true,
+        RemainingUsageCredits: undefined,
+      }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error).toContain("RemainingUsageCredits");
+  });
+
+  it("fails closed when a credit row has the wrong shape", async () => {
+    // Distinct from an unparsable AMOUNT, which is a string the node can
+    // really hold and is judged per unit. A row whose amount is not even a
+    // string is a contract break, and guessing at it could hide a real cap.
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({
+        usageLimited: true,
+        RemainingUsageCredits: [
+          { unit: `eip155:84532:${USDC_BASE_SEPOLIA}`, amount: 1000 },
+        ],
+      }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error).toContain("RemainingUsageCredits");
+  });
+
   it("fails closed when the node answers 200 without the usageLimited flag", async () => {
     // Version skew must not read as "uncapped" and mark pairs ready that a
     // capped key cannot actually pay.

--- a/packages/masumi/src/clients/masumi-payment.client.x402.test.ts
+++ b/packages/masumi/src/clients/masumi-payment.client.x402.test.ts
@@ -507,6 +507,48 @@ describe("getX402KeySpendCaps", () => {
     expect(caps?.creditsByUnit.size).toBe(0);
   });
 
+  it("drops an eip155 row whose amount is longer than any real balance", async () => {
+    // 200 digits cannot be a uint256 balance, and BigInt() is superlinear in
+    // digit count. Dropping the row costs the sync worker nothing and still
+    // ends grandfathering, so the unit reads zero and the pair delists.
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({
+        usageLimited: true,
+        RemainingUsageCredits: [
+          {
+            unit: `eip155:84532:${USDC_BASE_SEPOLIA}`,
+            amount: "9".repeat(200),
+          },
+        ],
+      }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    const caps = result.isOk() ? result.value : null;
+    expect(caps?.grandfatheredUncapped).toBe(false);
+    expect(caps?.creditsByUnit.size).toBe(0);
+  });
+
+  it("fails closed when the node returns more credit rows than a key can hold", async () => {
+    // A real key holds one row per unit it has credit in, so thousands is
+    // version skew or a node fault. Every row costs a BigInt parse.
+    getApiKeyStatusMock.mockResolvedValue(
+      statusResponse({
+        usageLimited: true,
+        RemainingUsageCredits: Array.from({ length: 1001 }, (_, index) => ({
+          unit: `eip155:84532:${USDC_BASE_SEPOLIA}${index}`,
+          amount: "1",
+        })),
+      }),
+    );
+
+    const result = await createClient().getX402KeySpendCaps();
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error).toContain("RemainingUsageCredits");
+  });
+
   it("reports an unlimited key as uncapped and not grandfathered", async () => {
     getApiKeyStatusMock.mockResolvedValue(
       statusResponse({ usageLimited: false }),
@@ -871,6 +913,35 @@ describe("getX402WalletBalances", () => {
           Balances: [
             walletBalance(),
             walletBalance({ native: { amount: -1 } }),
+          ],
+        },
+      },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    const result = await createClient().getX402WalletBalances({
+      evmWalletId: "wallet_1",
+      evmWalletAddress: purchasingWallet().address,
+      caip2Network: "eip155:84532",
+    });
+
+    expect(result.isErr() && result.error).toContain("malformed row");
+  });
+
+  it("fails closed when a balance amount is longer than any real balance", async () => {
+    // Max uint256 is 78 digits. A longer amount is not a balance, and the
+    // bound keeps an unbounded digit string off the BigInt path.
+    getX402WalletsBalanceMock.mockResolvedValue({
+      data: {
+        status: "success",
+        data: {
+          evmWalletId: "wallet_1",
+          address: purchasingWallet().address,
+          Balances: [
+            walletBalance({
+              native: { symbol: "ETH", decimals: 18, amount: "9".repeat(200) },
+            }),
           ],
         },
       },


### PR DESCRIPTION
## What

Adds `getX402KeySpendCaps` to the masumi payment client: the calling key's x402
spend cap, read from `GET /api-key-status`.

masumi ADR 0016 moves the x402 spend cap onto the API key as per-unit usage
credits and removes per-wallet budgets from the payment node, so
`GET /x402/budgets` disappears with the next node release. This is the client
half of that move. It is **additive only** — `getX402Budgets` and its consumers
are untouched, so nothing changes behaviour on this PR alone.

The node's credit unit is `eip155:<chainId>:<asset>`, byte-identical to the
`<caip2Network>:<asset>` pair key Core composes buy-side readiness on, so a cap
check downstream is a plain map lookup. Reading it costs no extra request: it
comes off the same memoized `api-key-status` every other scoped call here
already resolves.

## Three node behaviours the read mirrors

- **Split ledgers are summed.** Nothing on the node enforces one row per
  (key, unit), and its own debit path judges the total.
- **Cardano rows are dropped.** lovelace and native-asset credits share the same
  `UnitValue` ledger, so a Cardano-funded key must not make an EVM pair look
  payable.
- **Grandfathering is reported separately.** A `usageLimited` key holding no
  `eip155:` row at all is left uncapped by the node — not the same as capped at
  zero. Any `eip155:` row ends grandfathering, including one this read cannot
  parse, because the node *counts* those rows rather than parsing them.

A 200 without the `usageLimited` flag fails closed rather than reading as
uncapped, matching the version-skew posture of the other reads here.

## User-facing impact

None on its own. The behaviour change ships in the PR stacked on top, which
switches Core's buy-side readiness onto this read.

## Verification

- `pnpm check` — `Checked 3448 files. No fixes applied.`
- `pnpm typecheck` — `Tasks: 17 successful, 17 total`
- `pnpm --filter @sokosumi/masumi test` — `Tests 389 passed (389)`
- `pnpm --filter core test src/services/agent-sync.x402-readiness` — `Tests 58 passed (58)` (Core untouched, still on the budgets path)

## Notes for review

Requires the payment node to have shipped masumi ADR 0016 before the stack's
top PR is deployed. The pinned OpenAPI spec is deliberately not refreshed here:
the dev spec carries 25 unrelated new endpoints (115 paths vs 91 pinned) for
one removal. Re-run `pnpm fetch:specs` against the deployed node before
merging the top PR to confirm no drift.

masumi side: masumi-network/masumi-payment-service#746 and #747 (both merged to
`dev`).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
