### PR TITLE
fix(core): allow x-request-id in CORS preflight for browser Core client

### DIFF
--- a/apps/core/src/routes/v1/index.test.ts
+++ b/apps/core/src/routes/v1/index.test.ts
@@ -57,6 +57,27 @@ describe("v1 router", () => {
     });
   });
 
+  it("allows x-request-id on cors preflight from the web app", async () => {
+    const { default: app } = await import("./index.js");
+
+    const response = await app.request("http://localhost/v1/drive/files", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://app.sokosumi.com",
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "x-request-id,authorization",
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "https://app.sokosumi.com",
+    );
+    expect(response.headers.get("access-control-allow-headers")).toContain(
+      "X-Request-Id",
+    );
+  });
+
   it("serves openapi.json with cors headers and a relative v1 server url", async () => {
     const { default: app } = await import("./index.js");
 

--- a/apps/core/src/routes/v1/index.ts
+++ b/apps/core/src/routes/v1/index.ts
@@ -119,6 +119,7 @@ app.use(
     allowHeaders: [
       "Content-Type",
       "Authorization",
+      "X-Request-Id",
       "X-Organization-Slug",
       "X-Context-User-Id",
       "X-Context-Organization-Id",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes production CORS failures on browser Core API calls (e.g. Drive `/v1/drive/files`) after #3988.

PR #3988 added `attachCoreRequestIdInterceptor` to the browser Core client, which sends an `x-request-id` header on every request. Core's v1 CORS middleware did not include that header in `allowHeaders`, so browsers blocked the preflight with:

> Request header field x-request-id is not allowed by Access-Control-Allow-Headers in preflight response.

## Root cause

- **Introduced by:** #3988 (`feat(core): add evlog HTTP wide events`), merged today
- **Not a separate regression:** web started sending the header and Core never allowed it in the same PR

## Fix

Add `X-Request-Id` to `allowHeaders` in `apps/core/src/routes/v1/index.ts`.

## Verification

- `pnpm --filter @sokosumi/core exec vitest run src/routes/v1/index.test.ts`
- New test asserts OPTIONS preflight from `https://app.sokosumi.com` with `Access-Control-Request-Headers: x-request-id,authorization` returns `X-Request-Id` in `Access-Control-Allow-Headers`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-503e0e78-f3c5-4999-b053-c9d3469e4ec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-503e0e78-f3c5-4999-b053-c9d3469e4ec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

