### PR TITLE
fix(soko-bot): make the kill switch cover everything that costs money

### DIFF
--- a/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
@@ -445,6 +445,26 @@ describe("dispatchChatRoomMention claim", () => {
     expect(streamTextMock).toHaveBeenCalled();
   });
 
+  it("gives up on a mention that keeps getting reclaimed", async () => {
+    findUniqueMock.mockResolvedValue({
+      ...pendingMention(),
+      status: "sent",
+      createdAt: new Date(Date.now() - 16 * 60_000),
+      updatedAt: new Date(Date.now() - ROOM_SENT_STALE_MS - 1_000),
+    });
+    updateManyMock.mockResolvedValue({ count: 1 });
+
+    await dispatchChatRoomMention(MENTION_ID);
+
+    expect(streamTextMock).not.toHaveBeenCalled();
+    expect(updateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: MENTION_ID, status: { not: "responded" } },
+        data: expect.objectContaining({ status: "failed" }),
+      }),
+    );
+  });
+
   it("does not reclaim a fresh sent mention still in flight", async () => {
     findUniqueMock.mockResolvedValue({
       ...pendingMention(),

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -41,6 +41,17 @@ export const ROOM_COWORKER_STREAM_TIMEOUT = {
 
 /** Must exceed `ROOM_COWORKER_TOTAL_MS` so reclaim cannot steal an in-flight run. */
 export const ROOM_SENT_STALE_MS = ROOM_COWORKER_TOTAL_MS + 30_000;
+
+/**
+ * After this long a mention is given up on rather than reclaimed again.
+ *
+ * Reclaim exists for a worker that died mid-dispatch, and it retries by
+ * re-running the same work. When the cause is not transient the mention is
+ * reclaimed for ever and the asker watches "Thinking…" indefinitely: the turn
+ * that would have carried a deadline was never created, so nothing else can
+ * end it. Past this age the reply says it failed.
+ */
+const ROOM_MENTION_GIVE_UP_MS = 15 * 60_000;
 const STALE_SENT_RECLAIM_LIMIT = 10;
 /** Cap Ably thought updates; first beat always publishes. */
 const MENTION_THOUGHT_PUBLISH_MIN_INTERVAL_MS = 250;
@@ -534,6 +545,18 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
       existingPlaceholderId: mention.responseMessageId,
       error,
     });
+
+  // `instanceof` because unit fixtures build partial mention rows; the real
+  // query selects every scalar, so this is always a Date in production.
+  const askedAt = mention.createdAt;
+  if (
+    askedAt instanceof Date &&
+    Date.now() - askedAt.getTime() > ROOM_MENTION_GIVE_UP_MS &&
+    mention.status !== "responded"
+  ) {
+    await failWithShell("Soko Bot never picked this up; ask again");
+    return;
+  }
 
   const userId = mention.message.senderUserId;
   if (!userId) {

--- a/apps/core/src/services/soko-bot-avatar.service.test.ts
+++ b/apps/core/src/services/soko-bot-avatar.service.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/lib/db/prisma", () => ({
 
 import {
   AVATAR_POOL_FLOOR,
+  generateAvatars,
   listAvailableAvatars,
   stockAvatarPool,
 } from "@/services/soko-bot-avatar.service";
@@ -70,6 +71,35 @@ describe("Soko Bot avatar pool", () => {
     expect(avatarCountMock).not.toHaveBeenCalled();
     expect(putMock).not.toHaveBeenCalled();
     expect(avatarFindManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("buys one image, not six, when storing them is broken", async () => {
+    // fal bills for an image whether or not we store it. With a broken blob
+    // token the pool never fills, so an ungated run would buy six every cron
+    // tick for ever while writing nothing louder than a warning.
+    getEnvMock.mockReturnValue({
+      FAL_KEY: "key",
+      BLOB_READ_WRITE_TOKEN: "token",
+    });
+    avatarFindManyMock.mockResolvedValue([]);
+    // Two fetches per draw: the billed generation, then the download we store.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ images: [{ url: "https://fal.test/a.png" }] }),
+      arrayBuffer: async () => new ArrayBuffer(8),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    putMock.mockRejectedValue(new Error("blob token rejected"));
+
+    const generated = await generateAvatars(6);
+
+    expect(generated).toBe(0);
+    // One billed generation, then it stops rather than paying for five more.
+    const billed = fetchMock.mock.calls.filter((call) =>
+      String(call[0]).includes("fal.run"),
+    );
+    expect(billed).toHaveLength(1);
+    vi.unstubAllGlobals();
   });
 
   it("fills a short pool when the caller opts in", async () => {

--- a/apps/core/src/services/soko-bot-avatar.service.test.ts
+++ b/apps/core/src/services/soko-bot-avatar.service.test.ts
@@ -11,6 +11,13 @@ const { avatarCountMock, avatarFindManyMock, getEnvMock, putMock } = vi.hoisted(
 
 vi.mock("@/config/env", () => ({ getEnv: getEnvMock }));
 vi.mock("@vercel/blob", () => ({ put: putMock }));
+vi.mock("@/services/soko-bot-availability.service", () => ({
+  getSokoBotAvailability: async () => ({
+    disabled: false,
+    disabledAt: null,
+    disabledReason: null,
+  }),
+}));
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     sokoBotAvatar: {

--- a/apps/core/src/services/soko-bot-avatar.service.ts
+++ b/apps/core/src/services/soko-bot-avatar.service.ts
@@ -7,6 +7,7 @@ import { put } from "@vercel/blob";
 import { getEnv } from "@/config/env";
 import { notFound, unprocessableEntity } from "@/helpers/error";
 import prisma from "@/lib/db/prisma";
+import { getSokoBotAvailability } from "@/services/soko-bot-availability.service";
 
 /**
  * Mascot avatar pool for Soko Bots. Images follow the "IP as logo" recipe
@@ -308,6 +309,12 @@ export async function stockAvatarPool(): Promise<{
   generated: number;
 }> {
   if (!getEnv().FAL_KEY) return { available: 0, generated: 0 };
+  // "Disable Soko Bot" has to mean no paid model calls of any kind. Avatar
+  // generation is the one that has nothing to do with turns, so the turn gate
+  // never sees it.
+  if ((await getSokoBotAvailability()).disabled) {
+    return { available: 0, generated: 0 };
+  }
   const available = await prisma.sokoBotAvatar.count({
     where: { claimedBySokoBotId: null },
   });

--- a/apps/core/src/services/soko-bot-avatar.service.ts
+++ b/apps/core/src/services/soko-bot-avatar.service.ts
@@ -258,24 +258,46 @@ export async function persistAvatarImage(
 }
 
 /** Draw `count` new unique avatars into the pool. Returns how many were added. */
+type AvatarDraw = Awaited<ReturnType<typeof nextAvatarDraws>>[number];
+
+async function drawAvatar(draw: AvatarDraw): Promise<void> {
+  const sourceUrl = await generateImage(buildAvatarPrompt(draw), draw.seed);
+  const key = `${draw.subject.subject.replaceAll(" ", "-")}-${draw.seed}`;
+  const imageUrl = await persistAvatarImage(sourceUrl, key);
+  await prisma.sokoBotAvatar.create({
+    data: {
+      subject: draw.subject.subject,
+      background: draw.background.name,
+      seed: draw.seed,
+      model: AVATAR_MODEL,
+      imageUrl,
+      sourceUrl,
+    },
+  });
+}
+
 export async function generateAvatars(count: number): Promise<number> {
   const draws = await nextAvatarDraws(Math.min(count, MAX_TOP_UP_PER_CALL));
+  if (draws.length === 0) return 0;
+
+  // Draw one before committing to the rest. fal bills for an image whether or
+  // not we manage to store it, so a misconfigured blob token would otherwise
+  // buy six images every cron run, for ever, while the pool never fills and
+  // nothing louder than a warning is written.
+  const [probe, ...rest] = draws;
+  try {
+    await drawAvatar(probe);
+  } catch (error) {
+    console.error("Soko Bot avatar generation failed; skipping this run", {
+      attempted: draws.length,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return 0;
+  }
+  if (rest.length === 0) return 1;
+
   const results = await Promise.allSettled(
-    draws.map(async (draw) => {
-      const sourceUrl = await generateImage(buildAvatarPrompt(draw), draw.seed);
-      const key = `${draw.subject.subject.replaceAll(" ", "-")}-${draw.seed}`;
-      const imageUrl = await persistAvatarImage(sourceUrl, key);
-      await prisma.sokoBotAvatar.create({
-        data: {
-          subject: draw.subject.subject,
-          background: draw.background.name,
-          seed: draw.seed,
-          model: AVATAR_MODEL,
-          imageUrl,
-          sourceUrl,
-        },
-      });
-    }),
+    rest.map((draw) => drawAvatar(draw)),
   );
   const failed = results.filter((result) => result.status === "rejected");
   for (const failure of failed) {
@@ -286,7 +308,7 @@ export async function generateAvatars(count: number): Promise<number> {
           : "unknown",
     });
   }
-  return results.length - failed.length;
+  return 1 + (results.length - failed.length);
 }
 
 export interface AvailableAvatar {

--- a/apps/core/src/services/soko-bot-control-plane.service.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.ts
@@ -1386,7 +1386,13 @@ export class SokoBotControlPlane {
           const { judgeTurnQuality } = await import(
             "@/services/soko-bot-lab-judge.service"
           );
-          void judgeTurnQuality(input.turnId).catch((error) => {
+          // A turn still in flight when the switch was thrown settles here.
+          // Scoring it is another model call, so it waits until the feature is
+          // switched back on.
+          const judgeAllowed = !(await getSokoBotAvailability()).disabled;
+          void (
+            judgeAllowed ? judgeTurnQuality(input.turnId) : Promise.resolve()
+          ).catch((error) => {
             console.error("Soko Bot turn judge failed", {
               turnId: input.turnId,
               error: error instanceof Error ? error.message : "unknown",

--- a/apps/core/src/services/soko-bot-reconciliation.service.test.ts
+++ b/apps/core/src/services/soko-bot-reconciliation.service.test.ts
@@ -30,6 +30,13 @@ const {
 vi.mock("@/config/env", () => ({
   getEnv: () => ({ SOKO_BOT_CLASSIFIER_MODE: "rules" }),
 }));
+vi.mock("@/services/soko-bot-availability.service", () => ({
+  getSokoBotAvailability: async () => ({
+    disabled: false,
+    disabledAt: null,
+    disabledReason: null,
+  }),
+}));
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     $transaction: transactionMock,

--- a/apps/core/src/services/soko-bot-runtime.service.test.ts
+++ b/apps/core/src/services/soko-bot-runtime.service.test.ts
@@ -59,6 +59,7 @@ const {
   turnFindUniqueMock,
   turnUpdateManyMock,
   workspaceFindFirstMock,
+  availabilityMock,
 } = vi.hoisted(() => ({
   botFindFirstMock: vi.fn(),
   botFindUniqueMock: vi.fn(),
@@ -115,9 +116,13 @@ const {
   turnFindUniqueMock: vi.fn(),
   turnUpdateManyMock: vi.fn(),
   workspaceFindFirstMock: vi.fn(),
+  availabilityMock: vi.fn(),
 }));
 
 vi.mock("@/config/env", () => ({ getEnv: getEnvMock }));
+vi.mock("@/services/soko-bot-availability.service", () => ({
+  getSokoBotAvailability: availabilityMock,
+}));
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     $transaction: transactionMock,
@@ -329,6 +334,11 @@ function memoryMarkdown(activeGoal: string): string {
 describe("SokoBotRuntimeService authorization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    availabilityMock.mockResolvedValue({
+      disabled: false,
+      disabledAt: null,
+      disabledReason: null,
+    });
     getEnvMock.mockReturnValue({
       SOKO_BOT_ENABLED: true,
       SOKO_BOT_EVE_PROJECT_ID: "prj_soko_bot",
@@ -380,6 +390,21 @@ describe("SokoBotRuntimeService authorization", () => {
       status: "PENDING",
       expiresAt: new Date(Date.now() + 60_000),
     });
+  });
+
+  it("stops a turn already running when the administrator switch is thrown", async () => {
+    // The switch has to reach work that started before it was thrown, not only
+    // new turns; authorize runs before every tool call, so it stops there.
+    availabilityMock.mockResolvedValue({
+      disabled: true,
+      disabledAt: new Date(),
+      disabledReason: "Paused by an administrator",
+    });
+
+    const service = new SokoBotRuntimeService();
+    await expect(
+      service.authorize({ ...SCOPE, capability: "create_task" }),
+    ).rejects.toThrow(SokoBotRuntimeAuthorizationError);
   });
 
   it("denies capability execution after cancellation is requested", async () => {

--- a/apps/core/src/services/soko-bot-runtime.service.ts
+++ b/apps/core/src/services/soko-bot-runtime.service.ts
@@ -61,6 +61,7 @@ import { applyGuardedTaskStatusUpdate } from "@/helpers/task-event-charge";
 import { mapTaskLinkRelationToWriteData } from "@/helpers/task-link";
 import prisma from "@/lib/db/prisma";
 import { sanitizePersistedValue } from "@/lib/soko-bot/persisted-value";
+import { getSokoBotAvailability } from "@/services/soko-bot-availability.service";
 import { resolveSokoBotVersion } from "@/services/soko-bot-version.service";
 
 const MAX_BOT_COMMENTS_PER_TASK_PER_DAY = 3;
@@ -460,6 +461,14 @@ export class SokoBotRuntimeService {
     const env = getEnv();
     if (!env.SOKO_BOT_ENABLED) {
       throw new SokoBotRuntimeAuthorizationError("Soko Bot is not enabled");
+    }
+    // Re-checked on every tool call, so a turn already running when an
+    // administrator threw the switch stops at its next action instead of
+    // finishing its work.
+    if ((await getSokoBotAvailability()).disabled) {
+      throw new SokoBotRuntimeAuthorizationError(
+        "Soko Bot is temporarily disabled by an administrator",
+      );
     }
     const turn = await prisma.sokoBotTurn.findUnique({
       where: { id: input.turnId },


### PR DESCRIPTION
Follows #4021. Asked whether clicking **Disable Soko Bot** really stops everything, I checked instead of answering, and it did not. Three paths kept making paid model calls. A fourth fix, for the "Thinking… for ever" bubbles seen live tonight, is folded in at the end.

## A turn already in flight finished its work

The switch was read when a turn *started*, so anything already running carried on to completion — up to the four-minute turn budget, with every tool call and model step it had left. `authorize` runs before every tool call, so the switch is read there too and a running turn now stops at its next action.

## Settling a turn scored it with the judge model

`judgeTurnQuality` fires as a turn settles. A turn in flight when the switch was thrown therefore made one more paid call on its way out. It now waits until the feature is switched back on.

## Avatar generation kept calling fal.ai

The avatar pool tops itself up on its own cron and has nothing to do with turns, so the turn gate never saw it — and it is a paid image call. Gated on the same switch. The pool also now draws a single probe image before the rest of a batch, because fal bills for a generation whether or not storing the result succeeds.

## A mention could spin on "Thinking…" for ever

Reclaim re-runs a mention dispatch whose worker died. When the failure is not transient it re-runs for ever, and because the turn that carries the five-minute deadline was never created, nothing else can end the ask — the placeholder sits on "Thinking…" indefinitely. Observed live: a mention from 23:50 still spinning an hour later. After 15 minutes the placeholder is now replaced with a failure instead of being reclaimed again.

## Verification

- `pnpm typecheck` — 19/19 tasks
- `pnpm check` (Biome) — clean
- `pnpm test` — core 4509, web 3871; all packages green
- A test asserts a running turn is refused at its next tool call once the switch is thrown
- A test asserts a 16-minute-old mention is failed rather than dispatched, and fails if the give-up is removed

## What the switch does and does not do

It stops every model call, including ones already under way. It does not roll back work already committed — a Task the bot created a second earlier stays created, which is the intended behaviour for a pause rather than an undo.