### PR TITLE
fix(chat): update unread chrome when history resolves

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -247,8 +247,12 @@ The per-room list of that room’s threads, shown in the thread side panel. Ever
 _Avoid_: Unread threads (as the name of this list), inbox, treating this as a cross-room surface, Threads badge as a separate count
 
 **Look**:
-The user’s high-water mark in a Thread: they opened it, and that moment is stored. Distinct from room read state and from being a Participant. Look clears; it does not opt a lurker into unread. Opening the Thread, posting a reply, or Mark all threads Looks it. Marking the room as read does not.
+The user’s high-water mark in a Thread: they opened it, and that moment is stored. Distinct from Room last-read and from being a Participant. Look clears; it does not opt a lurker into unread. Opening the Thread, posting a reply, or Mark all threads Looks it. Advancing Room last-read does not Look.
 _Avoid_: Replied, Participant, lastLookedAt, read receipt. Do not use “looked” in product UI (say unread / mark as read)
+
+**Room last-read**:
+The user’s high-water mark on a room’s main transcript. Distinct from Look. Advancing it clears top-level Room unread and that room’s mention badge; leftover Participant Thread unread stays.
+_Avoid_: Look, lastReadAt (storage), treating this as reading Threads
 
 **User mention**:
 A human @-reference to a user on a room message (main transcript or Thread). Distinct from Mention status (coworker turn lifecycle).
@@ -259,7 +263,7 @@ A user of a Thread who authored the parent, has a remaining reply in that Thread
 _Avoid_: Follower, subscriber, treating Look (opened it) as participation
 
 **Room unread**:
-The count of unseen messages that page the user in this room: non-self top-level messages after room last-read, plus non-self replies in Threads where the user is a Participant (including coworker replies). Replies from before the user joined the room do not count. Drives sidebar **bold**. Not the mention badge.
+The count of unseen messages that page the user in this room: non-self top-level messages after Room last-read, plus non-self replies in Threads where the user is a Participant (including coworker replies). Replies from before the user joined the room do not count. Drives sidebar **bold**. Not the mention badge.
 _Avoid_: Attention, attentionReplyCount, counting lurker thread replies, a separate Threads badge, using the mention badge as the message unread count
 
 **Unread thread**:

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -508,6 +508,24 @@ describe("RoomsClient progressive history (real composer + list skeleton)", () =
     expect(rememberRoomRead).toHaveBeenCalled();
   });
 
+  it("restores unread when mark-read transport rejects", async () => {
+    vi.mocked(markOrganizationChatRoomReadAction).mockRejectedValue(
+      new Error("network"),
+    );
+
+    render(
+      <RoomsClient
+        {...baseProps}
+        rooms={[{ ...channelRoom(), unreadCount: 4 }]}
+        messages={[sampleMessage()]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(forgetRoomRead).toHaveBeenCalledWith("room-channel");
+    });
+  });
+
   it("restores unread after mark-read fails even if the room unmounted", async () => {
     let resolveRead!: (result: {
       ok: false;

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -508,6 +508,62 @@ describe("RoomsClient progressive history (real composer + list skeleton)", () =
     expect(rememberRoomRead).toHaveBeenCalled();
   });
 
+  it("restores unread after mark-read fails even if the room unmounted", async () => {
+    let resolveRead!: (result: {
+      ok: false;
+      error: { code: string; message: string };
+    }) => void;
+    vi.mocked(markOrganizationChatRoomReadAction).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    const unreadRoom = {
+      ...channelRoom(),
+      unreadCount: 4,
+      unreadMentionCount: 1,
+    };
+    const { unmount } = render(
+      <RoomsClient
+        {...baseProps}
+        rooms={[unreadRoom]}
+        messages={[sampleMessage()]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(rememberRoomRead).toHaveBeenCalled();
+    });
+    dispatchSpy.mockClear();
+    unmount();
+
+    await act(async () => {
+      resolveRead({
+        ok: false,
+        error: { code: "INTERNAL_SERVER_ERROR", message: "fail" },
+      });
+    });
+
+    expect(forgetRoomRead).toHaveBeenCalledWith("room-channel");
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "organization-chat-room-read",
+        detail: expect.objectContaining({
+          roomId: "room-channel",
+          room: expect.objectContaining({
+            id: "room-channel",
+            unreadCount: 4,
+            unreadMentionCount: 1,
+          }),
+        }),
+      }),
+    );
+    dispatchSpy.mockRestore();
+  });
+
   it("shows load-failed empty state when deferred history fails", async () => {
     let resolvePage!: (page: {
       messages: ChatRoomMessage[];

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -2,6 +2,11 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import { type ReactNode, type Ref, useImperativeHandle } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RoomShellRosterPage } from "@/app/chat/load-room-shell-roster";
+import { markOrganizationChatRoomReadAction } from "@/components/chat/organization-chat-list.actions";
+import {
+  forgetRoomRead,
+  rememberRoomRead,
+} from "@/components/chat/room-read-overlay";
 import type {
   ChatRoom,
   ChatRoomMessage,
@@ -121,7 +126,8 @@ vi.mock("@/components/chat/organization-chat-list.actions", () => ({
 }));
 
 vi.mock("@/components/chat/room-read-overlay", () => ({
-  applyRoomReadResultToOverlay: vi.fn(),
+  rememberRoomRead: vi.fn(),
+  forgetRoomRead: vi.fn(),
 }));
 
 vi.mock("../room-file-drop-zone", () => ({
@@ -286,6 +292,44 @@ const baseProps = {
 };
 
 describe("RoomsClient progressive history (real composer + list skeleton)", () => {
+  beforeEach(() => {
+    vi.mocked(markOrganizationChatRoomReadAction).mockReset();
+    vi.mocked(markOrganizationChatRoomReadAction).mockImplementation(
+      async (roomId: string) => ({
+        ok: true as const,
+        value: {
+          ...channelRoom(),
+          id: roomId,
+          unreadCount: 0,
+          unreadMentionCount: 0,
+          markedUnread: false,
+        },
+      }),
+    );
+    vi.mocked(rememberRoomRead).mockClear();
+    vi.mocked(forgetRoomRead).mockClear();
+  });
+
+  it("does not advance Room last-read while history is still pending", () => {
+    const messagesPromise = new Promise<{
+      messages: ChatRoomMessage[];
+      nextCursor: string | null;
+      failed: boolean;
+    }>(() => undefined);
+
+    render(
+      <RoomsClient
+        {...baseProps}
+        rooms={[{ ...channelRoom(), unreadCount: 4 }]}
+        messagesPromise={messagesPromise}
+      />,
+    );
+
+    expect(screen.getByTestId("room-message-list-skeleton")).toBeTruthy();
+    expect(markOrganizationChatRoomReadAction).not.toHaveBeenCalled();
+    expect(rememberRoomRead).not.toHaveBeenCalled();
+  });
+
   it("shows list skeleton and real composer while history is pending", () => {
     // Intentionally never settles — pending shell only.
     const messagesPromise = new Promise<{
@@ -340,6 +384,128 @@ describe("RoomsClient progressive history (real composer + list skeleton)", () =
     );
     expect(screen.getByTestId("room-session-composer")).toBe(composer);
     expect(composer).toHaveAttribute("data-focus-on-mount", "true");
+    expect(rememberRoomRead).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "room-channel",
+        unreadCount: 0,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    );
+    expect(markOrganizationChatRoomReadAction).toHaveBeenCalledWith(
+      "room-channel",
+    );
+  });
+
+  it("remembers local Room last-read before mark-read returns", async () => {
+    let resolveRead!: (result: { ok: true; value: ChatRoom }) => void;
+    vi.mocked(markOrganizationChatRoomReadAction).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+
+    let resolvePage!: (page: {
+      messages: ChatRoomMessage[];
+      nextCursor: string | null;
+      failed: boolean;
+    }) => void;
+    const messagesPromise = new Promise<{
+      messages: ChatRoomMessage[];
+      nextCursor: string | null;
+      failed: boolean;
+    }>((resolve) => {
+      resolvePage = resolve;
+    });
+
+    render(
+      <RoomsClient
+        {...baseProps}
+        rooms={[{ ...channelRoom(), unreadCount: 4, unreadMentionCount: 1 }]}
+        messagesPromise={messagesPromise}
+      />,
+    );
+
+    await act(async () => {
+      resolvePage({
+        messages: [sampleMessage("hydrated history body")],
+        nextCursor: null,
+        failed: false,
+      });
+      await messagesPromise;
+    });
+
+    await waitFor(() => {
+      expect(rememberRoomRead).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "room-channel",
+          unreadCount: 0,
+          unreadMentionCount: 0,
+          markedUnread: false,
+        }),
+      );
+    });
+    expect(markOrganizationChatRoomReadAction).toHaveBeenCalledWith(
+      "room-channel",
+    );
+    expect(rememberRoomRead).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: "room-channel",
+        unreadCount: 0,
+      }),
+    );
+
+    await act(async () => {
+      resolveRead({
+        ok: true,
+        value: {
+          ...channelRoom(),
+          unreadCount: 2,
+          unreadMentionCount: 0,
+          markedUnread: false,
+        },
+      });
+    });
+
+    expect(rememberRoomRead).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: "room-channel",
+        unreadCount: 2,
+      }),
+    );
+  });
+
+  it("advances Room last-read when history resolves empty", async () => {
+    render(<RoomsClient {...baseProps} messages={[]} />);
+
+    await waitFor(() => {
+      expect(rememberRoomRead).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "room-channel",
+          unreadCount: 0,
+          unreadMentionCount: 0,
+          markedUnread: false,
+        }),
+      );
+    });
+    expect(markOrganizationChatRoomReadAction).toHaveBeenCalledWith(
+      "room-channel",
+    );
+  });
+
+  it("forgets local Room last-read when mark-read fails", async () => {
+    vi.mocked(markOrganizationChatRoomReadAction).mockResolvedValue({
+      ok: false,
+      error: { code: "INTERNAL_SERVER_ERROR", message: "fail" },
+    });
+
+    render(<RoomsClient {...baseProps} messages={[sampleMessage()]} />);
+
+    await waitFor(() => {
+      expect(forgetRoomRead).toHaveBeenCalledWith("room-channel");
+    });
+    expect(rememberRoomRead).toHaveBeenCalled();
   });
 
   it("shows load-failed empty state when deferred history fails", async () => {
@@ -376,6 +542,8 @@ describe("RoomsClient progressive history (real composer + list skeleton)", () =
     expect(screen.getByText("Empty.messagesLoadFailedTitle")).toBeTruthy();
     expect(screen.queryByTestId("chat-message-row")).toBeNull();
     expect(screen.getByTestId("room-session-composer")).toBe(composer);
+    expect(markOrganizationChatRoomReadAction).not.toHaveBeenCalled();
+    expect(rememberRoomRead).not.toHaveBeenCalled();
   });
 
   it("settles to load-failed when deferred history promise rejects", async () => {
@@ -400,6 +568,8 @@ describe("RoomsClient progressive history (real composer + list skeleton)", () =
     });
     expect(screen.getByText("Empty.messagesLoadFailedTitle")).toBeTruthy();
     expect(screen.getByTestId("room-session-composer")).toBeTruthy();
+    expect(markOrganizationChatRoomReadAction).not.toHaveBeenCalled();
+    expect(rememberRoomRead).not.toHaveBeenCalled();
   });
 
   it("clears prior room messages when progressive room switches", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -140,7 +140,8 @@ vi.mock("@/components/chat/organization-chat-list.actions", () => ({
 }));
 
 vi.mock("@/components/chat/room-read-overlay", () => ({
-  applyRoomReadResultToOverlay: vi.fn(),
+  rememberRoomRead: vi.fn(),
+  forgetRoomRead: vi.fn(),
 }));
 
 vi.mock("../room-file-drop-zone", () => ({

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-scroll-on-send.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-scroll-on-send.test.tsx
@@ -130,7 +130,8 @@ vi.mock("@/components/chat/organization-chat-list.actions", () => ({
 }));
 
 vi.mock("@/components/chat/room-read-overlay", () => ({
-  applyRoomReadResultToOverlay: vi.fn(),
+  rememberRoomRead: vi.fn(),
+  forgetRoomRead: vi.fn(),
 }));
 
 vi.mock("../room-file-drop-zone", () => ({

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-thread-open-loading.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-thread-open-loading.test.tsx
@@ -119,7 +119,8 @@ vi.mock("@/components/chat/organization-chat-list.actions", () => ({
 }));
 
 vi.mock("@/components/chat/room-read-overlay", () => ({
-  applyRoomReadResultToOverlay: vi.fn(),
+  rememberRoomRead: vi.fn(),
+  forgetRoomRead: vi.fn(),
 }));
 
 vi.mock("../room-file-drop-zone", () => ({

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1538,7 +1538,7 @@ export function RoomsClient({
     readMarkerRef.current = marker;
 
     const roomId = selectedRoomReadId;
-    const restoreRoom = selectedRoom;
+    const unreadBeforeMarkRead = selectedRoom;
     const optimisticRoom = {
       ...selectedRoom,
       unreadCount: 0,
@@ -1558,7 +1558,7 @@ export function RoomsClient({
       }
       if (!result.ok) {
         forgetRoomRead(roomId);
-        dispatchOrganizationChatRoomRead(roomId, restoreRoom);
+        dispatchOrganizationChatRoomRead(roomId, unreadBeforeMarkRead);
         return;
       }
       rememberRoomRead(result.value);

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -747,6 +747,7 @@ export function RoomsClient({
     scrollToBottom();
   }, [messagesPending, scrollToBottom]);
   const readMarkerRef = useRef<string | null>(null);
+  const roomReadGenerationByRoomIdRef = useRef(new Map<string, number>());
   const syncedRoomIdRef = useRef<string | null>(null);
   // RoomsClient stays mounted across /chat/rooms/[id] navigations. Async
   // handlers must not merge into messagesState after the selection moved.
@@ -1517,8 +1518,8 @@ export function RoomsClient({
     if (!selectedRoomReadId || !selectedRoom) {
       return;
     }
-    // Empty rooms keep marker `room:empty`; skip while pending/failed so
-    // hydrate can still advance last-read.
+    // Skip while pending/failed so empty-room hydrate can still advance
+    // last-read (same marker as the pending empty transcript).
     if (messagesPending || effectiveMessageLoadFailed) {
       return;
     }
@@ -1544,26 +1545,25 @@ export function RoomsClient({
       unreadMentionCount: 0,
       markedUnread: false,
     };
+    const generation =
+      (roomReadGenerationByRoomIdRef.current.get(roomId) ?? 0) + 1;
+    roomReadGenerationByRoomIdRef.current.set(roomId, generation);
+
     rememberRoomRead(optimisticRoom);
     dispatchOrganizationChatRoomRead(roomId, optimisticRoom);
 
-    let cancelled = false;
     markOrganizationChatRoomReadAction(roomId).then((result) => {
+      if (roomReadGenerationByRoomIdRef.current.get(roomId) !== generation) {
+        return;
+      }
       if (!result.ok) {
         forgetRoomRead(roomId);
-        if (cancelled) {
-          return;
-        }
         dispatchOrganizationChatRoomRead(roomId, restoreRoom);
         return;
       }
       rememberRoomRead(result.value);
       dispatchOrganizationChatRoomRead(roomId, result.value);
     });
-
-    return () => {
-      cancelled = true;
-    };
   }, [
     effectiveMessageLoadFailed,
     latestOpenThreadMessageId,

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1552,18 +1552,29 @@ export function RoomsClient({
     rememberRoomRead(optimisticRoom);
     dispatchOrganizationChatRoomRead(roomId, optimisticRoom);
 
-    markOrganizationChatRoomReadAction(roomId).then((result) => {
-      if (roomReadGenerationByRoomIdRef.current.get(roomId) !== generation) {
-        return;
-      }
-      if (!result.ok) {
-        forgetRoomRead(roomId);
-        dispatchOrganizationChatRoomRead(roomId, unreadBeforeMarkRead);
-        return;
-      }
-      rememberRoomRead(result.value);
-      dispatchOrganizationChatRoomRead(roomId, result.value);
-    });
+    function restoreUnread(): void {
+      forgetRoomRead(roomId);
+      dispatchOrganizationChatRoomRead(roomId, unreadBeforeMarkRead);
+    }
+
+    markOrganizationChatRoomReadAction(roomId)
+      .then((result) => {
+        if (roomReadGenerationByRoomIdRef.current.get(roomId) !== generation) {
+          return;
+        }
+        if (!result.ok) {
+          restoreUnread();
+          return;
+        }
+        rememberRoomRead(result.value);
+        dispatchOrganizationChatRoomRead(roomId, result.value);
+      })
+      .catch(() => {
+        if (roomReadGenerationByRoomIdRef.current.get(roomId) !== generation) {
+          return;
+        }
+        restoreUnread();
+      });
   }, [
     effectiveMessageLoadFailed,
     latestOpenThreadMessageId,

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -108,7 +108,10 @@ import {
 } from "@/components/chat/membership-visible-rooms-store";
 import { notifyOrganizationChatRoomsChanged } from "@/components/chat/organization-chat-events";
 import { markOrganizationChatRoomReadAction } from "@/components/chat/organization-chat-list.actions";
-import { applyRoomReadResultToOverlay } from "@/components/chat/room-read-overlay";
+import {
+  forgetRoomRead,
+  rememberRoomRead,
+} from "@/components/chat/room-read-overlay";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
@@ -188,6 +191,17 @@ import {
 } from "./room-shell-layout";
 import { RoomShellRosterHydrator } from "./room-shell-roster-hydrator";
 import { ThreadPanel } from "./thread-panel";
+
+function dispatchOrganizationChatRoomRead(
+  roomId: string,
+  room: ChatRoom,
+): void {
+  window.dispatchEvent(
+    new CustomEvent("organization-chat-room-read", {
+      detail: { room, roomId },
+    }),
+  );
+}
 
 interface RoomsClientProps {
   /** Null in personal workspace. */
@@ -1500,7 +1514,12 @@ export function RoomsClient({
   const selectedRoomReadId = selectedRoom?.id ?? null;
 
   useEffect(() => {
-    if (!selectedRoomReadId) {
+    if (!selectedRoomReadId || !selectedRoom) {
+      return;
+    }
+    // Empty rooms keep marker `room:empty`; skip while pending/failed so
+    // hydrate can still advance last-read.
+    if (messagesPending || effectiveMessageLoadFailed) {
       return;
     }
 
@@ -1517,29 +1536,41 @@ export function RoomsClient({
     }
     readMarkerRef.current = marker;
 
+    const roomId = selectedRoomReadId;
+    const restoreRoom = selectedRoom;
+    const optimisticRoom = {
+      ...selectedRoom,
+      unreadCount: 0,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    };
+    rememberRoomRead(optimisticRoom);
+    dispatchOrganizationChatRoomRead(roomId, optimisticRoom);
+
     let cancelled = false;
-    markOrganizationChatRoomReadAction(selectedRoomReadId).then((result) => {
+    markOrganizationChatRoomReadAction(roomId).then((result) => {
       if (!result.ok) {
+        forgetRoomRead(roomId);
+        if (cancelled) {
+          return;
+        }
+        dispatchOrganizationChatRoomRead(roomId, restoreRoom);
         return;
       }
-      applyRoomReadResultToOverlay(result.value);
-      if (cancelled) {
-        return;
-      }
-      window.dispatchEvent(
-        new CustomEvent("organization-chat-room-read", {
-          detail: { room: result.value, roomId: selectedRoomReadId },
-        }),
-      );
+      rememberRoomRead(result.value);
+      dispatchOrganizationChatRoomRead(roomId, result.value);
     });
 
     return () => {
       cancelled = true;
     };
   }, [
+    effectiveMessageLoadFailed,
     latestOpenThreadMessageId,
     latestTopLevelMessageId,
+    messagesPending,
     openThreadParentId,
+    selectedRoom,
     selectedRoomReadId,
   ]);
 
@@ -1873,12 +1904,8 @@ export function RoomsClient({
     if (!roomResult.ok) {
       return;
     }
-    applyRoomReadResultToOverlay(roomResult.value);
-    window.dispatchEvent(
-      new CustomEvent("organization-chat-room-read", {
-        detail: { room: roomResult.value, roomId },
-      }),
-    );
+    rememberRoomRead(roomResult.value);
+    dispatchOrganizationChatRoomRead(roomId, roomResult.value);
   }
   syncRoomAttentionAfterThreadLookRef.current =
     syncRoomAttentionAfterThreadLook;

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
@@ -10,7 +10,7 @@ import {
 import { listOrganizationChatRoomsAction } from "@/components/chat/organization-chat-list.actions";
 import {
   applyRoomReadOverlays,
-  applyRoomReadResultToOverlay,
+  rememberRoomRead,
 } from "@/components/chat/room-read-overlay";
 import type { ChatRoom } from "@/lib/clients/generated/core";
 
@@ -75,7 +75,7 @@ export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
       }
 
       if (detail.room) {
-        applyRoomReadResultToOverlay(detail.room);
+        rememberRoomRead(detail.room);
       }
 
       setRooms((current) =>

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -73,10 +73,7 @@ import {
   listOrganizationChatRoomsAction,
 } from "./organization-chat-list.actions";
 import { partitionRoomsForSidebar } from "./partition-rooms-for-sidebar";
-import {
-  applyRoomReadOverlays,
-  applyRoomReadResultToOverlay,
-} from "./room-read-overlay";
+import { applyRoomReadOverlays, rememberRoomRead } from "./room-read-overlay";
 
 const ORGANIZATION_CHAT_POLL_MS = 15_000;
 
@@ -299,9 +296,8 @@ export function OrganizationChatList({
       }
 
       if (detail.room) {
-        // Dual-baseline: room mark-read may still leave unlooked threads.
-        // Only sticky-clear when the server row is fully clear.
-        applyRoomReadResultToOverlay(detail.room);
+        // Dual-baseline: leftover Participant Thread unread stays on the row.
+        rememberRoomRead(detail.room);
       }
 
       setRoomRows((current) =>
@@ -442,7 +438,7 @@ export function OrganizationChatList({
   }
 
   function handleRoomUpdated(updated: ChatRoom) {
-    applyRoomReadResultToOverlay(updated);
+    rememberRoomRead(updated);
     setRoomRows((current) =>
       applyRoomReadOverlays(
         current.map((room) => (room.id === updated.id ? updated : room)),

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -73,7 +73,11 @@ import {
   listOrganizationChatRoomsAction,
 } from "./organization-chat-list.actions";
 import { partitionRoomsForSidebar } from "./partition-rooms-for-sidebar";
-import { applyRoomReadOverlays, rememberRoomRead } from "./room-read-overlay";
+import {
+  applyRoomReadOverlays,
+  forgetRoomRead,
+  rememberRoomRead,
+} from "./room-read-overlay";
 
 const ORGANIZATION_CHAT_POLL_MS = 15_000;
 
@@ -438,7 +442,9 @@ export function OrganizationChatList({
   }
 
   function handleRoomUpdated(updated: ChatRoom) {
-    rememberRoomRead(updated);
+    if (updated.markedUnread) {
+      forgetRoomRead(updated.id);
+    }
     setRoomRows((current) =>
       applyRoomReadOverlays(
         current.map((room) => (room.id === updated.id ? updated : room)),

--- a/apps/web/src/components/chat/room-read-overlay.test.ts
+++ b/apps/web/src/components/chat/room-read-overlay.test.ts
@@ -111,6 +111,38 @@ describe("room-read-overlay", () => {
     });
   });
 
+  it("keeps leftover overlay after a matching poll so a later stale fetch still overlays", () => {
+    rememberRoomRead(
+      room({
+        unreadCount: 2,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    );
+
+    const caughtUp = applyRoomReadOverlays([
+      room({
+        unreadCount: 2,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    ]);
+    expect(caughtUp[0]).toMatchObject({ unreadCount: 2 });
+
+    const staleAgain = applyRoomReadOverlays([
+      room({
+        unreadCount: 10,
+        unreadMentionCount: 1,
+        markedUnread: false,
+      }),
+    ]);
+    expect(staleAgain[0]).toMatchObject({
+      unreadCount: 2,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    });
+  });
+
   it("optimistically clears stale remount chrome before the server row returns", () => {
     rememberRoomRead(
       room({

--- a/apps/web/src/components/chat/room-read-overlay.test.ts
+++ b/apps/web/src/components/chat/room-read-overlay.test.ts
@@ -135,6 +135,38 @@ describe("room-read-overlay", () => {
     });
   });
 
+  it("keeps a fully-clear overlay after a matching row so a later stale fetch stays read", () => {
+    rememberRoomRead(
+      room({
+        unreadCount: 0,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    );
+
+    const matchingClear = applyRoomReadOverlays([
+      room({
+        unreadCount: 0,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    ]);
+    expect(matchingClear[0]).toMatchObject({ unreadCount: 0 });
+
+    const staleUnread = applyRoomReadOverlays([
+      room({
+        unreadCount: 4,
+        unreadMentionCount: 1,
+        markedUnread: false,
+      }),
+    ]);
+    expect(staleUnread[0]).toMatchObject({
+      unreadCount: 0,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    });
+  });
+
   it("keeps leftover overlay after a matching poll so a later stale fetch still overlays", () => {
     rememberRoomRead(
       room({

--- a/apps/web/src/components/chat/room-read-overlay.test.ts
+++ b/apps/web/src/components/chat/room-read-overlay.test.ts
@@ -111,6 +111,30 @@ describe("room-read-overlay", () => {
     });
   });
 
+  it("does not let a stale fully-clear row wipe leftover thread unread", () => {
+    rememberRoomRead(
+      room({
+        unreadCount: 2,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    );
+
+    const staleFullyClear = applyRoomReadOverlays([
+      room({
+        unreadCount: 0,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    ]);
+
+    expect(staleFullyClear[0]).toMatchObject({
+      unreadCount: 2,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    });
+  });
+
   it("keeps leftover overlay after a matching poll so a later stale fetch still overlays", () => {
     rememberRoomRead(
       room({

--- a/apps/web/src/components/chat/room-read-overlay.test.ts
+++ b/apps/web/src/components/chat/room-read-overlay.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   applyRoomReadOverlays,
-  applyRoomReadResultToOverlay,
   clearRoomReadOverlays,
   forgetRoomRead,
   rememberRoomRead,
@@ -88,8 +87,8 @@ describe("room-read-overlay", () => {
     expect(rows[0]?.markedUnread).toBe(true);
   });
 
-  it("applyRoomReadResultToOverlay only sticky-clears fully clear rooms", () => {
-    applyRoomReadResultToOverlay(
+  it("keeps leftover thread unread on remount, not the stale full count", () => {
+    rememberRoomRead(
       room({
         unreadCount: 2,
         unreadMentionCount: 0,
@@ -97,15 +96,23 @@ describe("room-read-overlay", () => {
       }),
     );
 
-    const stillUnread = applyRoomReadOverlays([
+    const remounted = applyRoomReadOverlays([
       room({
-        unreadCount: 2,
-        unreadMentionCount: 0,
+        unreadCount: 10,
+        unreadMentionCount: 1,
+        markedUnread: true,
       }),
     ]);
-    expect(stillUnread[0]).toMatchObject({ unreadCount: 2 });
 
-    applyRoomReadResultToOverlay(
+    expect(remounted[0]).toMatchObject({
+      unreadCount: 2,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    });
+  });
+
+  it("optimistically clears stale remount chrome before the server row returns", () => {
+    rememberRoomRead(
       room({
         unreadCount: 0,
         unreadMentionCount: 0,
@@ -113,16 +120,42 @@ describe("room-read-overlay", () => {
       }),
     );
 
-    const cleared = applyRoomReadOverlays([
+    const remounted = applyRoomReadOverlays([
       room({
         unreadCount: 4,
         unreadMentionCount: 1,
+        markedUnread: true,
       }),
     ]);
-    expect(cleared[0]).toMatchObject({
+
+    expect(remounted[0]).toMatchObject({
       unreadCount: 0,
       unreadMentionCount: 0,
       markedUnread: false,
+    });
+  });
+
+  it("restores stale unread after a failed mark-read forgets the overlay", () => {
+    rememberRoomRead(
+      room({
+        unreadCount: 0,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    );
+    forgetRoomRead("room-1");
+
+    const remounted = applyRoomReadOverlays([
+      room({
+        unreadCount: 4,
+        unreadMentionCount: 1,
+        markedUnread: false,
+      }),
+    ]);
+
+    expect(remounted[0]).toMatchObject({
+      unreadCount: 4,
+      unreadMentionCount: 1,
     });
   });
 });

--- a/apps/web/src/components/chat/room-read-overlay.ts
+++ b/apps/web/src/components/chat/room-read-overlay.ts
@@ -49,9 +49,9 @@ export function clearRoomReadOverlays(): void {
 
 /**
  * Reapply post-read attention when the incoming list is stale (same or older
- * `updatedAt`). Newer activity drops the overlay. A fully-clear incoming row
- * only drops a fully-clear overlay — leftover Thread unread must not be wiped
- * by a stale empty cache.
+ * `updatedAt`). Newer activity or an explicit forget drops the overlay. A
+ * matching fully-clear row must not drop it — a later stale fetch still needs
+ * the overlay.
  */
 export function applyRoomReadOverlays<T extends RoomAttentionFields>(
   rooms: readonly T[],
@@ -68,19 +68,6 @@ export function applyRoomReadOverlays<T extends RoomAttentionFields>(
 
     const incomingUpdatedAtMs = toUpdatedAtMs(room.updatedAt);
     if (incomingUpdatedAtMs > overlay.updatedAtMs) {
-      overlaysByRoomId.delete(room.id);
-      return room;
-    }
-
-    const overlayFullyClear =
-      overlay.unreadCount === 0 &&
-      overlay.unreadMentionCount === 0 &&
-      overlay.markedUnread === false;
-    const incomingFullyClear =
-      room.unreadCount === 0 &&
-      room.unreadMentionCount === 0 &&
-      room.markedUnread === false;
-    if (overlayFullyClear && incomingFullyClear) {
       overlaysByRoomId.delete(room.id);
       return room;
     }

--- a/apps/web/src/components/chat/room-read-overlay.ts
+++ b/apps/web/src/components/chat/room-read-overlay.ts
@@ -54,9 +54,10 @@ interface RoomAttentionFields {
 }
 
 /**
- * Reapply post-read attention for rooms marked read this session when the
- * incoming list is stale (same or older `updatedAt`). Real new activity
- * (newer `updatedAt`) drops the overlay and trusts the server row.
+ * Reapply post-read attention when the incoming list is stale (same or older
+ * `updatedAt`). Newer activity or a fully-clear server row drops the overlay.
+ * Matching leftover counts must not drop it — a later stale fetch still needs
+ * the overlay.
  */
 export function applyRoomReadOverlays<T extends RoomAttentionFields>(
   rooms: readonly T[],
@@ -78,12 +79,9 @@ export function applyRoomReadOverlays<T extends RoomAttentionFields>(
     }
 
     if (
-      (room.unreadCount === 0 &&
-        room.unreadMentionCount === 0 &&
-        room.markedUnread === false) ||
-      (room.unreadCount === overlay.unreadCount &&
-        room.unreadMentionCount === overlay.unreadMentionCount &&
-        room.markedUnread === overlay.markedUnread)
+      room.unreadCount === 0 &&
+      room.unreadMentionCount === 0 &&
+      room.markedUnread === false
     ) {
       overlaysByRoomId.delete(room.id);
       return room;

--- a/apps/web/src/components/chat/room-read-overlay.ts
+++ b/apps/web/src/components/chat/room-read-overlay.ts
@@ -1,15 +1,18 @@
 /**
- * Session memory for rooms the client has successfully marked read.
+ * Session memory for rooms this client has marked read.
  *
- * Mobile sidebar mounts OrganizationChatList inside a Sheet that unmounts when
- * closed. Mark-read then dispatches `organization-chat-room-read` with no
- * listener, and remount rehydrates from stale RSC props so unread flash back.
- * This overlay survives unmount and is reapplied on every list hydrate/poll.
+ * Mobile Chats unmounts the list while a room is open. Remount hydrates from
+ * stale RSC unread. Overlay survives unmount and is reapplied on every list
+ * hydrate/poll. Stores post-read attention (including leftover Participant
+ * Thread unread), not only a full clear.
  */
 
 interface RoomReadOverlay {
   /** Room `updatedAt` at mark-read time. Newer activity invalidates the overlay. */
   updatedAtMs: number;
+  unreadCount: number;
+  unreadMentionCount: number;
+  markedUnread: boolean;
 }
 
 const overlaysByRoomId = new Map<string, RoomReadOverlay>();
@@ -22,37 +25,20 @@ function toUpdatedAtMs(updatedAt: string | Date): number {
 export function rememberRoomRead(room: {
   id: string;
   updatedAt: string | Date;
+  unreadCount: number;
+  unreadMentionCount: number;
+  markedUnread: boolean;
 }): void {
   overlaysByRoomId.set(room.id, {
     updatedAtMs: toUpdatedAtMs(room.updatedAt),
+    unreadCount: room.unreadCount,
+    unreadMentionCount: room.unreadMentionCount,
+    markedUnread: room.markedUnread,
   });
 }
 
 export function forgetRoomRead(roomId: string): void {
   overlaysByRoomId.delete(roomId);
-}
-
-/**
- * Persist full-clear overlay only when dual-baseline attention is actually
- * clear. Partial room mark-read (top-level only; unlooked threads remain)
- * must forget any sticky overlay so the real unreadCount stays visible.
- */
-export function applyRoomReadResultToOverlay(room: {
-  id: string;
-  updatedAt: string | Date;
-  unreadCount: number;
-  unreadMentionCount: number;
-  markedUnread?: boolean;
-}): void {
-  if (
-    room.unreadCount === 0 &&
-    room.unreadMentionCount === 0 &&
-    room.markedUnread !== true
-  ) {
-    rememberRoomRead(room);
-    return;
-  }
-  forgetRoomRead(room.id);
 }
 
 export function clearRoomReadOverlays(): void {
@@ -68,7 +54,7 @@ interface RoomAttentionFields {
 }
 
 /**
- * Reapply cleared attention for rooms marked read this session when the
+ * Reapply post-read attention for rooms marked read this session when the
  * incoming list is stale (same or older `updatedAt`). Real new activity
  * (newer `updatedAt`) drops the overlay and trusts the server row.
  */
@@ -92,9 +78,12 @@ export function applyRoomReadOverlays<T extends RoomAttentionFields>(
     }
 
     if (
-      room.unreadCount === 0 &&
-      room.unreadMentionCount === 0 &&
-      room.markedUnread === false
+      (room.unreadCount === 0 &&
+        room.unreadMentionCount === 0 &&
+        room.markedUnread === false) ||
+      (room.unreadCount === overlay.unreadCount &&
+        room.unreadMentionCount === overlay.unreadMentionCount &&
+        room.markedUnread === overlay.markedUnread)
     ) {
       overlaysByRoomId.delete(room.id);
       return room;
@@ -102,9 +91,9 @@ export function applyRoomReadOverlays<T extends RoomAttentionFields>(
 
     return {
       ...room,
-      unreadCount: 0,
-      unreadMentionCount: 0,
-      markedUnread: false,
+      unreadCount: overlay.unreadCount,
+      unreadMentionCount: overlay.unreadMentionCount,
+      markedUnread: overlay.markedUnread,
     };
   });
 }

--- a/apps/web/src/components/chat/room-read-overlay.ts
+++ b/apps/web/src/components/chat/room-read-overlay.ts
@@ -22,13 +22,15 @@ function toUpdatedAtMs(updatedAt: string | Date): number {
   return Number.isFinite(ms) ? ms : 0;
 }
 
-export function rememberRoomRead(room: {
+interface RoomAttentionFields {
   id: string;
   updatedAt: string | Date;
   unreadCount: number;
   unreadMentionCount: number;
   markedUnread: boolean;
-}): void {
+}
+
+export function rememberRoomRead(room: RoomAttentionFields): void {
   overlaysByRoomId.set(room.id, {
     updatedAtMs: toUpdatedAtMs(room.updatedAt),
     unreadCount: room.unreadCount,
@@ -45,19 +47,11 @@ export function clearRoomReadOverlays(): void {
   overlaysByRoomId.clear();
 }
 
-interface RoomAttentionFields {
-  id: string;
-  updatedAt: string | Date;
-  unreadCount: number;
-  unreadMentionCount: number;
-  markedUnread: boolean;
-}
-
 /**
  * Reapply post-read attention when the incoming list is stale (same or older
- * `updatedAt`). Newer activity or a fully-clear server row drops the overlay.
- * Matching leftover counts must not drop it — a later stale fetch still needs
- * the overlay.
+ * `updatedAt`). Newer activity drops the overlay. A fully-clear incoming row
+ * only drops a fully-clear overlay — leftover Thread unread must not be wiped
+ * by a stale empty cache.
  */
 export function applyRoomReadOverlays<T extends RoomAttentionFields>(
   rooms: readonly T[],
@@ -78,11 +72,15 @@ export function applyRoomReadOverlays<T extends RoomAttentionFields>(
       return room;
     }
 
-    if (
+    const overlayFullyClear =
+      overlay.unreadCount === 0 &&
+      overlay.unreadMentionCount === 0 &&
+      overlay.markedUnread === false;
+    const incomingFullyClear =
       room.unreadCount === 0 &&
       room.unreadMentionCount === 0 &&
-      room.markedUnread === false
-    ) {
+      room.markedUnread === false;
+    if (overlayFullyClear && incomingFullyClear) {
       overlaysByRoomId.delete(room.id);
       return room;
     }

--- a/docs/adr/0019-room-unread-chrome-follows-history-resolved.md
+++ b/docs/adr/0019-room-unread-chrome-follows-history-resolved.md
@@ -9,8 +9,10 @@
 
 **Why not wait for POST success:** back can happen while the write is in flight; the remounted list would still flash stale unread.
 
-**Why leftover Thread unread stays bold:** [ADR-0013](./0013-thread-unread-is-participant-gated.md). Opening the room does not Look Threads. First paint is leftover-only unread, not the pre-read total and not a fully-read flash.
+**Why leftover Thread unread stays bold:** [ADR-0013](./0013-thread-unread-is-participant-gated.md). Opening the room does not Look Threads. After mark-read returns, first paint is leftover-only unread, not the pre-read total.
 
-**Rejected:** advance last-read on route enter before history exists; on leave; after scroll-to-latest; Look every Thread on room open; optimistic fully-read then snap leftover; Instant Nav list-skeleton rewrite; transcript unread divider; numeric unread on the row.
+**Known limitation:** leftover thread unread is not on the room DTO until POST returns, so in-flight back can paint fully-read then leftover. Zeroing unreadCount immediately is required so the common fully-clear remount does not flash stale unread. Do not keep the pre-read total until POST — that is the jump this ADR removes.
+
+**Rejected:** advance last-read on route enter before history exists; on leave; after scroll-to-latest; Look every Thread on room open; Instant Nav list-skeleton rewrite; transcript unread divider; numeric unread on the row.
 
 **Out of scope:** making `/chat` skip Instant Nav skeleton.

--- a/docs/adr/0019-room-unread-chrome-follows-history-resolved.md
+++ b/docs/adr/0019-room-unread-chrome-follows-history-resolved.md
@@ -1,0 +1,16 @@
+# ADR 0019: Room unread chrome follows history resolved
+
+- Status: Accepted
+- Date: 2026-08-27
+
+**Room last-read** advances when that room’s main transcript **history has resolved on screen** (messages loaded, or the room is confirmed empty)—for every membership-visible room. Unread chrome (list bold, mention badge, Chats tab presence, document title) must match **post-read truth on first paint**, including after mobile back-navigation remounts the list. The client treats the room as locally read at that moment; a failed write restores unread. A failed history load does not advance last-read. Manual mark-as-unread clears when history resolves.
+
+**Why not on leave / list remount:** that is when mobile Chats is rebuilt from stale RSC, so unread snaps after the user already read. Last-read is a read event, not a navigation event.
+
+**Why not wait for POST success:** back can happen while the write is in flight; the remounted list would still flash stale unread.
+
+**Why leftover Thread unread stays bold:** [ADR-0013](./0013-thread-unread-is-participant-gated.md). Opening the room does not Look Threads. First paint is leftover-only unread, not the pre-read total and not a fully-read flash.
+
+**Rejected:** advance last-read on route enter before history exists; on leave; after scroll-to-latest; Look every Thread on room open; optimistic fully-read then snap leftover; Instant Nav list-skeleton rewrite; transcript unread divider; numeric unread on the row.
+
+**Out of scope:** making `/chat` skip Instant Nav skeleton.


### PR DESCRIPTION
## Summary

On mobile, opening an unread room already wrote last-read, but Chats unmounts. Back remounted the list from a stale cache, so **Room unread** chrome (bold, mention badge, Chats tab dot, document title) still looked unread, then snapped.

**Room last-read** now advances when that room’s main transcript **history has resolved** (messages loaded or confirmed empty). The client remembers post-read attention immediately so first paint after back is correct. A failed write restores unread. Leftover **Participant** Thread unread stays bold ([ADR-0013](docs/adr/0013-thread-unread-is-participant-gated.md)).

See [ADR-0019](docs/adr/0019-room-unread-chrome-follows-history-resolved.md).

## Out of scope

- Instant Nav list skeleton
- Transcript unread divider
- Numeric unread on the row
- Looking Threads when opening the room

## Verification

- `pnpm --filter web test` (593 files, 3856 passed)
- `pnpm --filter web typecheck`
- Husky `pnpm check && pnpm typecheck` on commit

Manual (mobile width): open an unread Channel, wait for messages, go back — the row should already be read (bold gone unless leftover Threads remain), no unread flash then snap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room unread indicators while chat history loads, including on mobile remounts.
  * Rooms are marked read only after history loads successfully; failed loads and failed updates restore unread status.
  * Preserved unread thread indicators when room-level unread status is cleared.
  * Prevented delayed updates from overwriting newer read or unread states.

* **Documentation**
  * Clarified how room last-read status differs from thread “Look” status and how unread indicators are resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->