### PR TITLE
fix(calendar): align task filters

### DIFF
--- a/apps/core/src/routes/v1/workspaces/[id]/calendar/get.test.ts
+++ b/apps/core/src/routes/v1/workspaces/[id]/calendar/get.test.ts
@@ -237,6 +237,34 @@ describe("GET /workspaces/{id}/calendar", () => {
     });
   });
 
+  it("filters occurrences by owner and coworker", async () => {
+    const assigneeId = "22222222-2222-7222-8222-222222222222";
+    const response = await requestCalendar(
+      createApp(),
+      `from=${FROM}&to=${TO}&scope=owned&assigneeId=${assigneeId}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(taskScheduleOccurrenceFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          seriesTask: {
+            ownerId: "user_123",
+            assigneeId,
+          },
+        }),
+      }),
+    );
+    expect(taskScheduleOccurrenceCountMock).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        seriesTask: {
+          ownerId: "user_123",
+          assigneeId,
+        },
+      }),
+    });
+  });
+
   it("allows a member to read an organization workspace calendar", async () => {
     workspaceFindUniqueMock.mockResolvedValue({
       userId: null,

--- a/apps/core/src/routes/v1/workspaces/[id]/calendar/get.ts
+++ b/apps/core/src/routes/v1/workspaces/[id]/calendar/get.ts
@@ -87,7 +87,9 @@ interface CalendarCursor {
 }
 
 export interface WorkspaceCalendarReadQuery {
+  assigneeId: string | null;
   from: Date;
+  scope: "owned" | "workspace";
   to: Date;
   cursor: CalendarCursor | null;
   requestedCursor: string | null;
@@ -149,7 +151,9 @@ export function parseWorkspaceCalendarQuery(
 ): WorkspaceCalendarReadQuery {
   const { from, to } = validateRange(query.from, query.to);
   return {
+    assigneeId: query.assigneeId ?? null,
     from,
+    scope: query.scope,
     to,
     cursor: query.cursor ? decodeCursor(query.cursor) : null,
     requestedCursor: query.cursor ?? null,
@@ -165,6 +169,7 @@ function isPersistedOccurrenceCursor(
 
 export async function readWorkspaceCalendar(
   workspaceId: string,
+  userId: string,
   query: WorkspaceCalendarReadQuery,
 ) {
   const { cursor, from, to } = query;
@@ -178,6 +183,14 @@ export async function readWorkspaceCalendar(
       ],
     },
     effectiveScheduledAt: { gte: from, lt: to },
+    ...(query.scope === "owned" || query.assigneeId
+      ? {
+          seriesTask: {
+            ...(query.scope === "owned" ? { ownerId: userId } : {}),
+            ...(query.assigneeId ? { assigneeId: query.assigneeId } : {}),
+          },
+        }
+      : {}),
   };
   const persistedOccurrenceWhere = {
     ...persistedOccurrenceBaseWhere,
@@ -309,6 +322,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     const { items, pagination } = await readWorkspaceCalendar(
       workspaceId,
+      userContext.userId,
       calendarQuery,
     );
 

--- a/apps/core/src/routes/v1/workspaces/calendar/get.ts
+++ b/apps/core/src/routes/v1/workspaces/calendar/get.ts
@@ -46,12 +46,13 @@ const route = withCoworkerContextHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    await requireAuthorizedUserContext(c.var.authContext);
+    const userContext = await requireAuthorizedUserContext(c.var.authContext);
     const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const query = c.req.valid("query");
     const calendarQuery = parseWorkspaceCalendarQuery(query);
     const { items, pagination } = await readWorkspaceCalendar(
       workspaceContext.workspaceId,
+      userContext.userId,
       calendarQuery,
     );
 

--- a/apps/core/src/schemas/workspace-calendar.schema.ts
+++ b/apps/core/src/schemas/workspace-calendar.schema.ts
@@ -23,6 +23,14 @@ export const workspaceCalendarQuerySchema = z
         "Exclusive end of the calendar range, at most 90 days after from",
       example: "2026-07-01T00:00:00.000Z",
     }),
+    scope: z.enum(["owned", "workspace"]).default("workspace").openapi({
+      description: "Whether to show only the caller's tasks or the workspace",
+      example: "workspace",
+    }),
+    assigneeId: z.uuid().optional().openapi({
+      description: "Only occurrences whose series task has this coworker",
+      example: "22222222-2222-7222-8222-222222222222",
+    }),
     cursor: z
       .string()
       .max(512)

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.test.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.test.tsx
@@ -258,7 +258,7 @@ describe("WorkspaceCalendar", () => {
     );
   });
 
-  it("removes blue event blocks and the all-day row from the week view", () => {
+  it("uses month event cards without the all-day row in the week view", () => {
     const { container } = render(
       <NuqsTestingAdapter searchParams="?view=week&date=2026-08-18">
         <WorkspaceCalendar items={ITEMS} initialDate="2026-08-18" />
@@ -271,7 +271,7 @@ describe("WorkspaceCalendar", () => {
     );
     expect(
       container.querySelector(".fc-timegrid-event [role='link']"),
-    ).not.toHaveClass("bg-primary/10");
+    ).toHaveClass("bg-primary/10");
     expect(screen.queryByText("all-day")).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.test.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.test.tsx
@@ -13,7 +13,8 @@ import {
   WorkspaceCalendar,
 } from "./workspace-calendar";
 
-const { getWorkspaceCalendarMock } = vi.hoisted(() => ({
+const { filterDropdownMenuMock, getWorkspaceCalendarMock } = vi.hoisted(() => ({
+  filterDropdownMenuMock: vi.fn(),
   getWorkspaceCalendarMock: vi.fn(),
 }));
 
@@ -32,6 +33,13 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/clients/core.browser.client", () => ({
   coreClient: {
     getWorkspaceCalendar: getWorkspaceCalendarMock,
+  },
+}));
+
+vi.mock("@/components/common/filter-dropdown-menu", () => ({
+  FilterDropdownMenu: (props: unknown) => {
+    filterDropdownMenuMock(props);
+    return <div data-testid="calendar-filters" />;
   },
 }));
 
@@ -125,7 +133,7 @@ describe("WorkspaceCalendar", () => {
     );
   });
 
-  it("renders source and accuracy labels with task navigation", () => {
+  it("renders agenda source details without the approximate-time label", () => {
     render(
       <NuqsTestingAdapter searchParams="?view=agenda&date=2026-08-18">
         <WorkspaceCalendar
@@ -137,40 +145,81 @@ describe("WorkspaceCalendar", () => {
     );
 
     expect(screen.getAllByTestId("calendar-agenda")).toHaveLength(2);
-    expect(screen.getAllByText("Release planning")).toHaveLength(3);
-    expect(screen.getAllByTestId("calendar-source-marker")).toHaveLength(4);
+    expect(screen.getAllByText("Release planning")).toHaveLength(2);
+    expect(screen.getAllByTestId("calendar-source-marker")).toHaveLength(2);
     expect(screen.getAllByText("accuracy.inferred")).toHaveLength(2);
-    expect(screen.getAllByText("accuracy.approximate")).toHaveLength(2);
+    expect(screen.queryByText("accuracy.approximate")).not.toBeInTheDocument();
     expect(
       screen.getAllByRole("link", { name: /Prepare release notes/ })[0],
     ).toBeInTheDocument();
   });
 
-  it("toggles individual catalog sources through the URL", async () => {
-    const user = userEvent.setup();
+  it("uses the task-style scope filter", async () => {
     const onUrlUpdate = vi.fn();
 
     render(
       <NuqsTestingAdapter onUrlUpdate={onUrlUpdate}>
         <WorkspaceCalendar
+          activeOrganizationId="org-1"
+          coworkers={[{ id: "coworker-1", name: "Ada" }]}
           items={ITEMS}
           initialDate="2026-08-18"
-          sources={SOURCES}
         />
       </NuqsTestingAdapter>,
     );
 
-    await user.click(screen.getByRole("button", { name: /Release planning/ }));
+    const props = filterDropdownMenuMock.mock.calls.at(-1)?.[0] as {
+      sections: Array<{
+        id: string;
+        onChange: (value: string | null) => void;
+      }>;
+    };
+    expect(props.sections.map((section) => section.id)).toEqual([
+      "scope",
+      "coworker",
+    ]);
 
-    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled());
+    props.sections.find((section) => section.id === "scope")?.onChange("owned");
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalledTimes(1));
+
     const updates = onUrlUpdate.mock.calls.map(([event]) =>
       event.searchParams.toString(),
     );
-    expect(updates.join("&")).toContain("source=workspace%3Aworkspace-1");
-    expect(screen.getByText("empty.title")).toBeInTheDocument();
+    expect(updates).toContain("scope=owned");
   });
 
-  it("persists view, date, source, status, and coworker filters in the URL", async () => {
+  it("preserves the selected scope when filtering by coworker", async () => {
+    const onUrlUpdate = vi.fn();
+
+    render(
+      <NuqsTestingAdapter searchParams="?scope=owned" onUrlUpdate={onUrlUpdate}>
+        <WorkspaceCalendar
+          activeOrganizationId="org-1"
+          coworkers={[{ id: "coworker-1", name: "Ada" }]}
+          items={ITEMS}
+          initialDate="2026-08-18"
+        />
+      </NuqsTestingAdapter>,
+    );
+
+    const props = filterDropdownMenuMock.mock.calls.at(-1)?.[0] as {
+      sections: Array<{
+        id: string;
+        onChange: (value: string | null) => void;
+      }>;
+    };
+    props.sections
+      .find((section) => section.id === "coworker")
+      ?.onChange("coworker-1");
+
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalledTimes(1));
+    const updates = onUrlUpdate.mock.calls.map(([event]) =>
+      event.searchParams.toString(),
+    );
+    expect(updates).toContain("scope=owned&assigneeId=coworker-1");
+  });
+
+  it("persists view and date in the URL", async () => {
     const user = userEvent.setup();
     const onUrlUpdate = vi.fn();
 
@@ -179,22 +228,12 @@ describe("WorkspaceCalendar", () => {
         searchParams="?view=month&date=2026-08-18"
         onUrlUpdate={onUrlUpdate}
       >
-        <WorkspaceCalendar
-          items={ITEMS}
-          initialDate="2026-08-18"
-          coworkers={[{ id: "coworker-1", name: "Ada" }]}
-          sources={SOURCES}
-        />
+        <WorkspaceCalendar items={ITEMS} initialDate="2026-08-18" />
       </NuqsTestingAdapter>,
     );
 
     await user.click(screen.getByRole("button", { name: "view.week" }));
     await user.click(screen.getByRole("button", { name: "next" }));
-    await user.click(screen.getByRole("button", { name: /Release planning/ }));
-    await user.click(screen.getByLabelText("status.label"));
-    await user.click(screen.getByRole("option", { name: "status.QUEUED" }));
-    await user.click(screen.getByLabelText("coworker.label"));
-    await user.click(screen.getByRole("option", { name: "Ada" }));
 
     await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled());
     const updates = onUrlUpdate.mock.calls.map(([event]) =>
@@ -203,9 +242,6 @@ describe("WorkspaceCalendar", () => {
     const updatedQuery = updates.join("&");
     expect(updatedQuery).toContain("view=week");
     expect(updatedQuery).toContain("date=2026-");
-    expect(updatedQuery).toContain("source=workspace%3Aworkspace-1");
-    expect(updatedQuery).toContain("status=QUEUED");
-    expect(updatedQuery).toContain("coworker=coworker-1");
   });
 
   it("falls back to the month view when a week is requested on mobile", () => {
@@ -265,17 +301,15 @@ describe("WorkspaceCalendar", () => {
       to: new Date("2026-09-01T00:00:00.000Z"),
       cursor: "cursor-2",
       limit: 100,
+      scope: "workspace",
+      assigneeId: undefined,
     });
   });
 
   it("shows an empty state after filters exclude all calendar items", () => {
     render(
-      <NuqsTestingAdapter searchParams="?source=workspace%3Aworkspace-1">
-        <WorkspaceCalendar
-          items={ITEMS}
-          initialDate="2026-08-18"
-          sources={SOURCES}
-        />
+      <NuqsTestingAdapter searchParams="?assigneeId=coworker-2">
+        <WorkspaceCalendar items={ITEMS} initialDate="2026-08-18" />
       </NuqsTestingAdapter>,
     );
 

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.test.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.test.tsx
@@ -258,6 +258,23 @@ describe("WorkspaceCalendar", () => {
     );
   });
 
+  it("removes blue event blocks and the all-day row from the week view", () => {
+    const { container } = render(
+      <NuqsTestingAdapter searchParams="?view=week&date=2026-08-18">
+        <WorkspaceCalendar items={ITEMS} initialDate="2026-08-18" />
+      </NuqsTestingAdapter>,
+    );
+
+    expect(container.querySelector(".fc-timegrid-event")).toHaveClass(
+      "!bg-transparent",
+      "!border-transparent",
+    );
+    expect(
+      container.querySelector(".fc-timegrid-event [role='link']"),
+    ).not.toHaveClass("bg-primary/10");
+    expect(screen.queryByText("all-day")).not.toBeInTheDocument();
+  });
+
   it("loads and renders the next calendar page", async () => {
     const user = userEvent.setup();
     getWorkspaceCalendarMock.mockResolvedValue({

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.test.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.test.tsx
@@ -113,6 +113,18 @@ describe("WorkspaceCalendar", () => {
     expect(screen.getByText("January 2040")).toBeInTheDocument();
   });
 
+  it("uses semantic theme tokens for FullCalendar", () => {
+    render(
+      <NuqsTestingAdapter>
+        <WorkspaceCalendar items={ITEMS} initialDate="2026-08-18" />
+      </NuqsTestingAdapter>,
+    );
+
+    expect(screen.getAllByTestId("calendar-month")[0]).toHaveClass(
+      "workspace-calendar-theme",
+    );
+  });
+
   it("disables forward navigation beyond the supplied calendar horizon", () => {
     render(
       <NuqsTestingAdapter>

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
@@ -145,13 +145,11 @@ function SourceMarker({
 
 function CalendarEvent({
   item,
-  isWeekView,
   onNavigate,
   showDetails,
   source,
 }: {
   item: WorkspaceCalendarItem;
-  isWeekView: boolean;
   onNavigate: () => void;
   showDetails: boolean;
   source: WorkspaceCalendarSource | undefined;
@@ -163,9 +161,7 @@ function CalendarEvent({
     <span
       role="link"
       tabIndex={0}
-      className={`text-foreground flex w-full min-w-0 items-center gap-1 overflow-hidden rounded px-1.5 py-1 text-xs font-medium ${
-        isWeekView ? "" : "bg-primary/10"
-      }`}
+      className="bg-primary/10 text-foreground flex w-full min-w-0 items-center gap-1 overflow-hidden rounded px-1.5 py-1 text-xs font-medium"
       onClick={(event) => {
         event.stopPropagation();
         onNavigate();
@@ -236,7 +232,6 @@ function CalendarView({
           return item ? (
             <CalendarEvent
               item={item}
-              isWeekView={view === "week"}
               onNavigate={() => onNavigate(item.taskId)}
               showDetails={view === "agenda"}
               source={sources.find(

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
@@ -145,11 +145,13 @@ function SourceMarker({
 
 function CalendarEvent({
   item,
+  isWeekView,
   onNavigate,
   showDetails,
   source,
 }: {
   item: WorkspaceCalendarItem;
+  isWeekView: boolean;
   onNavigate: () => void;
   showDetails: boolean;
   source: WorkspaceCalendarSource | undefined;
@@ -161,7 +163,9 @@ function CalendarEvent({
     <span
       role="link"
       tabIndex={0}
-      className="bg-primary/10 text-foreground flex w-full min-w-0 items-center gap-1 overflow-hidden rounded px-1.5 py-1 text-xs font-medium"
+      className={`text-foreground flex w-full min-w-0 items-center gap-1 overflow-hidden rounded px-1.5 py-1 text-xs font-medium ${
+        isWeekView ? "" : "bg-primary/10"
+      }`}
       onClick={(event) => {
         event.stopPropagation();
         onNavigate();
@@ -220,8 +224,11 @@ function CalendarView({
           id: item.id,
           title: item.taskName,
           start: item.scheduledAt.toISOString(),
+          classNames:
+            view === "week" ? ["!bg-transparent", "!border-transparent"] : [],
         }))}
         timeZone={CALENDAR_TIME_ZONE}
+        allDaySlot={false}
         headerToolbar={false}
         height="auto"
         eventContent={(eventInfo) => {
@@ -229,6 +236,7 @@ function CalendarView({
           return item ? (
             <CalendarEvent
               item={item}
+              isWeekView={view === "week"}
               onNavigate={() => onNavigate(item.taskId)}
               showDetails={view === "agenda"}
               source={sources.find(

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
@@ -13,20 +13,17 @@ import {
   startOfMonth,
   startOfWeek,
 } from "date-fns";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Building2, ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useFormatter, useTranslations } from "next-intl";
 import { parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
 import { useState } from "react";
+import {
+  FilterDropdownMenu,
+  type FilterDropdownMenuSection,
+} from "@/components/common/filter-dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { coreClient } from "@/lib/clients/core.browser.client";
 import type {
   WorkspaceCalendarItem,
@@ -47,6 +44,7 @@ interface CalendarCoworker {
 }
 
 interface WorkspaceCalendarProps {
+  activeOrganizationId?: string | null;
   initialDate: string;
   items: WorkspaceCalendarItem[];
   latestDate?: string;
@@ -63,10 +61,9 @@ interface WorkspaceCalendarProps {
 }
 
 const calendarParsers = {
-  coworker: parseAsString.withDefault("all"),
+  assigneeId: parseAsString,
   date: parseAsString,
-  source: parseAsString.withDefault(""),
-  status: parseAsString.withDefault("all"),
+  scope: parseAsStringLiteral(["owned", "workspace"]).withDefault("workspace"),
   view: parseAsStringLiteral(CALENDAR_VIEWS).withDefault("month"),
 };
 
@@ -149,10 +146,12 @@ function SourceMarker({
 function CalendarEvent({
   item,
   onNavigate,
+  showDetails,
   source,
 }: {
   item: WorkspaceCalendarItem;
   onNavigate: () => void;
+  showDetails: boolean;
   source: WorkspaceCalendarSource | undefined;
 }) {
   const t = useTranslations("App.Calendar");
@@ -162,7 +161,7 @@ function CalendarEvent({
     <span
       role="link"
       tabIndex={0}
-      className="bg-primary/10 text-foreground flex min-w-0 items-center gap-1 rounded px-1.5 py-1 text-xs font-medium"
+      className="bg-primary/10 text-foreground flex w-full min-w-0 items-center gap-1 overflow-hidden rounded px-1.5 py-1 text-xs font-medium"
       onClick={(event) => {
         event.stopPropagation();
         onNavigate();
@@ -176,17 +175,16 @@ function CalendarEvent({
       }}
     >
       <SourceMarker source={source} sourceName={sourceName} />
-      <span className="truncate">{item.taskName}</span>
-      <span className="text-muted-foreground shrink-0">{sourceName}</span>
-      {item.sourceAccuracy !== "EXACT" ? (
-        <span className="text-muted-foreground shrink-0">
-          {t(`accuracy.${item.sourceAccuracy.toLowerCase()}`)}
-        </span>
-      ) : null}
-      {item.timeAccuracy === "APPROXIMATE" ? (
-        <span className="text-muted-foreground shrink-0">
-          {t("accuracy.approximate")}
-        </span>
+      <span className="min-w-0 flex-1 truncate">{item.taskName}</span>
+      {showDetails ? (
+        <>
+          <span className="text-muted-foreground shrink-0">{sourceName}</span>
+          {item.sourceAccuracy !== "EXACT" ? (
+            <span className="text-muted-foreground shrink-0">
+              {t(`accuracy.${item.sourceAccuracy.toLowerCase()}`)}
+            </span>
+          ) : null}
+        </>
       ) : null}
     </span>
   );
@@ -232,6 +230,7 @@ function CalendarView({
             <CalendarEvent
               item={item}
               onNavigate={() => onNavigate(item.taskId)}
+              showDetails={view === "agenda"}
               source={sources.find(
                 ({ sourceId }) => sourceId === item.sourceId,
               )}
@@ -252,6 +251,7 @@ function CalendarView({
 }
 
 export function WorkspaceCalendar({
+  activeOrganizationId = null,
   initialDate,
   items,
   latestDate,
@@ -261,6 +261,7 @@ export function WorkspaceCalendar({
   coworkers = [],
 }: WorkspaceCalendarProps) {
   const t = useTranslations("App.Calendar");
+  const tFilters = useTranslations("App.Tasks.Filters");
   const formatDate = useFormatter().dateTime;
   const router = useRouter();
   const [state, setState] = useQueryStates(calendarParsers);
@@ -272,19 +273,10 @@ export function WorkspaceCalendar({
   const latestCalendarDate = latestDate
     ? parseCalendarDate(latestDate, initialDate)
     : null;
-  const visibleSourceIds = state.source ? state.source.split(",") : null;
-  const taskStatuses = [...new Set(loadedItems.map((item) => item.taskStatus))];
   const visibleItems = loadedItems
     .filter(
       (item) =>
-        visibleSourceIds === null || visibleSourceIds.includes(item.sourceId),
-    )
-    .filter(
-      (item) => state.status === "all" || item.taskStatus === state.status,
-    )
-    .filter(
-      (item) =>
-        state.coworker === "all" || item.taskAssigneeId === state.coworker,
+        state.assigneeId === null || item.taskAssigneeId === state.assigneeId,
     )
     .sort(
       (left, right) => left.scheduledAt.getTime() - right.scheduledAt.getTime(),
@@ -314,15 +306,6 @@ export function WorkspaceCalendar({
     void setState({ view }, { shallow: false });
   }
 
-  function handleSourceToggle(sourceId: string) {
-    const selectedSourceIds =
-      visibleSourceIds ?? sources.map((source) => source.sourceId);
-    const nextSourceIds = selectedSourceIds.includes(sourceId)
-      ? selectedSourceIds.filter((id) => id !== sourceId)
-      : [...selectedSourceIds, sourceId];
-    void setState({ source: nextSourceIds.join(",") });
-  }
-
   async function handleLoadMore() {
     if (!nextCursor || !range) {
       return;
@@ -336,6 +319,8 @@ export function WorkspaceCalendar({
         to: range.to,
         cursor: nextCursor,
         limit: pagination?.limit ?? 100,
+        scope: state.scope,
+        assigneeId: state.assigneeId ?? undefined,
       });
       setLoadedItems((currentItems) => [
         ...currentItems,
@@ -350,6 +335,41 @@ export function WorkspaceCalendar({
       setIsLoadingMore(false);
     }
   }
+
+  const filterSections: FilterDropdownMenuSection[] = [
+    ...(activeOrganizationId
+      ? [
+          {
+            id: "scope",
+            label: tFilters("scopeLabel"),
+            icon: Building2,
+            value: state.scope,
+            options: [
+              { value: "workspace", label: tFilters("scopeWorkspace") },
+              { value: "owned", label: tFilters("scopeOwned") },
+            ],
+            onChange: (scope: string | null) =>
+              void setState(
+                { scope: scope === "owned" ? "owned" : "workspace" },
+                { shallow: false },
+              ),
+          },
+        ]
+      : []),
+    {
+      id: "coworker",
+      label: tFilters("coworkerLabel"),
+      icon: Sparkles,
+      value: state.assigneeId,
+      allLabel: tFilters("all"),
+      options: coworkers.map((coworker) => ({
+        value: coworker.id,
+        label: coworker.name,
+      })),
+      onChange: (assigneeId: string | null) =>
+        void setState({ assigneeId }, { shallow: false }),
+    },
+  ];
 
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 pb-6">
@@ -407,65 +427,15 @@ export function WorkspaceCalendar({
             </Button>
           ))}
         </div>
-        <div
-          aria-label={t("source.label")}
-          className="flex flex-wrap gap-1"
-          role="group"
-        >
-          {sources.map((source) => {
-            const isVisible =
-              visibleSourceIds === null ||
-              visibleSourceIds.includes(source.sourceId);
-            return (
-              <Button
-                aria-pressed={isVisible}
-                key={source.sourceId}
-                size="sm"
-                variant={isVisible ? "secondary" : "outline"}
-                onClick={() => handleSourceToggle(source.sourceId)}
-              >
-                <SourceMarker
-                  decorative
-                  source={source}
-                  sourceName={source.displayName}
-                />
-                {source.displayName}
-              </Button>
-            );
-          })}
-        </div>
-        <Select
-          value={state.status}
-          onValueChange={(status) => void setState({ status })}
-        >
-          <SelectTrigger aria-label={t("status.label")} size="sm">
-            <SelectValue placeholder={t("status.all")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t("status.all")}</SelectItem>
-            {taskStatuses.map((status) => (
-              <SelectItem key={status} value={status}>
-                {t(`status.${status}`)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Select
-          value={state.coworker}
-          onValueChange={(coworker) => void setState({ coworker })}
-        >
-          <SelectTrigger aria-label={t("coworker.label")} size="sm">
-            <SelectValue placeholder={t("coworker.all")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t("coworker.all")}</SelectItem>
-            {coworkers.map((coworker) => (
-              <SelectItem key={coworker.id} value={coworker.id}>
-                {coworker.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <FilterDropdownMenu
+          buttonLabel={tFilters("title")}
+          emptyResultsLabel={tFilters("emptyResults")}
+          searchPlaceholder={tFilters("searchPlaceholder")}
+          sections={filterSections}
+          showActiveIndicator={
+            state.scope === "owned" || state.assigneeId !== null
+          }
+        />
       </div>
 
       {visibleItems.length === 0 ? (

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
@@ -225,6 +225,7 @@ function CalendarView({
         }))}
         timeZone={CALENDAR_TIME_ZONE}
         allDaySlot={false}
+        slotEventOverlap={false}
         headerToolbar={false}
         height="auto"
         eventContent={(eventInfo) => {

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.tsx
@@ -210,7 +210,10 @@ function CalendarView({
   }[view];
 
   return (
-    <div className="overflow-x-auto" data-testid={`calendar-${view}`}>
+    <div
+      className="workspace-calendar-theme overflow-x-auto"
+      data-testid={`calendar-${view}`}
+    >
       <FullCalendar
         key={`${getCalendarDayKey(date)}-${view}`}
         plugins={[dayGridPlugin, timeGridPlugin, listPlugin]}

--- a/apps/web/src/app/(app)/calendar/components/workspace-calendar.week-layout.test.tsx
+++ b/apps/web/src/app/(app)/calendar/components/workspace-calendar.week-layout.test.tsx
@@ -1,0 +1,79 @@
+import { render } from "@testing-library/react";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { describe, expect, it, vi } from "vitest";
+import type { WorkspaceCalendarItem } from "@/lib/clients/generated/core";
+
+const fullCalendarMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@fullcalendar/react", () => ({
+  default: ({
+    allDaySlot,
+    initialView,
+    slotEventOverlap,
+  }: FullCalendarProps) => {
+    fullCalendarMock({ allDaySlot, initialView, slotEventOverlap });
+    return null;
+  },
+}));
+
+vi.mock("next-intl", () => ({
+  useFormatter: () => ({ dateTime: () => "" }),
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/components/common/filter-dropdown-menu", () => ({
+  FilterDropdownMenu: () => null,
+}));
+
+import { WorkspaceCalendar } from "./workspace-calendar";
+
+interface FullCalendarProps {
+  allDaySlot?: boolean;
+  initialView?: string;
+  slotEventOverlap?: boolean;
+}
+
+const WEEK_ITEM: WorkspaceCalendarItem = {
+  id: "occurrence-1",
+  taskId: "task-1",
+  taskName: "Prepare release notes",
+  taskStatus: "QUEUED",
+  taskAssigneeId: null,
+  scheduledAt: new Date("2026-08-18T09:00:00.000Z"),
+  originalScheduledAt: new Date("2026-08-18T09:00:00.000Z"),
+  state: "PLANNED",
+  sourceId: "workspace:workspace-1",
+  sourceWorkspaceId: "workspace-1",
+  sourceType: "WORKSPACE",
+  sourceProjectId: null,
+  sourceAccuracy: "EXACT",
+  timeAccuracy: "EXACT",
+};
+
+describe("WorkspaceCalendar week layout", () => {
+  it("puts concurrent timed events in separate lanes", () => {
+    render(
+      <NuqsTestingAdapter searchParams="?view=week">
+        <WorkspaceCalendar initialDate="2026-08-18" items={[WEEK_ITEM]} />
+      </NuqsTestingAdapter>,
+    );
+
+    const weekProps = fullCalendarMock.mock.calls
+      .map(([props]) => props as FullCalendarProps)
+      .find((props) => props.initialView === "timeGridWeek");
+
+    expect(
+      fullCalendarMock.mock.calls.map(
+        ([props]) => (props as FullCalendarProps).initialView,
+      ),
+    ).toContain("timeGridWeek");
+    expect(weekProps).toMatchObject({
+      allDaySlot: false,
+      slotEventOverlap: false,
+    });
+  });
+});

--- a/apps/web/src/app/(app)/calendar/page.tsx
+++ b/apps/web/src/app/(app)/calendar/page.tsx
@@ -18,7 +18,11 @@ import { coworkerService } from "@/lib/services/coworker.service";
 import { taskService } from "@/lib/services/task.service";
 
 interface CalendarPageProps {
-  searchParams: Promise<{ date?: string }>;
+  searchParams: Promise<{
+    assigneeId?: string;
+    date?: string;
+    scope?: string;
+  }>;
 }
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -66,7 +70,7 @@ export default async function CalendarPage({
     notFound();
   }
 
-  const { date } = await searchParams;
+  const { assigneeId, date, scope } = await searchParams;
   const now = new Date();
   const latestCalendarDate = getLatestCalendarDate(now);
   const initialDate = resolveCalendarDate(date, now);
@@ -74,7 +78,9 @@ export default async function CalendarPage({
   const [{ items, pagination }, sources, coworkers] = await Promise.all([
     taskService.getWorkspaceCalendar({
       ...range,
+      assigneeId,
       limit: 100,
+      scope: scope === "owned" ? "owned" : "workspace",
     }),
     taskService.getWorkspaceCalendarSources(),
     coworkerService.listCoworkers().catch(() => []),
@@ -83,7 +89,8 @@ export default async function CalendarPage({
   return (
     <div className="w-full px-2">
       <WorkspaceCalendar
-        key={initialDate}
+        activeOrganizationId={session?.session?.activeOrganizationId ?? null}
+        key={`${initialDate}-${scope ?? "workspace"}-${assigneeId ?? "all"}`}
         initialDate={initialDate}
         items={items}
         latestDate={format(latestCalendarDate, "yyyy-MM-dd")}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -516,6 +516,15 @@
   }
 }
 
+.workspace-calendar-theme {
+  --fc-border-color: var(--border);
+  --fc-list-event-hover-bg-color: var(--accent);
+  --fc-neutral-bg-color: var(--muted);
+  --fc-neutral-text-color: var(--muted-foreground);
+  --fc-page-bg-color: var(--background);
+  --fc-today-bg-color: var(--primary-quinary);
+}
+
 /*
  * Agents full-bleed layout
  *

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -38459,6 +38459,14 @@ export type GetWorkspacesCalendarData = {
          */
         to: Date;
         /**
+         * Whether to show only the caller's tasks or the workspace
+         */
+        scope?: 'owned' | 'workspace';
+        /**
+         * Only occurrences whose series task has this coworker
+         */
+        assigneeId?: string;
+        /**
          * Opaque cursor for the next merged calendar page
          */
         cursor?: string;
@@ -38645,6 +38653,14 @@ export type GetWorkspacesByIdCalendarData = {
          * Exclusive end of the calendar range, at most 90 days after from
          */
         to: Date;
+        /**
+         * Whether to show only the caller's tasks or the workspace
+         */
+        scope?: 'owned' | 'workspace';
+        /**
+         * Only occurrences whose series task has this coworker
+         */
+        assigneeId?: string;
         /**
          * Opaque cursor for the next merged calendar page
          */


### PR DESCRIPTION
## Summary
- replace Calendar source and status controls with Tasks-style Scope and Coworker filters
- filter calendar occurrences in Core so pagination and counts stay correct
- remove the approximate-time label and prevent event content overflow
- make Calendar session organization lookup null-safe

Follow-up to #3998.

## Verification
- `pnpm test`
- `pnpm check`
- `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar filters for task scope: workspace-wide or owned tasks.
  * Added coworker/assignee filtering with URL persistence.
  * Consolidated calendar filters into a single dropdown menu.
  * Improved week-view layout to prevent overlapping events.
  * Updated calendar styling and theme integration for a more consistent appearance.
  * Simplified event details, showing additional information in agenda view.

* **Tests**
  * Added coverage for scope and assignee filtering, URL state, event styling, and week-view layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->