### PR TITLE
fix(drive): size file icons to folder glyphs and enable Tasks grid

### DIFF
--- a/apps/web/src/app/(app)/drive/components/drive-recents-panel.tsx
+++ b/apps/web/src/app/(app)/drive/components/drive-recents-panel.tsx
@@ -28,6 +28,7 @@ import {
 import { DriveListSkeleton } from "@/app/drive/components/drive-list-skeleton";
 import { buildDriveRecentsDayGroups } from "@/app/drive/components/drive-recents-list.utils";
 import {
+  DRIVE_FILE_TYPE_ICON_CLASS,
   driveItemIconWellClass,
   driveItemMetaDesktopClass,
   driveItemMetaMobileClass,
@@ -416,7 +417,9 @@ export function DriveRecentsPanel({
                             actions={driveFileActions}
                           >
                             <div className={driveItemIconWellClass(viewMode)}>
-                              <FileTypeIcon extension={extension || "file"} />
+                              <div className={DRIVE_FILE_TYPE_ICON_CLASS}>
+                                <FileTypeIcon extension={extension || "file"} />
+                              </div>
                             </div>
                             {isEditing ? (
                               <Input
@@ -543,7 +546,9 @@ export function DriveRecentsPanel({
                           }
                         >
                           <div className={driveItemIconWellClass(viewMode)}>
-                            <FileTypeIcon extension={extension || "file"} />
+                            <div className={DRIVE_FILE_TYPE_ICON_CLASS}>
+                              <FileTypeIcon extension={extension || "file"} />
+                            </div>
                           </div>
                           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                             {nameEl}

--- a/apps/web/src/app/(app)/drive/components/drive-view-layout.ts
+++ b/apps/web/src/app/(app)/drive/components/drive-view-layout.ts
@@ -49,9 +49,9 @@ export function driveItemIconWellClass(viewMode: FilesViewMode): string {
     : "flex size-8 shrink-0 items-center justify-center";
 }
 
-/** Matches Lucide Folder `size-5`; flex centers the svg inside the well. */
+/** Matches Lucide Folder `size-5`; flex centers the svg (keeps 40×48 aspect). */
 export const DRIVE_FILE_TYPE_ICON_CLASS =
-  "flex size-5 shrink-0 items-center justify-center [&_svg]:size-5";
+  "flex size-5 shrink-0 items-center justify-center [&_svg]:h-5 [&_svg]:w-auto";
 
 /** Grid: one-line size · date. List: mobile-only row; desktop uses `driveItemMetaDesktopClass`. */
 export function driveItemMetaMobileClass(viewMode: FilesViewMode): string {

--- a/apps/web/src/app/(app)/drive/components/drive-view-layout.ts
+++ b/apps/web/src/app/(app)/drive/components/drive-view-layout.ts
@@ -49,9 +49,9 @@ export function driveItemIconWellClass(viewMode: FilesViewMode): string {
     : "flex size-8 shrink-0 items-center justify-center";
 }
 
-/** Matches Lucide Folder `size-5` so react-file-icon does not fill the well. */
+/** Matches Lucide Folder `size-5`; flex centers the svg inside the well. */
 export const DRIVE_FILE_TYPE_ICON_CLASS =
-  "flex size-5 shrink-0 items-center justify-center overflow-hidden [&>svg]:size-full";
+  "flex size-5 shrink-0 items-center justify-center [&_svg]:size-5";
 
 /** Grid: one-line size · date. List: mobile-only row; desktop uses `driveItemMetaDesktopClass`. */
 export function driveItemMetaMobileClass(viewMode: FilesViewMode): string {

--- a/apps/web/src/app/(app)/drive/components/drive-view-layout.ts
+++ b/apps/web/src/app/(app)/drive/components/drive-view-layout.ts
@@ -49,6 +49,9 @@ export function driveItemIconWellClass(viewMode: FilesViewMode): string {
     : "flex size-8 shrink-0 items-center justify-center";
 }
 
+/** Matches Lucide Folder `size-5` so react-file-icon does not fill the well. */
+export const DRIVE_FILE_TYPE_ICON_CLASS = "size-5 shrink-0";
+
 /** Grid: one-line size · date. List: mobile-only row; desktop uses `driveItemMetaDesktopClass`. */
 export function driveItemMetaMobileClass(viewMode: FilesViewMode): string {
   return viewMode === "grid"

--- a/apps/web/src/app/(app)/drive/components/drive-view-layout.ts
+++ b/apps/web/src/app/(app)/drive/components/drive-view-layout.ts
@@ -50,7 +50,8 @@ export function driveItemIconWellClass(viewMode: FilesViewMode): string {
 }
 
 /** Matches Lucide Folder `size-5` so react-file-icon does not fill the well. */
-export const DRIVE_FILE_TYPE_ICON_CLASS = "size-5 shrink-0";
+export const DRIVE_FILE_TYPE_ICON_CLASS =
+  "flex size-5 shrink-0 items-center justify-center overflow-hidden [&>svg]:size-full";
 
 /** Grid: one-line size · date. List: mobile-only row; desktop uses `driveItemMetaDesktopClass`. */
 export function driveItemMetaMobileClass(viewMode: FilesViewMode): string {

--- a/apps/web/src/app/(app)/drive/drive-page-client.tsx
+++ b/apps/web/src/app/(app)/drive/drive-page-client.tsx
@@ -43,6 +43,7 @@ import { DriveListSkeleton } from "@/app/drive/components/drive-list-skeleton";
 import { DriveRecentsPanel } from "@/app/drive/components/drive-recents-panel";
 import { DriveTasksFilters } from "@/app/drive/components/drive-tasks-filters";
 import {
+  DRIVE_FILE_TYPE_ICON_CLASS,
   driveItemIconWellClass,
   driveItemMetaDesktopClass,
   driveItemMetaMobileClass,
@@ -331,7 +332,7 @@ function DrivePageWorkspace({
   const isRecentsView = !isTasksView && !isBrowseView;
   const primaryView: DrivePrimaryView =
     isBrowseView || isTasksView ? "browse" : "recents";
-  const layoutMode: FilesViewMode = isTasksView ? "list" : filesViewMode;
+  const layoutMode: FilesViewMode = filesViewMode;
   const projectIdParam = searchParams.get("projectId");
   const taskIdParam = searchParams.get("taskId");
   const assigneeIdParam = searchParams.get("assigneeId");
@@ -1259,7 +1260,7 @@ function DrivePageWorkspace({
     document.cookie = serializeFilesViewModeCookie(next);
   }
 
-  const filesViewModeSwitch = !isTasksView ? (
+  const filesViewModeSwitch = (
     <DriveViewModeSwitch
       value={filesViewMode}
       onChange={handleFilesViewModeChange}
@@ -1268,7 +1269,7 @@ function DrivePageWorkspace({
         grid: t("viewGrid"),
       }}
     />
-  ) : null;
+  );
 
   return (
     <div className={cn("w-full px-2", LIST_MOBILE_CREATE_FAB_CLEARANCE)}>
@@ -1804,7 +1805,9 @@ function DrivePageWorkspace({
                         }
                       >
                         <div className={driveItemIconWellClass(layoutMode)}>
-                          <FileTypeIcon extension={extension || "file"} />
+                          <div className={DRIVE_FILE_TYPE_ICON_CLASS}>
+                            <FileTypeIcon extension={extension || "file"} />
+                          </div>
                         </div>
                         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                           {nameEl}
@@ -2003,7 +2006,9 @@ function DrivePageWorkspace({
                       actions={blobActions}
                     >
                       <div className={driveItemIconWellClass(layoutMode)}>
-                        <FileTypeIcon extension={extension || "file"} />
+                        <div className={DRIVE_FILE_TYPE_ICON_CLASS}>
+                          <FileTypeIcon extension={extension || "file"} />
+                        </div>
                       </div>
                       {isEditing ? (
                         <Input

--- a/apps/web/src/app/(app)/drive/page.test.tsx
+++ b/apps/web/src/app/(app)/drive/page.test.tsx
@@ -768,21 +768,34 @@ describe("DrivePage files view mode", () => {
     });
   });
 
-  it("hides the layout switch on the Tasks special folder", async () => {
+  it("shows the layout switch on the Tasks special folder and respects grid", async () => {
+    const user = userEvent.setup();
     searchParams = new URLSearchParams("view=tasks");
     fetchDriveTasksPageMock.mockResolvedValue({
-      items: [],
+      items: [
+        {
+          type: "project" as const,
+          id: "proj_1",
+          name: "Alpha",
+          latestFileUpdatedAt: "2026-08-28T10:00:00.000Z",
+        },
+      ],
       nextCursor: null,
     });
 
     renderDrive();
 
     await waitFor(() => {
-      expect(screen.getByText("tasksEmptyTitle")).toBeVisible();
+      expect(screen.getByText("Alpha")).toBeVisible();
     });
-    expect(
-      screen.queryByTestId("files-view-mode-switch"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("files-view-mode-switch")).toBeVisible();
+    expect(screen.getByTestId("files-layout-list")).toBeVisible();
+
+    await user.click(screen.getByRole("radio", { name: "viewGrid" }));
+
+    expect(screen.getByTestId("files-layout-grid")).toBeVisible();
+    expect(screen.queryByTestId("files-layout-list")).not.toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeVisible();
   });
 
   it("hides task/project path under the filename in grid", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- File-type icons in Drive list/grid use a `flex size-5` wrapper (`DRIVE_FILE_TYPE_ICON_CLASS`) so glyphs center in the icon well like Lucide Folder icons.
- SVG uses `h-5 w-auto` to keep react-file-icon’s 40×48 aspect without stretching.
- Tasks special folder uses the same list/grid layout mode and view switch as Recents/Browse.

## Test plan
- [x] Biome check + typecheck
- [x] Visual: Tasks → file row/card — `flex size-5` wrapper centers SVG in `size-8` / `size-10` wells (geometry: center deltas 0)
- [x] Tasks folder shows list/grid toggle and grid layout

## Proof
[Grid view PDF icon centered in muted well](https://cursor.com/agents/bc-f5d971f8-eac2-4166-bbb2-95fbbf8d1e61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffile-icon-flex-centered-grid.png)
[Close-up of centered file icon in size-10 well](https://cursor.com/agents/bc-f5d971f8-eac2-4166-bbb2-95fbbf8d1e61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffile-icon-well-closeup-grid.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5d971f8-eac2-4166-bbb2-95fbbf8d1e61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5d971f8-eac2-4166-bbb2-95fbbf8d1e61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

