### PR TITLE
fix(soko-bot): stop the nudge sweep and bound tool calls by the turn deadline

### DIFF
--- a/apps/core/src/lib/soko-bot/in-process-runtime.test.ts
+++ b/apps/core/src/lib/soko-bot/in-process-runtime.test.ts
@@ -194,6 +194,39 @@ describe("InProcessSokoBotRuntime", () => {
     ]);
   });
 
+  it("fails a tool call that outlives the turn instead of hanging", async () => {
+    // A Composio request or slow query used to keep the loop alive past the
+    // turn budget until Vercel killed the invocation, leaving the turn on
+    // "Thinking…" until the fifteen-minute watchdog.
+    await new InProcessSokoBotRuntime().createSession({
+      sessionId: null,
+      turnId: TURN_ID,
+      message: "Cancel those tasks",
+      userId: "user_1",
+      sokoBotId: "bot_1",
+      workspaceId: "workspace_1",
+    });
+    await Promise.all(pendingTurns);
+
+    const tools = generateTextMock.mock.calls[0][0].tools;
+    executeToolMock.mockImplementation(() => new Promise(() => {}));
+
+    vi.useFakeTimers();
+    try {
+      const settled = tools.create_task
+        .execute({ name: "x" }, { toolCallId: "call_1" })
+        .then(
+          () => "resolved",
+          (error: Error) => error.message,
+        );
+      await vi.advanceTimersByTimeAsync(95_000);
+
+      await expect(settled).resolves.toMatch(/timed out/i);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("pins inference to the version's region", async () => {
     await new InProcessSokoBotRuntime().createSession({
       sessionId: null,

--- a/apps/core/src/lib/soko-bot/in-process-runtime.ts
+++ b/apps/core/src/lib/soko-bot/in-process-runtime.ts
@@ -75,6 +75,36 @@ const MAX_STEPS = 24;
  */
 const TURN_RUNTIME_BUDGET_MS = 240_000;
 
+/**
+ * A single tool call may not outlive the turn's budget. `abortSignal` on
+ * `generateText` stops the model, not a tool already running: a Composio
+ * request or a slow query kept the loop alive past the budget, Vercel killed
+ * the invocation at `maxDuration`, and the turn sat on "Thinking…" until the
+ * fifteen-minute watchdog because nothing wrote `session.waiting`.
+ */
+const TOOL_CALL_TIMEOUT_MS = 90_000;
+
+async function withTimeout<T>(
+  work: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} timed out after ${ms}ms`)),
+          ms,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 function runtimeEvent(
   type: string,
   data: Record<string, unknown>,
@@ -218,8 +248,15 @@ async function runTurn(
       tools[capability] = tool({
         description: SOKO_BOT_TOOL_DESCRIPTIONS[capability],
         inputSchema: SOKO_BOT_TOOL_INPUT_SCHEMAS[capability],
-        async execute(toolInput: unknown, options: { toolCallId: string }) {
+        async execute(
+          toolInput: unknown,
+          options: { toolCallId: string; abortSignal?: AbortSignal },
+        ) {
           const callId = options.toolCallId;
+          // The turn's deadline reaches the tool, not only the model.
+          if (abortSignal.aborted || options.abortSignal?.aborted) {
+            throw new Error("Soko Bot turn deadline reached");
+          }
           await log.append(
             // The model chose this input; it can carry a key or password, and
             // runtime events outlive the turn.
@@ -233,13 +270,17 @@ async function runTurn(
               ],
             }),
           );
-          const result = await service.executeTool({
-            sessionId,
-            turnId: input.turnId,
+          const result = await withTimeout(
+            service.executeTool({
+              sessionId,
+              turnId: input.turnId,
+              capability,
+              toolCallId: callId,
+              input: toolInput,
+            }),
+            TOOL_CALL_TIMEOUT_MS,
             capability,
-            toolCallId: callId,
-            input: toolInput,
-          });
+          );
           await log.append(
             runtimeEvent("action.result", { name: capability, callId }),
           );

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -16,6 +16,15 @@ import { sokoBotControlPlane } from "@/services/soko-bot-control-plane.service";
 
 /** Hard ceiling for streamText only (not conversation create ≤25s). */
 export const ROOM_COWORKER_TOTAL_MS = 240_000;
+
+/**
+ * Accepting a Soko Bot turn — classify, build the context packet, insert the
+ * row — happens before any turn exists to look at. When that stalled, the
+ * invocation was killed with the placeholder still spinning and nothing in the
+ * admin overview to explain it, because there was no turn. Bounded so the
+ * owner gets a failed reply instead of a "Thinking…" that never ends.
+ */
+const SOKO_BOT_ACCEPT_TIMEOUT_MS = 60_000;
 /** AI SDK stall budget after content has started; content chunks reset this. */
 export const ROOM_COWORKER_CHUNK_MS = 90_000;
 
@@ -1049,7 +1058,7 @@ async function runSokoBotMentionDispatch(params: {
         });
 
   try {
-    const result = await sokoBotControlPlane.startTurn({
+    const accepted = sokoBotControlPlane.startTurn({
       userId: bot.userId,
       workspaceId,
       clientTurnId: `chat:${mentionId}`,
@@ -1062,6 +1071,19 @@ async function runSokoBotMentionDispatch(params: {
         responseMessageId: placeholderId,
         requestedByUserId: isOwner ? null : userId,
       },
+    });
+    let acceptTimer: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      accepted,
+      new Promise<never>((_resolve, reject) => {
+        acceptTimer = setTimeout(
+          () =>
+            reject(new Error("Soko Bot took too long to accept the message")),
+          SOKO_BOT_ACCEPT_TIMEOUT_MS,
+        );
+      }),
+    ]).finally(() => {
+      if (acceptTimer) clearTimeout(acceptTimer);
     });
     if (
       result.reconciliationLeaseToken &&

--- a/apps/core/src/services/soko-bot-integrations.service.ts
+++ b/apps/core/src/services/soko-bot-integrations.service.ts
@@ -521,6 +521,9 @@ export async function runIntegrationTool(
   return execute(integration, slug, args);
 }
 
+/** A Composio call the model is waiting on; well under the turn budget. */
+const COMPOSIO_TIMEOUT_MS = 45_000;
+
 async function executeViaRest(
   integration: ActiveIntegration,
   slug: string,
@@ -548,6 +551,11 @@ async function executeViaRest(
         arguments: args,
         version: "latest",
       }),
+      // Every other external call in Core is bounded; this one was not, and it
+      // is the only unbounded I/O a tool call can reach. A provider that never
+      // answers held the whole turn open until the invocation was killed, which
+      // leaves the turn RUNNING and the chat on "Thinking…".
+      signal: AbortSignal.timeout(COMPOSIO_TIMEOUT_MS),
     },
   );
   const body = (await response.json().catch(() => ({}))) as {

--- a/apps/core/src/services/soko-bot-proactive.service.ts
+++ b/apps/core/src/services/soko-bot-proactive.service.ts
@@ -192,11 +192,12 @@ export async function findAttentionItems(bot: {
       archivedAt: null,
       status: { in: ["RUNNING", "INPUT_REQUIRED", "FAILED"] },
       updatedAt: { gte: new Date(bot.now.getTime() - ATTENTION_MAX_AGE_MS) },
-      ...(bot.followWholeBoard
-        ? {}
-        : {
-            OR: [{ assigneeId: bot.coworkerId }, { id: { in: delegatedIds } }],
-          }),
+      // Nudges stay on work this bot owns or delegated, whatever
+      // `followWholeBoard` says. Following the board is for awareness — it
+      // lets the bot answer when a comment names it. Sweeping every stuck or
+      // failed Task in the workspace made it chase a week of other people's
+      // abandoned work and, now that it can act rather than draft, restart it.
+      OR: [{ assigneeId: bot.coworkerId }, { id: { in: delegatedIds } }],
     },
     select: {
       id: true,


### PR DESCRIPTION
Two production problems seen within an hour of enabling Soko Bot. Proactive is currently paused on production because of the first one.

## The assistant worked through other people's abandoned Tasks

`followWholeBoard` became the default and was backfilled onto existing bots. That flag does more than widen what the bot watches: in `findAttentionItems` it drops the ownership filter entirely, so the bot swept **every** RUNNING, INPUT_REQUIRED or FAILED Task in the workspace, up to seven days old, up to 100 at a time, and nudged each one. Its prompt reads a nudge on failed work as restarting it with guidance. Before autonomy that produced drafts; now it acts.

Nudges stay on work the bot owns or delegated, whatever the flag says. Following the board keeps its real purpose — the bot sees the board and answers when a comment names it — without policing everyone else's work.

## A turn sat on "Thinking…" for eight minutes

The 240s turn budget aborts the **model** call only. The tool executor ignored the abort signal and had no timeout of its own, so a tool that hung kept the loop alive past the budget until Vercel killed the invocation at `maxDuration`. A killed invocation writes neither `turn.failed` nor `session.waiting`, so the turn stayed RUNNING and the console showed "Thinking…" until the fifteen-minute watchdog. The observed 8m01s matches that path.

Tool calls are now bounded at 90s and check the turn deadline before starting, so a hung tool fails as a tool error the model can react to instead of taking the whole turn down. A test hangs a tool and asserts it times out.

## Verification

- `pnpm typecheck` — 19/19 tasks
- `pnpm check` (Biome) — clean
- `pnpm test` — core 4500, web 3871, database 310; all packages green

## Note

Production runtime logs were not retrievable after the fact — Vercel had only the last ~100 rows, none from the turn's window. Diagnosis came from the code paths and the timing. A log drain would make the next one of these answerable from evidence rather than reconstruction.
