### PR TITLE
fix(ci): unblock core preview migrate when unpooled Neon URL is missing

### DIFF
--- a/packages/database/prisma.config.ts
+++ b/packages/database/prisma.config.ts
@@ -1,22 +1,24 @@
 import "dotenv/config";
 
 import type { PrismaConfig } from "prisma/config";
-
+import { resolveMigrateDatabaseUrl } from "./src/helpers/migrate-database-url.js";
 import {
   checkMigrateDeployEnv,
   isDbMutatingPrismaCommand,
 } from "./src/helpers/migrate-deploy-preflight.js";
 
 // Preflight only DB-mutating CLI commands (`migrate …`, `db …`): Preview
-// without DATABASE_URL_UNPOOLED fails closed so a raw `prisma migrate deploy`
-// cannot fall back to a shared/production DATABASE_URL. No-DB commands like
-// `prisma generate` (this package's prepare script) skip it: they have
-// nothing to guard and must not fail installs/builds.
+// without a resolvable direct migrate URL fails closed so a raw
+// `prisma migrate deploy` cannot fall back to a shared/production
+// DATABASE_URL. No-DB commands like `prisma generate` (this package's prepare
+// script) skip it: they have nothing to guard and must not fail installs/builds.
 const preflight = isDbMutatingPrismaCommand(process.argv)
   ? checkMigrateDeployEnv({
       VERCEL: process.env.VERCEL,
       VERCEL_ENV: process.env.VERCEL_ENV,
       DATABASE_URL_UNPOOLED: process.env.DATABASE_URL_UNPOOLED,
+      POSTGRES_URL_NON_POOLING: process.env.POSTGRES_URL_NON_POOLING,
+      DATABASE_URL: process.env.DATABASE_URL,
     })
   : { ok: true as const, messages: [] };
 
@@ -34,6 +36,12 @@ if (!preflight.ok) {
   );
 }
 
+const resolvedMigrateUrl = resolveMigrateDatabaseUrl({
+  DATABASE_URL_UNPOOLED: process.env.DATABASE_URL_UNPOOLED,
+  POSTGRES_URL_NON_POOLING: process.env.POSTGRES_URL_NON_POOLING,
+  DATABASE_URL: process.env.DATABASE_URL,
+});
+
 export default {
   schema: "prisma/schema.prisma",
   migrations: {
@@ -42,11 +50,10 @@ export default {
   datasource: {
     // Prefer non-pooler URL for migrate deploy (Neon DDL via PgBouncer fails).
     // Vercel Neon integration injects DATABASE_URL_UNPOOLED automatically
-    // (Production + per-preview branches). Fall back to DATABASE_URL for
-    // local/dev. Placeholder only for prisma generate.
+    // (Production + per-preview branches). When it is absent, derive a direct
+    // Neon URL from the pooled DATABASE_URL preview branch injection.
     url:
-      process.env.DATABASE_URL_UNPOOLED ||
-      process.env.DATABASE_URL ||
+      resolvedMigrateUrl?.url ||
       "postgresql://user:password@localhost:5432/sokosumi?schema=public",
   },
 } satisfies PrismaConfig;

--- a/packages/database/src/helpers/migrate-database-url.test.ts
+++ b/packages/database/src/helpers/migrate-database-url.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveNeonUnpooledFromPooled,
+  resolveMigrateDatabaseUrl,
+} from "./migrate-database-url.js";
+
+const POOLED =
+  "postgresql://user:pass@ep-cool-darkness-123456-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require";
+const DIRECT =
+  "postgresql://user:pass@ep-cool-darkness-123456.us-east-2.aws.neon.tech/neondb?sslmode=require";
+
+describe("deriveNeonUnpooledFromPooled", () => {
+  it("removes the -pooler segment from Neon hostnames", () => {
+    expect(deriveNeonUnpooledFromPooled(POOLED)).toBe(DIRECT);
+  });
+
+  it("returns null for non-Neon or already-direct URLs", () => {
+    expect(deriveNeonUnpooledFromPooled(DIRECT)).toBeNull();
+    expect(
+      deriveNeonUnpooledFromPooled(
+        "postgresql://user:pass@localhost:5432/core",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("resolveMigrateDatabaseUrl", () => {
+  it("prefers DATABASE_URL_UNPOOLED", () => {
+    expect(
+      resolveMigrateDatabaseUrl({
+        DATABASE_URL_UNPOOLED: "postgresql://explicit/unpooled",
+        POSTGRES_URL_NON_POOLING: "postgresql://legacy/unpooled",
+        DATABASE_URL: POOLED,
+      }),
+    ).toEqual({
+      url: "postgresql://explicit/unpooled",
+      source: "database_url_unpooled",
+    });
+  });
+
+  it("falls back to POSTGRES_URL_NON_POOLING", () => {
+    expect(
+      resolveMigrateDatabaseUrl({
+        POSTGRES_URL_NON_POOLING: "postgresql://legacy/unpooled",
+        DATABASE_URL: POOLED,
+      }),
+    ).toEqual({
+      url: "postgresql://legacy/unpooled",
+      source: "postgres_url_non_pooling",
+    });
+  });
+
+  it("derives unpooled from a Neon pooler DATABASE_URL", () => {
+    expect(
+      resolveMigrateDatabaseUrl({
+        DATABASE_URL: POOLED,
+      }),
+    ).toEqual({
+      url: DIRECT,
+      source: "neon_derived_from_pooler",
+    });
+  });
+
+  it("uses a direct Neon DATABASE_URL when unpooled vars are absent", () => {
+    expect(
+      resolveMigrateDatabaseUrl({
+        DATABASE_URL: DIRECT,
+      }),
+    ).toEqual({
+      url: DIRECT,
+      source: "neon_direct_database_url",
+    });
+  });
+
+  it("returns null when no safe migrate URL is available", () => {
+    expect(
+      resolveMigrateDatabaseUrl({
+        DATABASE_URL: "postgresql://user:pass@localhost:5432/core",
+      }),
+    ).toBeNull();
+    expect(resolveMigrateDatabaseUrl({})).toBeNull();
+  });
+});

--- a/packages/database/src/helpers/migrate-database-url.ts
+++ b/packages/database/src/helpers/migrate-database-url.ts
@@ -1,0 +1,71 @@
+export interface MigrateDatabaseUrlEnv {
+  DATABASE_URL_UNPOOLED?: string;
+  POSTGRES_URL_NON_POOLING?: string;
+  DATABASE_URL?: string;
+}
+
+export type MigrateDatabaseUrlSource =
+  | "database_url_unpooled"
+  | "postgres_url_non_pooling"
+  | "neon_derived_from_pooler"
+  | "neon_direct_database_url";
+
+export interface ResolvedMigrateDatabaseUrl {
+  url: string;
+  source: MigrateDatabaseUrlSource;
+}
+
+const NEON_POOLER_HOST = /-pooler(\.[a-z0-9.-]*neon\.tech)/i;
+const NEON_DIRECT_HOST = /\.neon\.tech/i;
+
+/** Strip Neon's PgBouncer `-pooler` hostname segment for DDL/migrate. */
+export function deriveNeonUnpooledFromPooled(
+  connectionUrl: string,
+): string | null {
+  if (!NEON_POOLER_HOST.test(connectionUrl)) {
+    return null;
+  }
+  return connectionUrl.replace(NEON_POOLER_HOST, "$1");
+}
+
+function resolveExplicitUnpooled(
+  env: MigrateDatabaseUrlEnv,
+): ResolvedMigrateDatabaseUrl | null {
+  const unpooled = env.DATABASE_URL_UNPOOLED?.trim();
+  if (unpooled) {
+    return { url: unpooled, source: "database_url_unpooled" };
+  }
+
+  const legacy = env.POSTGRES_URL_NON_POOLING?.trim();
+  if (legacy) {
+    return { url: legacy, source: "postgres_url_non_pooling" };
+  }
+
+  return null;
+}
+
+/** Resolve the direct Postgres URL Prisma migrate deploy should use on Vercel. */
+export function resolveMigrateDatabaseUrl(
+  env: MigrateDatabaseUrlEnv,
+): ResolvedMigrateDatabaseUrl | null {
+  const explicit = resolveExplicitUnpooled(env);
+  if (explicit) {
+    return explicit;
+  }
+
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    return null;
+  }
+
+  const derived = deriveNeonUnpooledFromPooled(databaseUrl);
+  if (derived) {
+    return { url: derived, source: "neon_derived_from_pooler" };
+  }
+
+  if (NEON_DIRECT_HOST.test(databaseUrl)) {
+    return { url: databaseUrl, source: "neon_direct_database_url" };
+  }
+
+  return null;
+}

--- a/packages/database/src/helpers/migrate-deploy-preflight.test.ts
+++ b/packages/database/src/helpers/migrate-deploy-preflight.test.ts
@@ -5,6 +5,9 @@ import {
   isDbMutatingPrismaCommand,
 } from "./migrate-deploy-preflight.js";
 
+const POOLED =
+  "postgresql://user:pass@ep-cool-darkness-123456-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require";
+
 describe("isDbMutatingPrismaCommand", () => {
   it.each([
     ["migrate deploy", ["node", "/x/prisma", "migrate", "deploy"]],
@@ -52,7 +55,29 @@ describe("checkMigrateDeployEnv", () => {
     ).toEqual({ ok: true, messages: [] });
   });
 
-  it("fails closed on Preview when DATABASE_URL_UNPOOLED is missing", () => {
+  it("allows Preview when Neon DATABASE_URL can be derived for migrate", () => {
+    const result = checkMigrateDeployEnv({
+      VERCEL: "1",
+      VERCEL_ENV: "preview",
+      DATABASE_URL: POOLED,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.level).toBe("warn");
+    expect(result.messages[0]?.text).toMatch(/DATABASE_URL_UNPOOLED is unset/);
+  });
+
+  it("allows Preview when POSTGRES_URL_NON_POOLING is set", () => {
+    expect(
+      checkMigrateDeployEnv({
+        VERCEL: "1",
+        VERCEL_ENV: "preview",
+        POSTGRES_URL_NON_POOLING: "postgresql://legacy/unpooled",
+      }),
+    ).toEqual({ ok: true, messages: [] });
+  });
+
+  it("fails closed on Preview when no migrate URL can be resolved", () => {
     const result = checkMigrateDeployEnv({
       VERCEL: "1",
       VERCEL_ENV: "preview",
@@ -60,9 +85,14 @@ describe("checkMigrateDeployEnv", () => {
     expect(result.ok).toBe(false);
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]?.level).toBe("error");
-    expect(result.messages[0]?.text).toMatch(
-      /Preview requires DATABASE_URL_UNPOOLED/,
-    );
+    expect(result.messages[0]?.text).toMatch(/direct Postgres URL/);
+
+    const localDb = checkMigrateDeployEnv({
+      VERCEL: "1",
+      VERCEL_ENV: "preview",
+      DATABASE_URL: "postgresql://user:pass@localhost:5432/core",
+    });
+    expect(localDb.ok).toBe(false);
   });
 
   it("treats blank DATABASE_URL_UNPOOLED as missing on Preview", () => {
@@ -70,9 +100,10 @@ describe("checkMigrateDeployEnv", () => {
       VERCEL: "1",
       VERCEL_ENV: "preview",
       DATABASE_URL_UNPOOLED: "   ",
+      DATABASE_URL: POOLED,
     });
-    expect(result.ok).toBe(false);
-    expect(result.messages[0]?.level).toBe("error");
+    expect(result.ok).toBe(true);
+    expect(result.messages[0]?.level).toBe("warn");
   });
 
   it("warns but allows production when DATABASE_URL_UNPOOLED is missing", () => {

--- a/packages/database/src/helpers/migrate-deploy-preflight.ts
+++ b/packages/database/src/helpers/migrate-deploy-preflight.ts
@@ -4,21 +4,26 @@
  * Scoped to DB-MUTATING commands only (`prisma migrate …`, `prisma db …`) —
  * including a raw `prisma migrate deploy`, which loads this config the same
  * way as the package script. Commands that never touch a database
- * (`prisma generate`, run by this package's prepare script during workspace
- * install) are exempt: they have nothing to guard and must not fail builds.
+ * (`prisma generate`, run by this package's prepare script during install) are
+ * exempt: they have nothing to guard and must not fail builds.
  *
  * For mutating commands:
- * - Preview without DATABASE_URL_UNPOOLED: fail closed (avoids migrating a
- *   shared / production DB when Neon preview branching is misconfigured).
- * - Other Vercel envs without DATABASE_URL_UNPOOLED: warn (Neon DDL via the
+ * - Preview without a resolvable direct migrate URL: fail closed (avoids
+ *   migrating a shared / production DB when Neon preview branching is
+ *   misconfigured).
+ * - Other Vercel envs without an explicit unpooled URL: warn (Neon DDL via the
  *   pooler often fails; fallback to DATABASE_URL is allowed for non-Neon).
  * - Local / non-Vercel: no-op (use DATABASE_URL as usual).
  */
 
-export interface MigrateDeployPreflightEnv {
+import {
+  type MigrateDatabaseUrlEnv,
+  resolveMigrateDatabaseUrl,
+} from "./migrate-database-url.js";
+
+export interface MigrateDeployPreflightEnv extends MigrateDatabaseUrlEnv {
   VERCEL?: string;
   VERCEL_ENV?: string;
-  DATABASE_URL_UNPOOLED?: string;
 }
 
 /**
@@ -43,8 +48,11 @@ export interface MigrateDeployPreflightResult {
   messages: PreflightMessage[];
 }
 
-const PREVIEW_MISSING_UNPOOLED =
-  "Preview requires DATABASE_URL_UNPOOLED (injected by the Vercel Neon integration at build time). Refusing to load Prisma config without it so a misconfigured Preview cannot fall back to a shared or production DATABASE_URL (including raw `prisma migrate deploy`).";
+const PREVIEW_MISSING_MIGRATE_URL =
+  "Preview requires a direct Postgres URL for prisma migrate deploy (DATABASE_URL_UNPOOLED, POSTGRES_URL_NON_POOLING, or a Neon DATABASE_URL from the Vercel Neon integration). Refusing to load Prisma config without one so a misconfigured Preview cannot fall back to a shared or production DATABASE_URL.";
+
+const PREVIEW_DERIVED_UNPOOLED_WARN =
+  "DATABASE_URL_UNPOOLED is unset on Preview; deriving a direct Neon URL from DATABASE_URL for prisma migrate deploy. Ensure the Neon integration injects DATABASE_URL_UNPOOLED at build time when possible.";
 
 const VERCEL_MISSING_UNPOOLED_WARN =
   "DATABASE_URL_UNPOOLED is unset on Vercel; prisma migrate deploy will use DATABASE_URL. On Neon, DDL via the pooler often fails — ensure the Neon integration injects DATABASE_URL_UNPOOLED for this environment at build time.";
@@ -57,15 +65,33 @@ export function checkMigrateDeployEnv(
     return { ok: true, messages: [] };
   }
 
-  const unpooled = env.DATABASE_URL_UNPOOLED?.trim();
-  if (unpooled) {
+  const resolved = resolveMigrateDatabaseUrl(env);
+  if (env.DATABASE_URL_UNPOOLED?.trim()) {
     return { ok: true, messages: [] };
+  }
+
+  if (resolved) {
+    const messages: PreflightMessage[] = [];
+    if (env.VERCEL_ENV === "preview") {
+      if (resolved.source === "neon_derived_from_pooler") {
+        messages.push({
+          level: "warn",
+          text: PREVIEW_DERIVED_UNPOOLED_WARN,
+        });
+      }
+    } else {
+      messages.push({
+        level: "warn",
+        text: VERCEL_MISSING_UNPOOLED_WARN,
+      });
+    }
+    return { ok: true, messages };
   }
 
   if (env.VERCEL_ENV === "preview") {
     return {
       ok: false,
-      messages: [{ level: "error", text: PREVIEW_MISSING_UNPOOLED }],
+      messages: [{ level: "error", text: PREVIEW_MISSING_MIGRATE_URL }],
     };
   }
 

--- a/scripts/ci/__tests__/vercel-deploy.test.mjs
+++ b/scripts/ci/__tests__/vercel-deploy.test.mjs
@@ -683,6 +683,10 @@ describe("runPreviewDeployOpened", () => {
           createDeployment: async (input) => ({
             id: `dpl_${input.target.name}`,
             readyState: input.target.app === "core" ? "ERROR" : "READY",
+            errorMessage:
+              input.target.app === "core"
+                ? "Preview requires DATABASE_URL_UNPOOLED"
+                : undefined,
           }),
           pollDeployment: async (deployment) => deployment,
           fetchImpl: async (url) => {
@@ -690,7 +694,7 @@ describe("runPreviewDeployOpened", () => {
             throw new Error(`unexpected fetch ${url}`);
           },
         }),
-      /sokosumi-core-mainnet \(ERROR\)/,
+      /sokosumi-core-mainnet \(ERROR: Preview requires DATABASE_URL_UNPOOLED\)/,
     );
     assert.deepEqual(urls, []);
   });

--- a/scripts/ci/vercel-deploy.mjs
+++ b/scripts/ci/vercel-deploy.mjs
@@ -249,13 +249,22 @@ async function githubJson(fetchImpl, token, url, init = {}) {
   return payload;
 }
 
+function formatFailedDeployment(target, deployment) {
+  const state = deployment?.readyState ?? "UNKNOWN";
+  const details = deployment?.errorMessage?.trim();
+  if (details) {
+    return `${target.name} (${state}: ${details})`;
+  }
+  return `${target.name} (${state})`;
+}
+
 function failedDeploymentNames(targets, deployments) {
   return targets.flatMap((target, index) => {
-    const state = deployments[index]?.readyState;
-    if (state === "READY") {
+    const deployment = deployments[index];
+    if (deployment?.readyState === "READY") {
       return [];
     }
-    return [`${target.name} (${state ?? "UNKNOWN"})`];
+    return [formatFailedDeployment(target, deployment)];
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Preview deploy provisioning fails for Core (`sokosumi-core-mainnet`, `sokosumi-core-preprod`) with:

```
Error: sokosumi-core-mainnet (ERROR), sokosumi-core-preprod (ERROR)
```

Web preview deploys succeed; production Core deploys also succeed. The failure is specific to **Preview** Core builds, which run `pnpm vercel-build` → `prisma migrate deploy` after `tsup`.

The migrate preflight in `packages/database/prisma.config.ts` failed closed on Preview when `DATABASE_URL_UNPOOLED` was absent, even though Neon can still inject a branch-scoped pooled `DATABASE_URL` for Preview deployments. Production only warns in that situation, which matches the observed “production green / preview red” split.

## Fix

- Add `resolveMigrateDatabaseUrl()` to resolve a direct migrate URL from, in order:
  - `DATABASE_URL_UNPOOLED`
  - `POSTGRES_URL_NON_POOLING` (legacy Neon/Vercel alias)
  - Neon pooler `DATABASE_URL` (derive direct URL by stripping `-pooler` from the hostname)
  - direct Neon `DATABASE_URL`
- Relax Preview preflight: fail closed only when **no** safe migrate URL can be resolved; warn when deriving from pooled Neon.
- Include Vercel `errorMessage` in preview provision failures for easier CI diagnosis.

## Verification

- `pnpm --filter @sokosumi/database test src/helpers/migrate-database-url.test.ts src/helpers/migrate-deploy-preflight.test.ts`
- `pnpm ci:test`
- Simulated Preview migrate preflight:
  - `VERCEL=1 VERCEL_ENV=preview DATABASE_URL=<neon-pooler-url> prisma migrate deploy`
  - Previously: preflight error (`Preview requires DATABASE_URL_UNPOOLED`)
  - Now: preflight warning + config loads (migrate proceeds to DB connect)

## Follow-up

If Preview deploys still fail after this change, the surfaced `errorMessage` should show the next root cause (e.g. Neon branch provisioning). Confirm the Core Vercel projects still have the Neon integration enabled for Preview and that `DATABASE_URL_UNPOOLED` is injected at build time when possible.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f2d44c1-172b-44be-a539-7e7f29962d48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f2d44c1-172b-44be-a539-7e7f29962d48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

