### PR TITLE
feat(drive): add recents search (SOK-900)

### DIFF
--- a/apps/core/src/helpers/drive-recents.test.ts
+++ b/apps/core/src/helpers/drive-recents.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   compareDriveRecentsItems,
   decodeDriveRecentsCursor,
+  driveRecentsDriveFileNameMatchesSearch,
   encodeDriveRecentsCursor,
   isRecentsItemOlderThanCursor,
 } from "@/helpers/drive-recents";
@@ -33,6 +34,26 @@ function taskOutput(taskFileId: string, activityAt: string): DriveRecentsItem {
     projectName: null,
   };
 }
+
+describe("driveRecentsDriveFileNameMatchesSearch", () => {
+  it("matches case-insensitive substrings", () => {
+    expect(driveRecentsDriveFileNameMatchesSearch("Report.pdf", "port")).toBe(
+      true,
+    );
+    expect(driveRecentsDriveFileNameMatchesSearch("Report.pdf", "PORT")).toBe(
+      true,
+    );
+    expect(
+      driveRecentsDriveFileNameMatchesSearch("Report.pdf", "invoice"),
+    ).toBe(false);
+  });
+
+  it("treats blank search as match-all", () => {
+    expect(driveRecentsDriveFileNameMatchesSearch("Report.pdf", "  ")).toBe(
+      true,
+    );
+  });
+});
 
 describe("compareDriveRecentsItems", () => {
   it("sorts by activityAt descending", () => {

--- a/apps/core/src/helpers/drive-recents.test.ts
+++ b/apps/core/src/helpers/drive-recents.test.ts
@@ -1,13 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   compareDriveRecentsItems,
   decodeDriveRecentsCursor,
   driveRecentsDriveFileNameMatchesSearch,
   encodeDriveRecentsCursor,
+  fetchDriveRecentsPage,
   isRecentsItemOlderThanCursor,
 } from "@/helpers/drive-recents";
+import type { DriveTaskOutputRecentsRow } from "@/helpers/drive-task-output-catalog";
 import type { DriveRecentsItem } from "@/schemas/drive-recents.schema";
+
+const listMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@vercel/blob", () => ({
+  list: listMock,
+}));
 
 function driveFile(pathname: string, activityAt: string): DriveRecentsItem {
   return {
@@ -106,3 +114,133 @@ describe("drive recents cursor", () => {
     expect(isRecentsItemOlderThanCursor(cursorItem, cursorItem)).toBe(false);
   });
 });
+
+describe("fetchDriveRecentsPage", () => {
+  beforeEach(() => {
+    listMock.mockReset();
+  });
+
+  function taskRow(id: string, updatedAt: string): DriveTaskOutputRecentsRow {
+    return {
+      id,
+      name: "output.pdf",
+      fileUrl: "https://example.com/output.pdf",
+      size: 200,
+      updatedAt: new Date(updatedAt),
+      taskId: "task-1",
+      taskName: "Task",
+      projectId: null,
+      projectName: null,
+    };
+  }
+
+  it("keeps global recency order across multiple drive and task batches", async () => {
+    let drivePage = 0;
+    listMock.mockImplementation(async () => {
+      drivePage += 1;
+      if (drivePage === 1) {
+        return {
+          blobs: [
+            {
+              url: "https://blob.example/old-drive.pdf",
+              pathname: "drive/users/u/old-drive.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-18T12:00:00.000Z"),
+            },
+          ],
+          hasMore: true,
+          cursor: "blob-page-2",
+        };
+      }
+
+      return {
+        blobs: [
+          {
+            url: "https://blob.example/new-drive.pdf",
+            pathname: "drive/users/u/new-drive.pdf",
+            size: 100,
+            uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+          },
+        ],
+        hasMore: false,
+      };
+    });
+
+    let taskPage = 0;
+    const fetchTaskOutputs = vi.fn(
+      async (): Promise<{
+        rows: DriveTaskOutputRecentsRow[];
+        hasMore: boolean;
+        nextCursor: string | null;
+      }> => {
+        taskPage += 1;
+        if (taskPage === 1) {
+          return {
+            rows: [taskRow("tf_mid", "2026-08-20T12:00:00.000Z")],
+            hasMore: false,
+            nextCursor: null,
+          };
+        }
+        return { rows: [], hasMore: false, nextCursor: null };
+      },
+    );
+
+    const page = await fetchDriveRecentsPage({
+      prefix: "drive/users/u/",
+      token: "test-token",
+      limit: 3,
+      fetchTaskOutputs,
+    });
+
+    expect(page.items.map((item) => recentsItemKey(item))).toEqual([
+      "drive-file:new-drive.pdf",
+      "task-output:tf_mid",
+      "drive-file:old-drive.pdf",
+    ]);
+  });
+
+  it("filters drive filenames in-memory while preserving recency order", async () => {
+    listMock.mockResolvedValue({
+      blobs: [
+        {
+          url: "https://blob.example/report.pdf",
+          pathname: "drive/users/u/report.pdf",
+          size: 100,
+          uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+        },
+        {
+          url: "https://blob.example/notes.pdf",
+          pathname: "drive/users/u/notes.pdf",
+          size: 100,
+          uploadedAt: new Date("2026-08-20T12:00:00.000Z"),
+        },
+      ],
+      hasMore: false,
+    });
+
+    const fetchTaskOutputs = vi.fn(async () => ({
+      rows: [],
+      hasMore: false,
+      nextCursor: null,
+    }));
+
+    const page = await fetchDriveRecentsPage({
+      prefix: "drive/users/u/",
+      token: "test-token",
+      limit: 10,
+      searchQuery: "report",
+      fetchTaskOutputs,
+    });
+
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0]?.kind).toBe("drive-file");
+    expect(page.items[0]?.name).toBe("report.pdf");
+  });
+});
+
+function recentsItemKey(item: DriveRecentsItem): string {
+  if (item.kind === "drive-file") {
+    return `drive-file:${item.name}`;
+  }
+  return `task-output:${item.taskFileId}`;
+}

--- a/apps/core/src/helpers/drive-recents.test.ts
+++ b/apps/core/src/helpers/drive-recents.test.ts
@@ -12,10 +12,16 @@ import type { DriveTaskOutputRecentsRow } from "@/helpers/drive-task-output-cata
 import type { DriveRecentsItem } from "@/schemas/drive-recents.schema";
 
 const listMock = vi.hoisted(() => vi.fn());
+const headMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@vercel/blob", () => ({
   list: listMock,
+  head: headMock,
 }));
+
+const CURSOR_SECRET = "test-cursor-secret";
+const PREFIX = "drive/users/u/";
+const CURSOR_BINDING = { prefix: PREFIX, searchQuery: "" };
 
 function driveFile(pathname: string, activityAt: string): DriveRecentsItem {
   return {
@@ -41,6 +47,12 @@ function taskOutput(taskFileId: string, activityAt: string): DriveRecentsItem {
     projectId: null,
     projectName: null,
   };
+}
+
+function fetchTaskOutputsByIds(
+  rows: DriveTaskOutputRecentsRow[],
+): (ids: string[]) => Promise<DriveTaskOutputRecentsRow[]> {
+  return async (ids) => rows.filter((row) => ids.includes(row.id));
 }
 
 describe("driveRecentsDriveFileNameMatchesSearch", () => {
@@ -82,7 +94,7 @@ describe("compareDriveRecentsItems", () => {
 });
 
 describe("drive recents cursor", () => {
-  it("round-trips cursor payload", () => {
+  it("round-trips signed cursor payload", () => {
     const item = driveFile(
       "drive/users/u/report.pdf",
       "2026-08-20T10:00:00.000Z",
@@ -91,33 +103,105 @@ describe("drive recents cursor", () => {
       lastItem: item,
       driveBlobCursor: "blob-cursor",
       taskFileCursor: "task-cursor",
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
     });
 
-    const decoded = decodeDriveRecentsCursor(encoded);
+    const decoded = decodeDriveRecentsCursor(encoded, {
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
+    });
     expect(decoded.lastItem?.kind).toBe("drive-file");
     expect(decoded.lastItem?.activityAt).toBe(item.activityAt);
     expect(decoded.driveBlobCursor).toBe("blob-cursor");
     expect(decoded.taskFileCursor).toBe("task-cursor");
-    expect(decoded.pendingItems).toEqual([]);
+    expect(decoded.pendingRefs).toEqual([]);
   });
 
-  it("round-trips pending items in cursor payload", () => {
+  it("round-trips pending refs without embedding full records", () => {
     const item = driveFile(
       "drive/users/u/report.pdf",
       "2026-08-20T10:00:00.000Z",
     );
-    const pending = [
-      driveFile("drive/users/u/older.pdf", "2026-08-19T10:00:00.000Z"),
-    ];
+    const pendingPath = "drive/users/u/older.pdf";
+    const pending = driveFile(pendingPath, "2026-08-19T10:00:00.000Z");
     const encoded = encodeDriveRecentsCursor({
       lastItem: item,
       driveBlobCursor: "blob-cursor",
       taskFileCursor: null,
-      pendingItems: pending,
+      pendingRefs: [
+        {
+          kind: "drive-file",
+          id: pendingPath,
+          activityAt: pending.activityAt,
+        },
+      ],
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
     });
 
-    const decoded = decodeDriveRecentsCursor(encoded);
-    expect(decoded.pendingItems).toEqual(pending);
+    expect(encoded.length).toBeLessThan(2048);
+
+    const decoded = decodeDriveRecentsCursor(encoded, {
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
+    });
+    expect(decoded.pendingRefs).toEqual([
+      {
+        kind: "drive-file",
+        id: pendingPath,
+        activityAt: pending.activityAt,
+      },
+    ]);
+  });
+
+  it("rejects cursors signed for a different workspace prefix", () => {
+    const item = driveFile(
+      "drive/users/u/report.pdf",
+      "2026-08-20T10:00:00.000Z",
+    );
+    const encoded = encodeDriveRecentsCursor({
+      lastItem: item,
+      driveBlobCursor: null,
+      taskFileCursor: null,
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
+    });
+
+    expect(() =>
+      decodeDriveRecentsCursor(encoded, {
+        cursorSecret: CURSOR_SECRET,
+        cursorBinding: {
+          prefix: "drive/users/other/",
+          searchQuery: "",
+        },
+      }),
+    ).toThrow("Invalid pagination cursor");
+  });
+
+  it("rejects legacy cursors that embed pendingItems records", () => {
+    const legacyPayload = Buffer.from(
+      JSON.stringify({
+        payload: JSON.stringify({
+          v: 2,
+          activityAt: "2026-08-20T10:00:00.000Z",
+          kind: "drive-file",
+          id: "drive/users/u/report.pdf",
+          pendingItems: [
+            driveFile("drive/users/u/older.pdf", "2026-08-19T10:00:00.000Z"),
+          ],
+        }),
+        signature: "not-valid",
+      }),
+      "utf8",
+    ).toString("base64url");
+
+    expect(() =>
+      decodeDriveRecentsCursor(legacyPayload, {
+        cursorSecret: CURSOR_SECRET,
+        cursorBinding: CURSOR_BINDING,
+      }),
+    ).toThrow("Invalid pagination cursor");
   });
 
   it("detects items older than cursor position", () => {
@@ -138,6 +222,13 @@ describe("drive recents cursor", () => {
 describe("fetchDriveRecentsPage", () => {
   beforeEach(() => {
     listMock.mockReset();
+    headMock.mockReset();
+    headMock.mockImplementation(async (pathname: string) => ({
+      url: `https://blob.example/${pathname}`,
+      pathname,
+      size: 100,
+      uploadedAt: new Date("2026-08-19T10:00:00.000Z"),
+    }));
   });
 
   function taskRow(id: string, updatedAt: string): DriveTaskOutputRecentsRow {
@@ -206,10 +297,13 @@ describe("fetchDriveRecentsPage", () => {
     );
 
     const page = await fetchDriveRecentsPage({
-      prefix: "drive/users/u/",
+      prefix: PREFIX,
       token: "test-token",
       limit: 3,
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
       fetchTaskOutputs,
+      fetchTaskOutputsByIds: fetchTaskOutputsByIds([]),
     });
 
     expect(page.items.map((item) => recentsItemKey(item))).toEqual([
@@ -245,11 +339,14 @@ describe("fetchDriveRecentsPage", () => {
     }));
 
     const page = await fetchDriveRecentsPage({
-      prefix: "drive/users/u/",
+      prefix: PREFIX,
       token: "test-token",
       limit: 10,
       searchQuery: "report",
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: { prefix: PREFIX, searchQuery: "report" },
       fetchTaskOutputs,
+      fetchTaskOutputsByIds: fetchTaskOutputsByIds([]),
     });
 
     expect(page.items).toHaveLength(1);
@@ -303,6 +400,21 @@ describe("fetchDriveRecentsPage", () => {
       };
     });
 
+    headMock.mockImplementation(async (pathname: string) => {
+      const uploadedAtByPath: Record<string, string> = {
+        "drive/users/u/b-mid.pdf": "2026-08-20T12:00:00.000Z",
+        "drive/users/u/c-old.pdf": "2026-08-18T12:00:00.000Z",
+      };
+      return {
+        url: `https://blob.example/${pathname}`,
+        pathname,
+        size: 100,
+        uploadedAt: new Date(
+          uploadedAtByPath[pathname] ?? "2026-08-19T10:00:00.000Z",
+        ),
+      };
+    });
+
     const fetchTaskOutputs = vi.fn(async () => ({
       rows: [],
       hasMore: false,
@@ -310,23 +422,30 @@ describe("fetchDriveRecentsPage", () => {
     }));
 
     const firstPage = await fetchDriveRecentsPage({
-      prefix: "drive/users/u/",
+      prefix: PREFIX,
       token: "test-token",
       limit: 1,
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
       fetchTaskOutputs,
+      fetchTaskOutputsByIds: fetchTaskOutputsByIds([]),
     });
 
     expect(firstPage.items).toHaveLength(1);
     expect(firstPage.items[0]?.name).toBe("a-new.pdf");
     expect(firstPage.hasMore).toBe(true);
     expect(firstPage.nextCursor).toBeTruthy();
+    expect(firstPage.nextCursor?.length).toBeLessThan(2048);
 
     const secondPage = await fetchDriveRecentsPage({
-      prefix: "drive/users/u/",
+      prefix: PREFIX,
       token: "test-token",
       limit: 1,
       cursor: firstPage.nextCursor ?? undefined,
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
       fetchTaskOutputs,
+      fetchTaskOutputsByIds: fetchTaskOutputsByIds([]),
     });
 
     expect(secondPage.items).toHaveLength(1);
@@ -334,16 +453,95 @@ describe("fetchDriveRecentsPage", () => {
     expect(secondPage.hasMore).toBe(true);
 
     const thirdPage = await fetchDriveRecentsPage({
-      prefix: "drive/users/u/",
+      prefix: PREFIX,
       token: "test-token",
       limit: 1,
       cursor: secondPage.nextCursor ?? undefined,
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
       fetchTaskOutputs,
+      fetchTaskOutputsByIds: fetchTaskOutputsByIds([]),
     });
 
     expect(thirdPage.items).toHaveLength(1);
     expect(thirdPage.items[0]?.name).toBe("c-old.pdf");
     expect(thirdPage.hasMore).toBe(false);
+  });
+
+  it("continues scanning blob pages when the newest match appears on page three", async () => {
+    let drivePage = 0;
+    listMock.mockImplementation(async () => {
+      drivePage += 1;
+      if (drivePage === 1) {
+        return {
+          blobs: [
+            {
+              url: "https://blob.example/aaa-old.pdf",
+              pathname: "drive/users/u/aaa-old.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-18T12:00:00.000Z"),
+            },
+            {
+              url: "https://blob.example/aab-old.pdf",
+              pathname: "drive/users/u/aab-old.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-19T12:00:00.000Z"),
+            },
+          ],
+          hasMore: true,
+          cursor: "blob-page-2",
+        };
+      }
+      if (drivePage === 2) {
+        return {
+          blobs: [
+            {
+              url: "https://blob.example/aac-mid.pdf",
+              pathname: "drive/users/u/aac-mid.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-20T12:00:00.000Z"),
+            },
+          ],
+          hasMore: true,
+          cursor: "blob-page-3",
+        };
+      }
+
+      return {
+        blobs: [
+          {
+            url: "https://blob.example/zzz-newest.pdf",
+            pathname: "drive/users/u/zzz-newest.pdf",
+            size: 100,
+            uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+          },
+        ],
+        hasMore: false,
+      };
+    });
+
+    const fetchTaskOutputs = vi.fn(async () => ({
+      rows: [],
+      hasMore: false,
+      nextCursor: null,
+    }));
+
+    const page = await fetchDriveRecentsPage({
+      prefix: PREFIX,
+      token: "test-token",
+      limit: 2,
+      searchQuery: "pdf",
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: { prefix: PREFIX, searchQuery: "pdf" },
+      fetchTaskOutputs,
+      fetchTaskOutputsByIds: fetchTaskOutputsByIds([]),
+    });
+
+    expect(page.items.map((item) => item.name)).toEqual([
+      "zzz-newest.pdf",
+      "aac-mid.pdf",
+    ]);
+    expect(drivePage).toBe(3);
   });
 });
 

--- a/apps/core/src/helpers/drive-recents.test.ts
+++ b/apps/core/src/helpers/drive-recents.test.ts
@@ -98,6 +98,26 @@ describe("drive recents cursor", () => {
     expect(decoded.lastItem?.activityAt).toBe(item.activityAt);
     expect(decoded.driveBlobCursor).toBe("blob-cursor");
     expect(decoded.taskFileCursor).toBe("task-cursor");
+    expect(decoded.pendingItems).toEqual([]);
+  });
+
+  it("round-trips pending items in cursor payload", () => {
+    const item = driveFile(
+      "drive/users/u/report.pdf",
+      "2026-08-20T10:00:00.000Z",
+    );
+    const pending = [
+      driveFile("drive/users/u/older.pdf", "2026-08-19T10:00:00.000Z"),
+    ];
+    const encoded = encodeDriveRecentsCursor({
+      lastItem: item,
+      driveBlobCursor: "blob-cursor",
+      taskFileCursor: null,
+      pendingItems: pending,
+    });
+
+    const decoded = decodeDriveRecentsCursor(encoded);
+    expect(decoded.pendingItems).toEqual(pending);
   });
 
   it("detects items older than cursor position", () => {
@@ -235,6 +255,95 @@ describe("fetchDriveRecentsPage", () => {
     expect(page.items).toHaveLength(1);
     expect(page.items[0]?.kind).toBe("drive-file");
     expect(page.items[0]?.name).toBe("report.pdf");
+  });
+
+  it("preserves buffered eligible items across paginated pages", async () => {
+    let drivePage = 0;
+    listMock.mockImplementation(async () => {
+      drivePage += 1;
+      if (drivePage === 1) {
+        return {
+          blobs: [
+            {
+              url: "https://blob.example/c-old.pdf",
+              pathname: "drive/users/u/c-old.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-18T12:00:00.000Z"),
+            },
+          ],
+          hasMore: true,
+          cursor: "blob-page-2",
+        };
+      }
+      if (drivePage === 2) {
+        return {
+          blobs: [
+            {
+              url: "https://blob.example/b-mid.pdf",
+              pathname: "drive/users/u/b-mid.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-20T12:00:00.000Z"),
+            },
+          ],
+          hasMore: true,
+          cursor: "blob-page-3",
+        };
+      }
+
+      return {
+        blobs: [
+          {
+            url: "https://blob.example/a-new.pdf",
+            pathname: "drive/users/u/a-new.pdf",
+            size: 100,
+            uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+          },
+        ],
+        hasMore: false,
+      };
+    });
+
+    const fetchTaskOutputs = vi.fn(async () => ({
+      rows: [],
+      hasMore: false,
+      nextCursor: null,
+    }));
+
+    const firstPage = await fetchDriveRecentsPage({
+      prefix: "drive/users/u/",
+      token: "test-token",
+      limit: 1,
+      fetchTaskOutputs,
+    });
+
+    expect(firstPage.items).toHaveLength(1);
+    expect(firstPage.items[0]?.name).toBe("a-new.pdf");
+    expect(firstPage.hasMore).toBe(true);
+    expect(firstPage.nextCursor).toBeTruthy();
+
+    const secondPage = await fetchDriveRecentsPage({
+      prefix: "drive/users/u/",
+      token: "test-token",
+      limit: 1,
+      cursor: firstPage.nextCursor ?? undefined,
+      fetchTaskOutputs,
+    });
+
+    expect(secondPage.items).toHaveLength(1);
+    expect(secondPage.items[0]?.name).toBe("b-mid.pdf");
+    expect(secondPage.hasMore).toBe(true);
+
+    const thirdPage = await fetchDriveRecentsPage({
+      prefix: "drive/users/u/",
+      token: "test-token",
+      limit: 1,
+      cursor: secondPage.nextCursor ?? undefined,
+      fetchTaskOutputs,
+    });
+
+    expect(thirdPage.items).toHaveLength(1);
+    expect(thirdPage.items[0]?.name).toBe("c-old.pdf");
+    expect(thirdPage.hasMore).toBe(false);
   });
 });
 

--- a/apps/core/src/helpers/drive-recents.test.ts
+++ b/apps/core/src/helpers/drive-recents.test.ts
@@ -468,6 +468,75 @@ describe("fetchDriveRecentsPage", () => {
     expect(thirdPage.hasMore).toBe(false);
   });
 
+  it("does not fail page two when head omits blob size for a pending ref", async () => {
+    let drivePage = 0;
+    listMock.mockImplementation(async () => {
+      drivePage += 1;
+      if (drivePage === 1) {
+        return {
+          blobs: [
+            {
+              url: "https://blob.example/c-old.pdf",
+              pathname: "drive/users/u/c-old.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-18T12:00:00.000Z"),
+            },
+          ],
+          hasMore: true,
+          cursor: "blob-page-2",
+        };
+      }
+
+      return {
+        blobs: [
+          {
+            url: "https://blob.example/a-new.pdf",
+            pathname: "drive/users/u/a-new.pdf",
+            size: 100,
+            uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+          },
+        ],
+        hasMore: false,
+      };
+    });
+
+    headMock.mockImplementation(async (pathname: string) => ({
+      url: `https://blob.example/${pathname}`,
+      pathname,
+      uploadedAt: new Date("2026-08-18T12:00:00.000Z"),
+    }));
+
+    const fetchTaskOutputs = vi.fn(async () => ({
+      rows: [],
+      hasMore: false,
+      nextCursor: null,
+    }));
+
+    const firstPage = await fetchDriveRecentsPage({
+      prefix: PREFIX,
+      token: "test-token",
+      limit: 1,
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
+      fetchTaskOutputs,
+      fetchTaskOutputsByIds: fetchTaskOutputsByIds([]),
+    });
+
+    const secondPage = await fetchDriveRecentsPage({
+      prefix: PREFIX,
+      token: "test-token",
+      limit: 1,
+      cursor: firstPage.nextCursor ?? undefined,
+      cursorSecret: CURSOR_SECRET,
+      cursorBinding: CURSOR_BINDING,
+      fetchTaskOutputs,
+      fetchTaskOutputsByIds: fetchTaskOutputsByIds([]),
+    });
+
+    expect(secondPage.items).toHaveLength(1);
+    expect(secondPage.items[0]?.name).toBe("c-old.pdf");
+  });
+
   it("continues scanning blob pages when the newest match appears on page three", async () => {
     let drivePage = 0;
     listMock.mockImplementation(async () => {

--- a/apps/core/src/helpers/drive-recents.ts
+++ b/apps/core/src/helpers/drive-recents.ts
@@ -1,11 +1,23 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { z } from "@hono/zod-openapi";
 import { isDriveFolderMarker } from "@sokosumi/utils";
 import type { ListBlobResult } from "@vercel/blob";
-import { list } from "@vercel/blob";
+import { head, list } from "@vercel/blob";
 import type { DriveTaskOutputRecentsRow } from "@/helpers/drive-task-output-catalog";
 import { badRequest } from "@/helpers/error";
 import type { DriveRecentsItem } from "@/schemas/drive-recents.schema";
+import { driveRecentsItemSchema } from "@/schemas/drive-recents.schema";
 
-const RECENTS_CURSOR_VERSION = 1;
+const RECENTS_CURSOR_VERSION = 2;
+const MAX_PENDING_REFS = 100;
+
+const driveRecentsItemRefSchema = z.object({
+  kind: z.enum(["drive-file", "task-output"]),
+  id: z.string().min(1),
+  activityAt: z.string().min(1),
+});
+
+type DriveRecentsItemRef = z.infer<typeof driveRecentsItemRefSchema>;
 
 interface RecentsCursorPayload {
   v: typeof RECENTS_CURSOR_VERSION;
@@ -14,14 +26,19 @@ interface RecentsCursorPayload {
   id: string;
   driveBlobCursor?: string | null;
   taskFileCursor?: string | null;
-  pendingItems?: DriveRecentsItem[];
+  pendingRefs?: DriveRecentsItemRef[];
+}
+
+export interface DriveRecentsCursorBinding {
+  prefix: string;
+  searchQuery: string;
 }
 
 export interface DriveRecentsPageState {
   lastItem: DriveRecentsItem | null;
   driveBlobCursor: string | null;
   taskFileCursor: string | null;
-  pendingItems: DriveRecentsItem[];
+  pendingRefs: DriveRecentsItemRef[];
 }
 
 export interface DriveRecentsPageResult {
@@ -37,6 +54,14 @@ function recentsItemId(item: DriveRecentsItem): string {
     return item.pathname;
   }
   return item.taskFileId;
+}
+
+function recentsItemRef(item: DriveRecentsItem): DriveRecentsItemRef {
+  return {
+    kind: item.kind,
+    id: recentsItemId(item),
+    activityAt: item.activityAt,
+  };
 }
 
 export function driveRecentsDriveFileNameMatchesSearch(
@@ -73,11 +98,96 @@ export function isRecentsItemOlderThanCursor(
   return compareDriveRecentsItems(item, cursorItem) > 0;
 }
 
+function signRecentsCursorEnvelope(
+  payload: RecentsCursorPayload,
+  secret: string,
+  binding: DriveRecentsCursorBinding,
+): string {
+  const payloadJson = JSON.stringify(payload);
+  const bindingJson = JSON.stringify(binding);
+  const signature = createHmac("sha256", secret)
+    .update(bindingJson)
+    .update("\0")
+    .update(payloadJson)
+    .digest("base64url");
+
+  return Buffer.from(
+    JSON.stringify({ payload: payloadJson, signature }),
+    "utf8",
+  ).toString("base64url");
+}
+
+function parseRecentsCursorPayload(raw: unknown): RecentsCursorPayload {
+  if (!raw || typeof raw !== "object") {
+    throw badRequest("Invalid pagination cursor");
+  }
+
+  const payload = raw as Partial<RecentsCursorPayload> & {
+    pendingItems?: unknown;
+  };
+
+  if (payload.v !== RECENTS_CURSOR_VERSION) {
+    throw badRequest("Invalid pagination cursor");
+  }
+  if (!payload.activityAt || !payload.kind || !payload.id) {
+    throw badRequest("Invalid pagination cursor");
+  }
+  if ("pendingItems" in payload) {
+    throw badRequest("Invalid pagination cursor");
+  }
+
+  let pendingRefs: DriveRecentsItemRef[] | undefined;
+  if (payload.pendingRefs !== undefined) {
+    const parsed = z
+      .array(driveRecentsItemRefSchema)
+      .safeParse(payload.pendingRefs);
+    if (!parsed.success) {
+      throw badRequest("Invalid pagination cursor");
+    }
+    pendingRefs = parsed.data;
+  }
+
+  return {
+    v: RECENTS_CURSOR_VERSION,
+    activityAt: payload.activityAt,
+    kind: payload.kind,
+    id: payload.id,
+    driveBlobCursor: payload.driveBlobCursor ?? null,
+    taskFileCursor: payload.taskFileCursor ?? null,
+    ...(pendingRefs && pendingRefs.length > 0 ? { pendingRefs } : {}),
+  };
+}
+
+function verifyRecentsCursorSignature(
+  payloadJson: string,
+  signature: string,
+  secret: string,
+  binding: DriveRecentsCursorBinding,
+): void {
+  const bindingJson = JSON.stringify(binding);
+  const expected = createHmac("sha256", secret)
+    .update(bindingJson)
+    .update("\0")
+    .update(payloadJson)
+    .digest("base64url");
+
+  const signatureBuf = Buffer.from(signature);
+  const expectedBuf = Buffer.from(expected);
+  if (
+    signatureBuf.length !== expectedBuf.length ||
+    !timingSafeEqual(signatureBuf, expectedBuf)
+  ) {
+    throw badRequest("Invalid pagination cursor");
+  }
+}
+
 export function encodeDriveRecentsCursor(input: {
   lastItem: DriveRecentsItem;
   driveBlobCursor: string | null;
   taskFileCursor: string | null;
-  pendingItems?: DriveRecentsItem[];
+  pendingRefs?: DriveRecentsItemRef[];
+  cursorSecret: string;
+  cursorBinding: DriveRecentsCursorBinding;
 }): string {
   const payload: RecentsCursorPayload = {
     v: RECENTS_CURSOR_VERSION,
@@ -86,54 +196,143 @@ export function encodeDriveRecentsCursor(input: {
     id: recentsItemId(input.lastItem),
     driveBlobCursor: input.driveBlobCursor,
     taskFileCursor: input.taskFileCursor,
-    ...(input.pendingItems && input.pendingItems.length > 0
-      ? { pendingItems: input.pendingItems }
+    ...(input.pendingRefs && input.pendingRefs.length > 0
+      ? { pendingRefs: input.pendingRefs }
       : {}),
   };
-  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+
+  return signRecentsCursorEnvelope(
+    payload,
+    input.cursorSecret,
+    input.cursorBinding,
+  );
+}
+
+function lastItemFromCursorPayload(
+  payload: RecentsCursorPayload,
+): DriveRecentsItem {
+  return payload.kind === "drive-file"
+    ? {
+        kind: "drive-file",
+        name: "",
+        fileUrl: "https://example.com/placeholder",
+        pathname: payload.id,
+        size: 0,
+        activityAt: payload.activityAt,
+      }
+    : {
+        kind: "task-output",
+        name: "",
+        fileUrl: "https://example.com/placeholder",
+        size: null,
+        activityAt: payload.activityAt,
+        taskFileId: payload.id,
+        taskId: "",
+        taskName: "",
+        projectId: null,
+        projectName: null,
+      };
+}
+
+export async function hydrateDriveRecentsPendingRefs(input: {
+  refs: DriveRecentsItemRef[];
+  prefix: string;
+  token: string;
+  fetchTaskOutputsByIds: (
+    ids: string[],
+  ) => Promise<DriveTaskOutputRecentsRow[]>;
+}): Promise<DriveRecentsItem[]> {
+  const hydrated: DriveRecentsItem[] = [];
+
+  const taskOutputIds = input.refs
+    .filter((ref) => ref.kind === "task-output")
+    .map((ref) => ref.id);
+  const taskRows =
+    taskOutputIds.length > 0
+      ? await input.fetchTaskOutputsByIds(taskOutputIds)
+      : [];
+  const taskRowById = new Map(taskRows.map((row) => [row.id, row]));
+
+  for (const ref of input.refs) {
+    if (ref.kind === "drive-file") {
+      if (!ref.id.startsWith(input.prefix)) {
+        continue;
+      }
+
+      try {
+        const blob = await head(ref.id, { token: input.token });
+        if (isDriveFolderMarker(blob.pathname)) {
+          continue;
+        }
+        const segments = blob.pathname
+          .split("/")
+          .filter((segment) => segment.length > 0);
+        const name = segments[segments.length - 1];
+        if (!name) {
+          continue;
+        }
+        const item: DriveRecentsItem = {
+          kind: "drive-file",
+          name,
+          fileUrl: blob.url,
+          pathname: blob.pathname,
+          size: blob.size,
+          activityAt: blob.uploadedAt.toISOString(),
+        };
+        if (item.activityAt === ref.activityAt) {
+          hydrated.push(item);
+        }
+      } catch {
+        continue;
+      }
+      continue;
+    }
+
+    const row = taskRowById.get(ref.id);
+    if (!row) {
+      continue;
+    }
+    const item = mapTaskOutputRowToRecentsItem(row);
+    if (item.activityAt === ref.activityAt) {
+      hydrated.push(item);
+    }
+  }
+
+  return hydrated;
 }
 
 export function decodeDriveRecentsCursor(
   cursor: string,
+  input: {
+    cursorSecret: string;
+    cursorBinding: DriveRecentsCursorBinding;
+  },
 ): DriveRecentsPageState {
   try {
     const decoded = Buffer.from(cursor, "base64url").toString("utf8");
-    const payload = JSON.parse(decoded) as RecentsCursorPayload;
-    if (payload.v !== RECENTS_CURSOR_VERSION) {
-      throw badRequest("Invalid pagination cursor");
-    }
-    if (!payload.activityAt || !payload.kind || !payload.id) {
+    const envelope = JSON.parse(decoded) as {
+      payload?: string;
+      signature?: string;
+    };
+
+    if (!envelope.payload || !envelope.signature) {
       throw badRequest("Invalid pagination cursor");
     }
 
-    const lastItem: DriveRecentsItem =
-      payload.kind === "drive-file"
-        ? {
-            kind: "drive-file",
-            name: "",
-            fileUrl: "https://example.com/placeholder",
-            pathname: payload.id,
-            size: 0,
-            activityAt: payload.activityAt,
-          }
-        : {
-            kind: "task-output",
-            name: "",
-            fileUrl: "https://example.com/placeholder",
-            size: null,
-            activityAt: payload.activityAt,
-            taskFileId: payload.id,
-            taskId: "",
-            taskName: "",
-            projectId: null,
-            projectName: null,
-          };
+    verifyRecentsCursorSignature(
+      envelope.payload,
+      envelope.signature,
+      input.cursorSecret,
+      input.cursorBinding,
+    );
+
+    const payload = parseRecentsCursorPayload(JSON.parse(envelope.payload));
 
     return {
-      lastItem,
+      lastItem: lastItemFromCursorPayload(payload),
       driveBlobCursor: payload.driveBlobCursor ?? null,
       taskFileCursor: payload.taskFileCursor ?? null,
-      pendingItems: payload.pendingItems ?? [],
+      pendingRefs: payload.pendingRefs ?? [],
     };
   } catch (error) {
     if (
@@ -226,21 +425,53 @@ export async function fetchDriveRecentsPage(input: {
   limit: number;
   cursor?: string;
   searchQuery?: string;
+  cursorSecret: string;
+  cursorBinding: DriveRecentsCursorBinding;
   fetchTaskOutputs: (options: { cursor?: string; take: number }) => Promise<{
     rows: DriveTaskOutputRecentsRow[];
     hasMore: boolean;
     nextCursor: string | null;
   }>;
+  fetchTaskOutputsByIds: (
+    ids: string[],
+  ) => Promise<DriveTaskOutputRecentsRow[]>;
 }): Promise<DriveRecentsPageResult> {
   const searchQuery = input.searchQuery?.trim() ?? "";
-  const pageState = input.cursor
-    ? decodeDriveRecentsCursor(input.cursor)
-    : {
-        lastItem: null,
-        driveBlobCursor: null,
-        taskFileCursor: null,
-        pendingItems: [],
-      };
+  const cursorBinding: DriveRecentsCursorBinding = {
+    prefix: input.cursorBinding.prefix,
+    searchQuery,
+  };
+
+  let pageState: DriveRecentsPageState = {
+    lastItem: null,
+    driveBlobCursor: null,
+    taskFileCursor: null,
+    pendingRefs: [],
+  };
+
+  if (input.cursor) {
+    pageState = decodeDriveRecentsCursor(input.cursor, {
+      cursorSecret: input.cursorSecret,
+      cursorBinding,
+    });
+  }
+
+  const hydratedPending =
+    pageState.pendingRefs.length > 0
+      ? await hydrateDriveRecentsPendingRefs({
+          refs: pageState.pendingRefs,
+          prefix: input.prefix,
+          token: input.token,
+          fetchTaskOutputsByIds: input.fetchTaskOutputsByIds,
+        })
+      : [];
+
+  for (const item of hydratedPending) {
+    const parsed = driveRecentsItemSchema.safeParse(item);
+    if (!parsed.success) {
+      throw badRequest("Invalid pagination cursor");
+    }
+  }
 
   const batchSize = Math.max(input.limit * 4, 20);
   const pool: DriveRecentsItem[] = [];
@@ -278,13 +509,13 @@ export async function fetchDriveRecentsPage(input: {
     }
   }
 
-  addItemsToPool(pageState.pendingItems);
+  addItemsToPool(hydratedPending);
 
-  function collectPendingItems(
+  function collectPendingRefs(
     returnedItems: DriveRecentsItem[],
-  ): DriveRecentsItem[] {
+  ): DriveRecentsItemRef[] {
     const returnedIds = new Set(returnedItems.map(recentsItemId));
-    const pending: DriveRecentsItem[] = [];
+    const pendingItems: DriveRecentsItem[] = [];
     for (const item of pool) {
       if (!shouldIncludeItem(item)) {
         continue;
@@ -292,38 +523,11 @@ export async function fetchDriveRecentsPage(input: {
       if (returnedIds.has(recentsItemId(item))) {
         continue;
       }
-      pending.push(item);
+      pendingItems.push(item);
     }
-    pending.sort(compareDriveRecentsItems);
-    return pending;
+    pendingItems.sort(compareDriveRecentsItems);
+    return pendingItems.map(recentsItemRef);
   }
-
-  function getTopEligiblePreview(): {
-    signature: string | null;
-    count: number;
-  } {
-    const topEligible: DriveRecentsItem[] = [];
-    for (const item of pool) {
-      if (!shouldIncludeItem(item)) {
-        continue;
-      }
-      topEligible.push(item);
-      if (topEligible.length >= input.limit + 1) {
-        break;
-      }
-    }
-
-    if (topEligible.length === 0) {
-      return { signature: null, count: 0 };
-    }
-
-    return {
-      signature: topEligible.map(recentsItemId).join("\0"),
-      count: topEligible.length,
-    };
-  }
-
-  let previousTopSignature: string | null = null;
 
   while (driveHasMore || taskHasMore) {
     type DriveBlobRecentsBatch = Awaited<
@@ -370,22 +574,14 @@ export async function fetchDriveRecentsPage(input: {
     addItemsToPool(taskBatch.rows.map(mapTaskOutputRowToRecentsItem));
 
     pool.sort(compareDriveRecentsItems);
-    const { signature: topSignature, count: topEligibleCount } =
-      getTopEligiblePreview();
 
+    const eligibleCount = pool.filter((item) => shouldIncludeItem(item)).length;
     if (!driveHasMore && !taskHasMore) {
       break;
     }
-
-    if (
-      topSignature !== null &&
-      topSignature === previousTopSignature &&
-      topEligibleCount >= input.limit + 1
-    ) {
+    if (!driveHasMore && eligibleCount >= input.limit + 1) {
       break;
     }
-
-    previousTopSignature = topSignature;
   }
 
   pool.sort(compareDriveRecentsItems);
@@ -404,7 +600,9 @@ export async function fetchDriveRecentsPage(input: {
   const hasMore = merged.length > input.limit;
   const items = merged.slice(0, input.limit);
   const lastItem = items[items.length - 1] ?? null;
-  const pendingItems = hasMore ? collectPendingItems(items) : [];
+  const pendingRefs = hasMore
+    ? collectPendingRefs(items).slice(0, MAX_PENDING_REFS)
+    : [];
 
   return {
     items,
@@ -415,7 +613,9 @@ export async function fetchDriveRecentsPage(input: {
             lastItem,
             driveBlobCursor,
             taskFileCursor,
-            pendingItems,
+            pendingRefs,
+            cursorSecret: input.cursorSecret,
+            cursorBinding,
           })
         : null,
     driveBlobCursor,

--- a/apps/core/src/helpers/drive-recents.ts
+++ b/apps/core/src/helpers/drive-recents.ts
@@ -37,6 +37,17 @@ function recentsItemId(item: DriveRecentsItem): string {
   return item.taskFileId;
 }
 
+export function driveRecentsDriveFileNameMatchesSearch(
+  name: string,
+  searchQuery: string,
+): boolean {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+  return name.toLowerCase().includes(normalizedQuery);
+}
+
 export function compareDriveRecentsItems(
   left: DriveRecentsItem,
   right: DriveRecentsItem,
@@ -207,12 +218,14 @@ export async function fetchDriveRecentsPage(input: {
   token: string;
   limit: number;
   cursor?: string;
+  searchQuery?: string;
   fetchTaskOutputs: (options: { cursor?: string; take: number }) => Promise<{
     rows: DriveTaskOutputRecentsRow[];
     hasMore: boolean;
     nextCursor: string | null;
   }>;
 }): Promise<DriveRecentsPageResult> {
+  const searchQuery = input.searchQuery?.trim() ?? "";
   const pageState = input.cursor
     ? decodeDriveRecentsCursor(input.cursor)
     : {
@@ -279,6 +292,13 @@ export async function fetchDriveRecentsPage(input: {
       if (
         pageState.lastItem &&
         !isRecentsItemOlderThanCursor(item, pageState.lastItem)
+      ) {
+        continue;
+      }
+      if (
+        searchQuery &&
+        item.kind === "drive-file" &&
+        !driveRecentsDriveFileNameMatchesSearch(item.name, searchQuery)
       ) {
         continue;
       }

--- a/apps/core/src/helpers/drive-recents.ts
+++ b/apps/core/src/helpers/drive-recents.ts
@@ -235,13 +235,69 @@ export async function fetchDriveRecentsPage(input: {
       };
 
   const batchSize = Math.max(input.limit * 4, 20);
-  const merged: DriveRecentsItem[] = [];
+  const pool: DriveRecentsItem[] = [];
+  const poolItemIds = new Set<string>();
   let driveBlobCursor = pageState.driveBlobCursor;
   let taskFileCursor = pageState.taskFileCursor;
   let driveHasMore = true;
   let taskHasMore = true;
 
-  while (merged.length < input.limit + 1 && (driveHasMore || taskHasMore)) {
+  function shouldIncludeItem(item: DriveRecentsItem): boolean {
+    if (
+      pageState.lastItem &&
+      !isRecentsItemOlderThanCursor(item, pageState.lastItem)
+    ) {
+      return false;
+    }
+    if (
+      searchQuery &&
+      item.kind === "drive-file" &&
+      !driveRecentsDriveFileNameMatchesSearch(item.name, searchQuery)
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  function addItemsToPool(items: DriveRecentsItem[]): void {
+    for (const item of items) {
+      const itemId = recentsItemId(item);
+      if (poolItemIds.has(itemId)) {
+        continue;
+      }
+      poolItemIds.add(itemId);
+      pool.push(item);
+    }
+  }
+
+  function getTopEligiblePreview(): {
+    signature: string | null;
+    count: number;
+  } {
+    const topEligible: DriveRecentsItem[] = [];
+    for (const item of pool) {
+      if (!shouldIncludeItem(item)) {
+        continue;
+      }
+      topEligible.push(item);
+      if (topEligible.length >= input.limit + 1) {
+        break;
+      }
+    }
+
+    if (topEligible.length === 0) {
+      return { signature: null, count: 0 };
+    }
+
+    return {
+      signature: topEligible.map(recentsItemId).join("\0"),
+      count: topEligible.length,
+    };
+  }
+
+  let previousTopSignature: string | null = null;
+
+  while (driveHasMore || taskHasMore) {
     type DriveBlobRecentsBatch = Awaited<
       ReturnType<typeof fetchDriveBlobRecentsBatch>
     >;
@@ -282,40 +338,37 @@ export async function fetchDriveRecentsPage(input: {
     driveBlobCursor = driveBatch.nextCursor;
     taskFileCursor = taskBatch.nextCursor;
 
-    const candidates = [
-      ...driveBatch.items,
-      ...taskBatch.rows.map(mapTaskOutputRowToRecentsItem),
-    ];
-    candidates.sort(compareDriveRecentsItems);
+    addItemsToPool(driveBatch.items);
+    addItemsToPool(taskBatch.rows.map(mapTaskOutputRowToRecentsItem));
 
-    for (const item of candidates) {
-      if (
-        pageState.lastItem &&
-        !isRecentsItemOlderThanCursor(item, pageState.lastItem)
-      ) {
-        continue;
-      }
-      if (
-        searchQuery &&
-        item.kind === "drive-file" &&
-        !driveRecentsDriveFileNameMatchesSearch(item.name, searchQuery)
-      ) {
-        continue;
-      }
-      if (
-        merged.some(
-          (existing) => recentsItemId(existing) === recentsItemId(item),
-        )
-      ) {
-        continue;
-      }
-      merged.push(item);
-      if (merged.length >= input.limit + 1) {
-        break;
-      }
-    }
+    pool.sort(compareDriveRecentsItems);
+    const { signature: topSignature, count: topEligibleCount } =
+      getTopEligiblePreview();
 
     if (!driveHasMore && !taskHasMore) {
+      break;
+    }
+
+    if (
+      topSignature !== null &&
+      topSignature === previousTopSignature &&
+      topEligibleCount >= input.limit + 1
+    ) {
+      break;
+    }
+
+    previousTopSignature = topSignature;
+  }
+
+  pool.sort(compareDriveRecentsItems);
+
+  const merged: DriveRecentsItem[] = [];
+  for (const item of pool) {
+    if (!shouldIncludeItem(item)) {
+      continue;
+    }
+    merged.push(item);
+    if (merged.length >= input.limit + 1) {
       break;
     }
   }

--- a/apps/core/src/helpers/drive-recents.ts
+++ b/apps/core/src/helpers/drive-recents.ts
@@ -14,12 +14,14 @@ interface RecentsCursorPayload {
   id: string;
   driveBlobCursor?: string | null;
   taskFileCursor?: string | null;
+  pendingItems?: DriveRecentsItem[];
 }
 
 export interface DriveRecentsPageState {
   lastItem: DriveRecentsItem | null;
   driveBlobCursor: string | null;
   taskFileCursor: string | null;
+  pendingItems: DriveRecentsItem[];
 }
 
 export interface DriveRecentsPageResult {
@@ -75,6 +77,7 @@ export function encodeDriveRecentsCursor(input: {
   lastItem: DriveRecentsItem;
   driveBlobCursor: string | null;
   taskFileCursor: string | null;
+  pendingItems?: DriveRecentsItem[];
 }): string {
   const payload: RecentsCursorPayload = {
     v: RECENTS_CURSOR_VERSION,
@@ -83,6 +86,9 @@ export function encodeDriveRecentsCursor(input: {
     id: recentsItemId(input.lastItem),
     driveBlobCursor: input.driveBlobCursor,
     taskFileCursor: input.taskFileCursor,
+    ...(input.pendingItems && input.pendingItems.length > 0
+      ? { pendingItems: input.pendingItems }
+      : {}),
   };
   return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
 }
@@ -127,6 +133,7 @@ export function decodeDriveRecentsCursor(
       lastItem,
       driveBlobCursor: payload.driveBlobCursor ?? null,
       taskFileCursor: payload.taskFileCursor ?? null,
+      pendingItems: payload.pendingItems ?? [],
     };
   } catch (error) {
     if (
@@ -232,6 +239,7 @@ export async function fetchDriveRecentsPage(input: {
         lastItem: null,
         driveBlobCursor: null,
         taskFileCursor: null,
+        pendingItems: [],
       };
 
   const batchSize = Math.max(input.limit * 4, 20);
@@ -268,6 +276,26 @@ export async function fetchDriveRecentsPage(input: {
       poolItemIds.add(itemId);
       pool.push(item);
     }
+  }
+
+  addItemsToPool(pageState.pendingItems);
+
+  function collectPendingItems(
+    returnedItems: DriveRecentsItem[],
+  ): DriveRecentsItem[] {
+    const returnedIds = new Set(returnedItems.map(recentsItemId));
+    const pending: DriveRecentsItem[] = [];
+    for (const item of pool) {
+      if (!shouldIncludeItem(item)) {
+        continue;
+      }
+      if (returnedIds.has(recentsItemId(item))) {
+        continue;
+      }
+      pending.push(item);
+    }
+    pending.sort(compareDriveRecentsItems);
+    return pending;
   }
 
   function getTopEligiblePreview(): {
@@ -376,6 +404,7 @@ export async function fetchDriveRecentsPage(input: {
   const hasMore = merged.length > input.limit;
   const items = merged.slice(0, input.limit);
   const lastItem = items[items.length - 1] ?? null;
+  const pendingItems = hasMore ? collectPendingItems(items) : [];
 
   return {
     items,
@@ -386,6 +415,7 @@ export async function fetchDriveRecentsPage(input: {
             lastItem,
             driveBlobCursor,
             taskFileCursor,
+            pendingItems,
           })
         : null,
     driveBlobCursor,

--- a/apps/core/src/helpers/drive-recents.ts
+++ b/apps/core/src/helpers/drive-recents.ts
@@ -60,8 +60,12 @@ function recentsItemRef(item: DriveRecentsItem): DriveRecentsItemRef {
   return {
     kind: item.kind,
     id: recentsItemId(item),
-    activityAt: item.activityAt,
+    activityAt: normalizeRecentsActivityAt(item.activityAt),
   };
+}
+
+function normalizeRecentsActivityAt(activityAt: string | Date): string {
+  return typeof activityAt === "string" ? activityAt : activityAt.toISOString();
 }
 
 export function driveRecentsDriveFileNameMatchesSearch(
@@ -191,7 +195,7 @@ export function encodeDriveRecentsCursor(input: {
 }): string {
   const payload: RecentsCursorPayload = {
     v: RECENTS_CURSOR_VERSION,
-    activityAt: input.lastItem.activityAt,
+    activityAt: normalizeRecentsActivityAt(input.lastItem.activityAt),
     kind: input.lastItem.kind,
     id: recentsItemId(input.lastItem),
     driveBlobCursor: input.driveBlobCursor,
@@ -264,6 +268,9 @@ export async function hydrateDriveRecentsPendingRefs(input: {
         if (isDriveFolderMarker(blob.pathname)) {
           continue;
         }
+        if (!blob.uploadedAt) {
+          continue;
+        }
         const segments = blob.pathname
           .split("/")
           .filter((segment) => segment.length > 0);
@@ -271,17 +278,19 @@ export async function hydrateDriveRecentsPendingRefs(input: {
         if (!name) {
           continue;
         }
+        const activityAt = ref.activityAt;
         const item: DriveRecentsItem = {
           kind: "drive-file",
           name,
           fileUrl: blob.url,
           pathname: blob.pathname,
-          size: blob.size,
-          activityAt: blob.uploadedAt.toISOString(),
+          size:
+            typeof blob.size === "number" && Number.isFinite(blob.size)
+              ? blob.size
+              : 0,
+          activityAt,
         };
-        if (item.activityAt === ref.activityAt) {
-          hydrated.push(item);
-        }
+        hydrated.push(item);
       } catch {
         continue;
       }
@@ -293,7 +302,7 @@ export async function hydrateDriveRecentsPendingRefs(input: {
       continue;
     }
     const item = mapTaskOutputRowToRecentsItem(row);
-    if (item.activityAt === ref.activityAt) {
+    if (normalizeRecentsActivityAt(item.activityAt) === ref.activityAt) {
       hydrated.push(item);
     }
   }
@@ -466,10 +475,11 @@ export async function fetchDriveRecentsPage(input: {
         })
       : [];
 
+  const validatedPending: DriveRecentsItem[] = [];
   for (const item of hydratedPending) {
     const parsed = driveRecentsItemSchema.safeParse(item);
-    if (!parsed.success) {
-      throw badRequest("Invalid pagination cursor");
+    if (parsed.success) {
+      validatedPending.push(parsed.data);
     }
   }
 
@@ -509,7 +519,7 @@ export async function fetchDriveRecentsPage(input: {
     }
   }
 
-  addItemsToPool(hydratedPending);
+  addItemsToPool(validatedPending);
 
   function collectPendingRefs(
     returnedItems: DriveRecentsItem[],

--- a/apps/core/src/helpers/drive-task-output-catalog.test.ts
+++ b/apps/core/src/helpers/drive-task-output-catalog.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaTaskFileFindFirstMock = vi.hoisted(() => vi.fn());
+const prismaTaskFileFindManyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    taskFile: {
+      findFirst: prismaTaskFileFindFirstMock,
+      findMany: prismaTaskFileFindManyMock,
+    },
+  },
+}));
+
+import { fetchDriveTaskOutputRecentsBatch } from "@/helpers/drive-task-output-catalog";
+
+describe("fetchDriveTaskOutputRecentsBatch", () => {
+  beforeEach(() => {
+    prismaTaskFileFindFirstMock.mockReset();
+    prismaTaskFileFindManyMock.mockReset();
+  });
+
+  it("restarts from the beginning when the task cursor is stale", async () => {
+    prismaTaskFileFindFirstMock.mockResolvedValue(null);
+    prismaTaskFileFindManyMock.mockResolvedValue([
+      {
+        id: "tf-1",
+        name: "output.pdf",
+        fileUrl: "https://example.com/output.pdf",
+        size: BigInt(100),
+        updatedAt: new Date("2026-08-21T12:00:00.000Z"),
+        task: {
+          id: "task-1",
+          name: "Task",
+          projectId: null,
+          project: null,
+        },
+      },
+    ]);
+
+    const page = await fetchDriveTaskOutputRecentsBatch({
+      baseTaskWhere: { workspaceId: "ws_1" },
+      cursor: "deleted-task-file",
+      take: 10,
+    });
+
+    expect(prismaTaskFileFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursor: undefined,
+        skip: undefined,
+      }),
+    );
+    expect(page.rows).toHaveLength(1);
+    expect(page.rows[0]?.id).toBe("tf-1");
+    expect(page.hasMore).toBe(false);
+  });
+});

--- a/apps/core/src/helpers/drive-task-output-catalog.ts
+++ b/apps/core/src/helpers/drive-task-output-catalog.ts
@@ -145,3 +145,59 @@ export async function fetchDriveTaskOutputRecentsBatch(input: {
       : null,
   };
 }
+
+export async function fetchDriveTaskOutputRecentsByIds(input: {
+  ids: string[];
+  baseTaskWhere: Prisma.TaskWhereInput;
+  searchQuery?: string;
+}): Promise<DriveTaskOutputRecentsRow[]> {
+  if (input.ids.length === 0) {
+    return [];
+  }
+
+  const taskFileWhere = buildDriveTaskOutputRecentsWhere({
+    baseTaskWhere: input.baseTaskWhere,
+    searchQuery: input.searchQuery,
+  });
+
+  const matchingFiles = await prisma.taskFile.findMany({
+    where: {
+      id: { in: input.ids },
+      ...taskFileWhere,
+    },
+    include: {
+      task: {
+        select: {
+          id: true,
+          name: true,
+          projectId: true,
+          project: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const rows: DriveTaskOutputRecentsRow[] = [];
+  for (const file of matchingFiles) {
+    if (!file.fileUrl) {
+      continue;
+    }
+    rows.push({
+      id: file.id,
+      name: file.name,
+      fileUrl: file.fileUrl,
+      size: file.size ? Number(file.size) : null,
+      updatedAt: file.updatedAt,
+      taskId: file.task.id,
+      taskName: file.task.name,
+      projectId: file.task.projectId,
+      projectName: file.task.project?.name ?? null,
+    });
+  }
+
+  return rows;
+}

--- a/apps/core/src/helpers/drive-task-output-catalog.ts
+++ b/apps/core/src/helpers/drive-task-output-catalog.ts
@@ -80,6 +80,7 @@ export async function fetchDriveTaskOutputRecentsBatch(input: {
     searchQuery,
   });
 
+  let effectiveCursor = cursor;
   if (cursor) {
     const cursorFile = await prisma.taskFile.findFirst({
       where: {
@@ -89,7 +90,7 @@ export async function fetchDriveTaskOutputRecentsBatch(input: {
       select: { id: true },
     });
     if (!cursorFile) {
-      return { rows: [], hasMore: false, nextCursor: null };
+      effectiveCursor = undefined;
     }
   }
 
@@ -97,8 +98,8 @@ export async function fetchDriveTaskOutputRecentsBatch(input: {
     where: taskFileWhere,
     orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
     take: takePlusOne,
-    skip: cursor ? 1 : undefined,
-    cursor: cursor ? { id: cursor } : undefined,
+    skip: effectiveCursor ? 1 : undefined,
+    cursor: effectiveCursor ? { id: effectiveCursor } : undefined,
     include: {
       task: {
         select: {

--- a/apps/core/src/helpers/drive-task-output-catalog.ts
+++ b/apps/core/src/helpers/drive-task-output-catalog.ts
@@ -20,22 +20,65 @@ export interface DriveTaskOutputRecentsRow {
   projectName: string | null;
 }
 
+function buildDriveTaskOutputRecentsWhere(input: {
+  baseTaskWhere: Prisma.TaskWhereInput;
+  searchQuery?: string;
+}): Prisma.TaskFileWhereInput {
+  const { baseTaskWhere, searchQuery } = input;
+  const trimmedSearch = searchQuery?.trim();
+  if (!trimmedSearch) {
+    return {
+      ...DRIVE_TASK_FILE_WHERE,
+      task: baseTaskWhere,
+    };
+  }
+
+  return {
+    ...DRIVE_TASK_FILE_WHERE,
+    OR: [
+      {
+        name: { contains: trimmedSearch, mode: "insensitive" },
+        task: baseTaskWhere,
+      },
+      {
+        task: {
+          AND: [
+            baseTaskWhere,
+            {
+              OR: [
+                { name: { contains: trimmedSearch, mode: "insensitive" } },
+                {
+                  description: {
+                    contains: trimmedSearch,
+                    mode: "insensitive",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
 export async function fetchDriveTaskOutputRecentsBatch(input: {
   baseTaskWhere: Prisma.TaskWhereInput;
   cursor?: string;
   take: number;
+  searchQuery?: string;
 }): Promise<{
   rows: DriveTaskOutputRecentsRow[];
   hasMore: boolean;
   nextCursor: string | null;
 }> {
-  const { baseTaskWhere, cursor, take } = input;
+  const { baseTaskWhere, cursor, take, searchQuery } = input;
   const takePlusOne = take + 1;
 
-  const taskFileWhere: Prisma.TaskFileWhereInput = {
-    ...DRIVE_TASK_FILE_WHERE,
-    task: baseTaskWhere,
-  };
+  const taskFileWhere = buildDriveTaskOutputRecentsWhere({
+    baseTaskWhere,
+    searchQuery,
+  });
 
   if (cursor) {
     const cursorFile = await prisma.taskFile.findFirst({

--- a/apps/core/src/routes/v1/drive/recents/get.test.ts
+++ b/apps/core/src/routes/v1/drive/recents/get.test.ts
@@ -175,4 +175,50 @@ describe("GET /v1/drive/recents", () => {
     const response = await app.request("/?scope=org&limit=20");
     expect(response.status).toBe(400);
   });
+
+  it("filters drive files and task outputs when q is set", async () => {
+    listMock.mockResolvedValue({
+      blobs: [
+        {
+          url: "https://blob.example/report.pdf",
+          pathname: "drive/users/user_123/report.pdf",
+          size: 1000,
+          uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+        },
+        {
+          url: "https://blob.example/notes.pdf",
+          pathname: "drive/users/user_123/notes.pdf",
+          size: 500,
+          uploadedAt: new Date("2026-08-20T12:00:00.000Z"),
+        },
+      ],
+      hasMore: false,
+      cursor: undefined,
+    });
+    prismaTaskFileFindManyMock.mockResolvedValue([
+      {
+        id: "tf_mockup",
+        name: "output.pdf",
+        fileUrl: "https://blob.example/output.pdf",
+        size: BigInt(500),
+        updatedAt: new Date("2026-08-22T12:00:00.000Z"),
+        task: {
+          id: "task_1",
+          name: "Design mockup",
+          projectId: null,
+          project: null,
+        },
+      },
+    ]);
+
+    const app = createRecentsApp();
+    const response = await app.request("/?scope=me&limit=20&q=mockup");
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].kind).toBe("task-output");
+    expect(body.data[0].taskName).toBe("Design mockup");
+    expect(prismaTaskFileFindManyMock).toHaveBeenCalled();
+  });
 });

--- a/apps/core/src/routes/v1/drive/recents/get.test.ts
+++ b/apps/core/src/routes/v1/drive/recents/get.test.ts
@@ -221,4 +221,133 @@ describe("GET /v1/drive/recents", () => {
     expect(body.data[0].taskName).toBe("Design mockup");
     expect(prismaTaskFileFindManyMock).toHaveBeenCalled();
   });
+
+  it("filters drive files by filename when q is set", async () => {
+    listMock.mockResolvedValue({
+      blobs: [
+        {
+          url: "https://blob.example/report.pdf",
+          pathname: "drive/users/user_123/report.pdf",
+          size: 1000,
+          uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+        },
+        {
+          url: "https://blob.example/notes.pdf",
+          pathname: "drive/users/user_123/notes.pdf",
+          size: 500,
+          uploadedAt: new Date("2026-08-20T12:00:00.000Z"),
+        },
+      ],
+      hasMore: false,
+      cursor: undefined,
+    });
+    prismaTaskFileFindManyMock.mockResolvedValue([]);
+
+    const app = createRecentsApp();
+    const response = await app.request("/?scope=me&limit=20&q=report");
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].kind).toBe("drive-file");
+    expect(body.data[0].name).toBe("report.pdf");
+  });
+
+  it("paginates search results with cursor while keeping q applied", async () => {
+    listMock.mockResolvedValue({
+      blobs: [
+        {
+          url: "https://blob.example/report.pdf",
+          pathname: "drive/users/user_123/report.pdf",
+          size: 1000,
+          uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+        },
+        {
+          url: "https://blob.example/report-copy.pdf",
+          pathname: "drive/users/user_123/report-copy.pdf",
+          size: 500,
+          uploadedAt: new Date("2026-08-20T12:00:00.000Z"),
+        },
+      ],
+      hasMore: false,
+      cursor: undefined,
+    });
+    prismaTaskFileFindManyMock.mockResolvedValue([]);
+
+    const app = createRecentsApp();
+    const firstResponse = await app.request("/?scope=me&limit=1&q=report");
+    expect(firstResponse.status).toBe(200);
+
+    const firstBody = await firstResponse.json();
+    expect(firstBody.data).toHaveLength(1);
+    expect(firstBody.data[0].name).toBe("report.pdf");
+    expect(firstBody.meta.pagination.nextCursor).toBeTruthy();
+
+    const secondResponse = await app.request(
+      `/?scope=me&limit=1&q=report&cursor=${encodeURIComponent(firstBody.meta.pagination.nextCursor)}`,
+    );
+    expect(secondResponse.status).toBe(200);
+
+    const secondBody = await secondResponse.json();
+    expect(secondBody.data).toHaveLength(1);
+    expect(secondBody.data[0].name).toBe("report-copy.pdf");
+    expect(secondBody.meta.pagination.nextCursor).toBeNull();
+  });
+
+  it("keeps global recency order when blob listing spans multiple pages", async () => {
+    let blobPage = 0;
+    listMock.mockImplementation(async () => {
+      blobPage += 1;
+      if (blobPage === 1) {
+        return {
+          blobs: [
+            {
+              url: "https://blob.example/older-report.pdf",
+              pathname: "drive/users/user_123/older-report.pdf",
+              size: 1000,
+              uploadedAt: new Date("2026-08-18T12:00:00.000Z"),
+            },
+          ],
+          hasMore: true,
+          cursor: "blob-page-2",
+        };
+      }
+
+      return {
+        blobs: [
+          {
+            url: "https://blob.example/newer-report.pdf",
+            pathname: "drive/users/user_123/newer-report.pdf",
+            size: 500,
+            uploadedAt: new Date("2026-08-21T12:00:00.000Z"),
+          },
+        ],
+        hasMore: false,
+      };
+    });
+    prismaTaskFileFindManyMock.mockResolvedValue([
+      {
+        id: "tf_mid",
+        name: "mid-report.pdf",
+        fileUrl: "https://blob.example/mid-report.pdf",
+        size: BigInt(500),
+        updatedAt: new Date("2026-08-20T12:00:00.000Z"),
+        task: {
+          id: "task_1",
+          name: "Report task",
+          projectId: null,
+          project: null,
+        },
+      },
+    ]);
+
+    const app = createRecentsApp();
+    const response = await app.request("/?scope=me&limit=3&q=report");
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(
+      body.data.map((item: { kind: string; name: string }) => item.name),
+    ).toEqual(["newer-report.pdf", "mid-report.pdf", "older-report.pdf"]);
+  });
 });

--- a/apps/core/src/routes/v1/drive/recents/get.test.ts
+++ b/apps/core/src/routes/v1/drive/recents/get.test.ts
@@ -55,12 +55,25 @@ vi.mock("@/helpers/vendor-grants", () => ({
 
 vi.mock("@vercel/blob", () => ({
   list: listMock,
-  head: vi.fn(async (pathname: string) => ({
-    url: `https://blob.example/${pathname}`,
-    pathname,
-    size: 100,
-    uploadedAt: new Date("2026-08-19T10:00:00.000Z"),
-  })),
+  head: vi.fn(async (pathname: string) => {
+    const uploadedAtByPath: Record<string, string> = {
+      "drive/users/user_123/file-0.pdf": "2026-08-20T12:00:00.000Z",
+      "drive/users/user_123/file-1.pdf": "2026-08-19T12:00:00.000Z",
+      "drive/users/user_123/file-2.pdf": "2026-08-18T12:00:00.000Z",
+      "drive/users/user_123/report.pdf": "2026-08-21T12:00:00.000Z",
+      "drive/users/user_123/report-copy.pdf": "2026-08-20T12:00:00.000Z",
+      "drive/users/user_123/older-report.pdf": "2026-08-18T12:00:00.000Z",
+      "drive/users/user_123/newer-report.pdf": "2026-08-21T12:00:00.000Z",
+    };
+    return {
+      url: `https://blob.example/${pathname}`,
+      pathname,
+      size: 100,
+      uploadedAt: new Date(
+        uploadedAtByPath[pathname] ?? "2026-08-19T10:00:00.000Z",
+      ),
+    };
+  }),
 }));
 
 vi.mock("@/config/env", async (importOriginal) => {
@@ -186,6 +199,62 @@ describe("GET /v1/drive/recents", () => {
     const body = await response.json();
     expect(body.data).toHaveLength(2);
     expect(body.meta.pagination.nextCursor).toBeTruthy();
+  });
+
+  it("paginates without search when more items remain", async () => {
+    let blobPage = 0;
+    listMock.mockImplementation(async () => {
+      blobPage += 1;
+      if (blobPage === 1) {
+        return {
+          blobs: [
+            {
+              url: "https://blob.example/file-0.pdf",
+              pathname: "drive/users/user_123/file-0.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-20T12:00:00.000Z"),
+            },
+            {
+              url: "https://blob.example/file-1.pdf",
+              pathname: "drive/users/user_123/file-1.pdf",
+              size: 100,
+              uploadedAt: new Date("2026-08-19T12:00:00.000Z"),
+            },
+          ],
+          hasMore: true,
+          cursor: "blob-page-2",
+        };
+      }
+
+      return {
+        blobs: [
+          {
+            url: "https://blob.example/file-2.pdf",
+            pathname: "drive/users/user_123/file-2.pdf",
+            size: 100,
+            uploadedAt: new Date("2026-08-18T12:00:00.000Z"),
+          },
+        ],
+        hasMore: false,
+      };
+    });
+
+    const app = createRecentsApp();
+    const firstResponse = await app.request("/?scope=me&limit=1");
+    expect(firstResponse.status).toBe(200);
+
+    const firstBody = await firstResponse.json();
+    expect(firstBody.data).toHaveLength(1);
+    expect(firstBody.meta.pagination.nextCursor).toBeTruthy();
+
+    const secondResponse = await app.request(
+      `/?scope=me&limit=1&cursor=${encodeURIComponent(firstBody.meta.pagination.nextCursor)}`,
+    );
+    expect(secondResponse.status).toBe(200);
+
+    const secondBody = await secondResponse.json();
+    expect(secondBody.data).toHaveLength(1);
+    expect(secondBody.data[0].name).toBe("file-1.pdf");
   });
 
   it("requires organizationId for org scope", async () => {

--- a/apps/core/src/routes/v1/drive/recents/get.test.ts
+++ b/apps/core/src/routes/v1/drive/recents/get.test.ts
@@ -55,6 +55,12 @@ vi.mock("@/helpers/vendor-grants", () => ({
 
 vi.mock("@vercel/blob", () => ({
   list: listMock,
+  head: vi.fn(async (pathname: string) => ({
+    url: `https://blob.example/${pathname}`,
+    pathname,
+    size: 100,
+    uploadedAt: new Date("2026-08-19T10:00:00.000Z"),
+  })),
 }));
 
 vi.mock("@/config/env", async (importOriginal) => {
@@ -65,6 +71,7 @@ vi.mock("@/config/env", async (importOriginal) => {
       ...actual.getEnv(),
       BLOB_READ_WRITE_TOKEN: "test-token",
       STRIPE_SECRET_KEY: "sk_test_123",
+      BETTER_AUTH_SECRET: "test-better-auth-secret",
     }),
   };
 });
@@ -150,15 +157,26 @@ describe("GET /v1/drive/recents", () => {
   });
 
   it("returns nextCursor when more items remain", async () => {
-    listMock.mockResolvedValue({
-      blobs: Array.from({ length: 3 }, (_, index) => ({
-        url: `https://blob.example/file-${index}.pdf`,
-        pathname: `drive/users/user_123/file-${index}.pdf`,
-        size: 100,
-        uploadedAt: new Date(`2026-08-${20 - index}T12:00:00.000Z`),
-      })),
-      hasMore: true,
-      cursor: "blob-page-2",
+    let blobPage = 0;
+    listMock.mockImplementation(async () => {
+      blobPage += 1;
+      if (blobPage === 1) {
+        return {
+          blobs: Array.from({ length: 3 }, (_, index) => ({
+            url: `https://blob.example/file-${index}.pdf`,
+            pathname: `drive/users/user_123/file-${index}.pdf`,
+            size: 100,
+            uploadedAt: new Date(`2026-08-${20 - index}T12:00:00.000Z`),
+          })),
+          hasMore: true,
+          cursor: "blob-page-2",
+        };
+      }
+
+      return {
+        blobs: [],
+        hasMore: false,
+      };
     });
 
     const app = createRecentsApp();

--- a/apps/core/src/routes/v1/drive/recents/get.ts
+++ b/apps/core/src/routes/v1/drive/recents/get.ts
@@ -12,6 +12,7 @@ import { fetchDriveRecentsPage } from "@/helpers/drive-recents";
 import {
   DRIVE_TASK_FILE_WHERE,
   fetchDriveTaskOutputRecentsBatch,
+  fetchDriveTaskOutputRecentsByIds,
 } from "@/helpers/drive-task-output-catalog";
 import { resolveDriveTasksWorkspace } from "@/helpers/drive-tasks-workspace";
 import {
@@ -139,12 +140,23 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       token,
       limit: take,
       cursor,
+      cursorSecret: env.BETTER_AUTH_SECRET,
+      cursorBinding: {
+        prefix,
+        searchQuery: searchQuery ?? "",
+      },
       ...(searchQuery ? { searchQuery } : {}),
       fetchTaskOutputs: ({ cursor: taskCursor, take: taskTake }) =>
         fetchDriveTaskOutputRecentsBatch({
           baseTaskWhere,
           cursor: taskCursor,
           take: taskTake,
+          ...(searchQuery ? { searchQuery } : {}),
+        }),
+      fetchTaskOutputsByIds: (ids) =>
+        fetchDriveTaskOutputRecentsByIds({
+          ids,
+          baseTaskWhere,
           ...(searchQuery ? { searchQuery } : {}),
         }),
     });

--- a/apps/core/src/routes/v1/drive/recents/get.ts
+++ b/apps/core/src/routes/v1/drive/recents/get.ts
@@ -132,17 +132,20 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     }
 
     const { cursor, take } = parseCursorPagination(query);
+    const searchQuery = query.q?.trim();
 
     const page = await fetchDriveRecentsPage({
       prefix,
       token,
       limit: take,
       cursor,
+      ...(searchQuery ? { searchQuery } : {}),
       fetchTaskOutputs: ({ cursor: taskCursor, take: taskTake }) =>
         fetchDriveTaskOutputRecentsBatch({
           baseTaskWhere,
           cursor: taskCursor,
           take: taskTake,
+          ...(searchQuery ? { searchQuery } : {}),
         }),
     });
 

--- a/apps/core/src/schemas/drive-recents.schema.ts
+++ b/apps/core/src/schemas/drive-recents.schema.ts
@@ -105,6 +105,15 @@ export const driveRecentsQuerySchema = z
         example: "org_123",
         description: "Organization ID (required when scope=org)",
       }),
+    q: z
+      .string()
+      .optional()
+      .openapi({
+        param: { name: "q", in: "query" },
+        example: "report",
+        description:
+          "Search recents by file name (Drive blobs) or task/file name and task description (task outputs). Case-insensitive substring.",
+      }),
   })
   .merge(cursorPaginationQuerySchema)
   .refine((data) => data.scope !== "org" || Boolean(data.organizationId), {

--- a/apps/web/src/app/(app)/drive/components/drive-recents-panel.tsx
+++ b/apps/web/src/app/(app)/drive/components/drive-recents-panel.tsx
@@ -256,6 +256,7 @@ export function DriveRecentsPanel({
     const controller = new AbortController();
     loadMoreAbortRef.current = controller;
     const requestedWorkspaceId = activeOrganizationId;
+    const searchQueryAtRequest = trimmedSearchQuery;
     setLoadingMore(true);
 
     try {
@@ -265,14 +266,15 @@ export function DriveRecentsPanel({
           ? { organizationId: activeOrganizationId }
           : {}),
         cursor: nextCursor,
-        ...(trimmedSearchQuery ? { q: trimmedSearchQuery } : {}),
+        ...(searchQueryAtRequest ? { q: searchQueryAtRequest } : {}),
         signal: controller.signal,
       });
 
-      if (
-        controller.signal.aborted ||
-        workspaceIdRef.current !== requestedWorkspaceId
-      ) {
+      const queryStillMatches =
+        workspaceIdRef.current === requestedWorkspaceId &&
+        trimmedSearchQuery === searchQueryAtRequest;
+
+      if (controller.signal.aborted || !queryStillMatches) {
         return;
       }
 

--- a/apps/web/src/app/(app)/drive/components/drive-recents-panel.tsx
+++ b/apps/web/src/app/(app)/drive/components/drive-recents-panel.tsx
@@ -64,6 +64,7 @@ function handleDownload(fileUrl: string, fileName: string) {
 interface DriveRecentsPanelProps {
   driveStore: DriveWorkspaceStore;
   activeOrganizationId: string | null;
+  searchQuery: string;
   onOpenMoveDialog: (item: DriveItem) => void;
   onOpenDeleteDialog: (item: DriveItem) => void;
   onRenameFile: (item: DriveItem, newName: string) => Promise<void>;
@@ -148,6 +149,7 @@ function toDriveFileItem(
 export function DriveRecentsPanel({
   driveStore,
   activeOrganizationId,
+  searchQuery,
   onOpenMoveDialog,
   onOpenDeleteDialog,
   onRenameFile,
@@ -167,6 +169,7 @@ export function DriveRecentsPanel({
   const loadMoreAbortRef = useRef<AbortController | null>(null);
   const workspaceIdRef = useRef(activeOrganizationId);
   workspaceIdRef.current = activeOrganizationId;
+  const trimmedSearchQuery = searchQuery.trim();
 
   const dayGroups = useMemo(
     () => buildDriveRecentsDayGroups(items, locale),
@@ -203,6 +206,7 @@ export function DriveRecentsPanel({
         ...(driveStore.scope === "org" && activeOrganizationId
           ? { organizationId: activeOrganizationId }
           : {}),
+        ...(trimmedSearchQuery ? { q: trimmedSearchQuery } : {}),
         signal: controller.signal,
       });
 
@@ -233,7 +237,7 @@ export function DriveRecentsPanel({
         setLoading(false);
       }
     }
-  }, [activeOrganizationId, driveStore.scope, t]);
+  }, [activeOrganizationId, driveStore.scope, t, trimmedSearchQuery]);
 
   useEffect(() => {
     void loadRecents();
@@ -261,6 +265,7 @@ export function DriveRecentsPanel({
           ? { organizationId: activeOrganizationId }
           : {}),
         cursor: nextCursor,
+        ...(trimmedSearchQuery ? { q: trimmedSearchQuery } : {}),
         signal: controller.signal,
       });
 
@@ -329,10 +334,12 @@ export function DriveRecentsPanel({
       >
         <div className="max-w-sm">
           <h2 className="text-foreground text-lg font-semibold">
-            {t("recentsEmptyTitle")}
+            {trimmedSearchQuery ? t("noMatchTitle") : t("recentsEmptyTitle")}
           </h2>
           <p className="text-muted-foreground mt-2 text-sm">
-            {t("recentsEmptyDescription")}
+            {trimmedSearchQuery
+              ? t("noMatchDescription")
+              : t("recentsEmptyDescription")}
           </p>
         </div>
       </div>

--- a/apps/web/src/app/(app)/drive/page.test.tsx
+++ b/apps/web/src/app/(app)/drive/page.test.tsx
@@ -530,6 +530,23 @@ describe("DrivePage recents view", () => {
     });
   });
 
+  it("opens browse for legacy folder links without view=browse", async () => {
+    searchParams = new URLSearchParams("folder=Reports");
+    listDriveItemsMock.mockResolvedValue([reportsFolder()]);
+
+    renderDrive();
+
+    await waitFor(() => {
+      expect(listDriveItemsMock).toHaveBeenCalled();
+    });
+
+    expect(fetchDriveRecentsPageMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("tab", { name: "Org A" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
   it("switches to browse when the browse tab is selected", async () => {
     const user = userEvent.setup();
     listDriveItemsMock.mockResolvedValue([reportsFolder()]);

--- a/apps/web/src/app/(app)/drive/page.test.tsx
+++ b/apps/web/src/app/(app)/drive/page.test.tsx
@@ -492,7 +492,7 @@ describe("DrivePage recents view", () => {
     useSessionMock.mockReturnValue(sessionFor("org_a"));
   });
 
-  it("loads recents by default and hides browse chrome", async () => {
+  it("loads recents by default and shows search without browse actions", async () => {
     renderDrive();
 
     await waitFor(() => {
@@ -505,9 +505,29 @@ describe("DrivePage recents view", () => {
       "true",
     );
     expect(screen.getByText("recentsEmptyTitle")).toBeVisible();
+    expect(screen.getAllByPlaceholderText("searchPlaceholder")).toHaveLength(2);
     expect(
-      screen.queryByPlaceholderText("searchPlaceholder"),
+      screen.queryByRole("button", { name: "createFolder" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("passes search query to recents fetch", async () => {
+    const user = userEvent.setup();
+    renderDrive();
+
+    await waitFor(() => {
+      expect(fetchDriveRecentsPageMock).toHaveBeenCalled();
+    });
+
+    fetchDriveRecentsPageMock.mockClear();
+    const [searchInput] = screen.getAllByPlaceholderText("searchPlaceholder");
+    await user.type(searchInput, "report");
+
+    await waitFor(() => {
+      expect(fetchDriveRecentsPageMock).toHaveBeenCalledWith(
+        expect.objectContaining({ q: "report" }),
+      );
+    });
   });
 
   it("switches to browse when the browse tab is selected", async () => {

--- a/apps/web/src/app/(app)/drive/page.tsx
+++ b/apps/web/src/app/(app)/drive/page.tsx
@@ -1472,6 +1472,20 @@ function DrivePageWorkspace({
               />
             </div>
           )}
+          {!isTasksView && isRecentsView && (
+            <div className="hidden items-center gap-2 md:flex">
+              <div className="relative">
+                <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
+                <Input
+                  type="text"
+                  placeholder={t("searchPlaceholder")}
+                  value={searchQuery}
+                  onChange={(e) => handleSearchChange(e.target.value)}
+                  className="w-64 pl-8"
+                />
+              </div>
+            </div>
+          )}
         </div>
 
         {!isTasksView && isBrowseView ? (
@@ -1602,10 +1616,26 @@ function DrivePageWorkspace({
         </div>
       )}
 
+      {!isTasksView && isRecentsView && (
+        <div className="mb-6 flex items-center gap-2 md:hidden">
+          <div className="relative flex-1">
+            <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
+            <Input
+              type="text"
+              placeholder={t("searchPlaceholder")}
+              value={searchQuery}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="w-full pl-8"
+            />
+          </div>
+        </div>
+      )}
+
       {isRecentsView ? (
         <DriveRecentsPanel
           driveStore={driveStore}
           activeOrganizationId={activeOrganizationId}
+          searchQuery={debouncedSearchQuery}
           onOpenMoveDialog={openMoveDialog}
           onOpenDeleteDialog={openDeleteDialog}
           onRenameFile={handleRename}

--- a/apps/web/src/app/(app)/drive/page.tsx
+++ b/apps/web/src/app/(app)/drive/page.tsx
@@ -464,7 +464,8 @@ function DrivePageWorkspace({
   const currentFolder = folderParam;
   const viewParam = searchParams.get("view");
   const isTasksView = viewParam === "tasks";
-  const isBrowseView = viewParam === "browse";
+  const isBrowseView =
+    !isTasksView && (viewParam === "browse" || folderParam.length > 0);
   const isRecentsView = !isTasksView && !isBrowseView;
   const primaryView: DrivePrimaryView = isBrowseView ? "browse" : "recents";
   const projectIdParam = searchParams.get("projectId");

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -17741,6 +17741,10 @@ export type GetDriveRecentsData = {
          */
         organizationId?: string;
         /**
+         * Search recents by file name (Drive blobs) or task/file name and task description (task outputs). Case-insensitive substring.
+         */
+        q?: string;
+        /**
          * Cursor for pagination (ID of the last item from previous page)
          */
         cursor?: string;

--- a/apps/web/src/lib/utils/drive-recents-list.client.ts
+++ b/apps/web/src/lib/utils/drive-recents-list.client.ts
@@ -15,6 +15,7 @@ export interface FetchDriveRecentsPageOptions {
   scope: "me" | "org";
   organizationId?: string;
   cursor?: string;
+  q?: string;
   signal?: AbortSignal;
 }
 
@@ -30,6 +31,7 @@ export async function fetchDriveRecentsPage(
         ? { organizationId: options.organizationId }
         : {}),
       ...(options.cursor ? { cursor: options.cursor } : {}),
+      ...(options.q?.trim() ? { q: options.q.trim() } : {}),
     },
     ...(options.signal ? { signal: options.signal } : {}),
     throwOnError: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses review feedback on drive recents search pagination (SOK-900).

- Replaces full `pendingItems` records in pagination cursors with HMAC-signed, workspace-bound `pendingRefs` (kind/id/activityAt only), re-hydrated server-side via blob `head` and authorized task-file lookups.
- Rejects tampered or legacy cursors that embed raw item payloads.
- Keeps scanning Vercel Blob pages while `driveHasMore` is true so pathname-ordered listings cannot miss newer matches on later pages.
- Caps buffered refs at 100 to keep cursors bounded.

## Review threads

- **Fixed:** Codex P1/P2 and CodeRabbit security/correctness comments on `drive-recents.ts`.
- **Dismissed:** CodeRabbit React Query refactor on `drive-recents-panel.tsx` — out of scope for this PR; replied in thread.

## Verification

- `pnpm --filter core test src/helpers/drive-recents.test.ts src/routes/v1/drive/recents/get.test.ts`
- `pnpm check && pnpm typecheck` (via pre-commit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd9ddfae-51cb-46fb-b4e8-5129c059e934?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd9ddfae-51cb-46fb-b4e8-5129c059e934&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search to Drive recents across file names, task names, and descriptions.
  * Added search controls for desktop and mobile recents views.
  * Folder links now open browse mode automatically.

* **Bug Fixes**
  * Search results remain consistent while loading additional pages.
  * Improved pagination ordering across Drive files and task outputs.
  * Invalid or stale pagination cursors now restart from the first page.
  * Empty states distinguish between no matches and no recent items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->