### PR TITLE
fix(projects): restore mobile list browse with inline counts

### DIFF
--- a/apps/web/src/app/(app)/projects/__tests__/projects-instant-loading-contract.test.ts
+++ b/apps/web/src/app/(app)/projects/__tests__/projects-instant-loading-contract.test.ts
@@ -4,9 +4,10 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+  PROJECTS_BROWSE_DIVIDE_CLASS,
   PROJECTS_BROWSE_LAYOUT_CLASS,
-  PROJECTS_ITEM_LAYOUT_CLASS,
   PROJECTS_LIST_CARD_MIN_H_CLASS,
+  PROJECTS_LIST_ROW_LAYOUT_CLASS,
   PROJECTS_PAGE_SHELL_CLASS,
 } from "@/app/projects/constants";
 
@@ -89,7 +90,7 @@ describe("projects list CLS layout pairing", () => {
     expect(PROJECTS_LIST_CARD_MIN_H_CLASS).toBe("min-h-[320px]");
   });
 
-  it("skeleton and live ProjectListItem use PROJECTS_ITEM_LAYOUT_CLASS", () => {
+  it("skeleton and live ProjectListItem use PROJECTS_LIST_ROW_LAYOUT_CLASS", () => {
     const loading = stripComments(
       readApp("projects/components/projects-loading-view.tsx"),
     );
@@ -97,18 +98,16 @@ describe("projects list CLS layout pairing", () => {
       readApp("projects/components/project-list-item.tsx"),
     );
 
-    expect(loading).toMatch(/PROJECTS_ITEM_LAYOUT_CLASS/);
-    expect(item).toMatch(/PROJECTS_ITEM_LAYOUT_CLASS/);
-    expect(PROJECTS_ITEM_LAYOUT_CLASS).toContain(
-      "[contain-intrinsic-size:auto_148px]",
+    expect(loading).toMatch(/PROJECTS_LIST_ROW_LAYOUT_CLASS/);
+    expect(item).toMatch(/PROJECTS_LIST_ROW_LAYOUT_CLASS/);
+    expect(loading).not.toMatch(/PROJECTS_ITEM_LAYOUT_CLASS/);
+    expect(item).not.toMatch(/PROJECTS_ITEM_LAYOUT_CLASS/);
+    expect(PROJECTS_LIST_ROW_LAYOUT_CLASS).toBe(
+      "[content-visibility:auto] [contain-intrinsic-size:auto_72px]",
     );
-    expect(PROJECTS_ITEM_LAYOUT_CLASS).toContain(
-      "md:[contain-intrinsic-size:auto_72px]",
-    );
-    expect(PROJECTS_ITEM_LAYOUT_CLASS).toContain("[content-visibility:auto]");
   });
 
-  it("skeleton and live browse share PROJECTS_BROWSE_LAYOUT_CLASS", () => {
+  it("skeleton and live browse share PROJECTS_BROWSE_LAYOUT_CLASS + divide", () => {
     const loading = stripComments(
       readApp("projects/components/projects-loading-view.tsx"),
     );
@@ -118,8 +117,12 @@ describe("projects list CLS layout pairing", () => {
 
     expect(loading).toMatch(/PROJECTS_BROWSE_LAYOUT_CLASS/);
     expect(view).toMatch(/PROJECTS_BROWSE_LAYOUT_CLASS/);
-    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("grid-cols-2");
-    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:grid-cols-1");
+    expect(loading).toMatch(/PROJECTS_BROWSE_DIVIDE_CLASS/);
+    expect(view).toMatch(/PROJECTS_BROWSE_DIVIDE_CLASS/);
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("rounded-none");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:rounded-xl");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).not.toContain("grid-cols-2");
+    expect(PROJECTS_BROWSE_DIVIDE_CLASS).toBe("divide-border/50 divide-y px-2");
   });
 
   it("page and Instant shell share PROJECTS_PAGE_SHELL_CLASS", () => {

--- a/apps/web/src/app/(app)/projects/components/project-list-item.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-list-item.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { ProjectListItem } from "@/app/projects/components/project-list-item";
-import { PROJECTS_ITEM_LAYOUT_CLASS } from "@/app/projects/constants";
+import { PROJECTS_LIST_ROW_LAYOUT_CLASS } from "@/app/projects/constants";
 import type { ProjectListItem as ProjectListItemType } from "@/lib/clients/generated/core/types.gen";
 
 const labels = {
@@ -57,17 +57,22 @@ describe("ProjectListItem", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders as a bordered card on mobile and a list row from md up", () => {
+  it("renders as a horizontal list row with no mobile card chrome", () => {
     render(<ProjectListItem project={project} labels={labels} />);
 
     const link = screen.getByRole("link", { name: /Autumn Launch/ });
-    expect(link.className).toContain("border");
-    expect(link.className).toContain("rounded-lg");
-    expect(link.className).toContain("md:border-0");
-    expect(link.className).toContain("p-3");
+    expect(link.className).toContain("flex-row");
+    expect(link.className).toContain("items-center");
+    expect(link.className).toContain("gap-4");
+    expect(link.className).toContain("hover:bg-muted/50");
+    expect(link.className).toContain("rounded-none");
+    expect(link.className).toContain("md:rounded-lg");
+    expect(link.className).not.toContain("border-border/50");
+    expect(link.className).not.toContain("bg-background/60");
+    expect(link.className.split(/\s+/)).not.toContain("border");
 
     const article = link.closest("article");
-    for (const token of PROJECTS_ITEM_LAYOUT_CLASS.split(/\s+/)) {
+    for (const token of PROJECTS_LIST_ROW_LAYOUT_CLASS.split(/\s+/)) {
       expect(article?.className).toContain(token);
     }
   });

--- a/apps/web/src/app/(app)/projects/components/project-list-item.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-list-item.tsx
@@ -1,7 +1,7 @@
 import { Briefcase, ListTodo, type LucideIcon } from "lucide-react";
 import Link from "next/link";
 import { ProjectAvatar } from "@/app/projects/components/project-avatar";
-import { PROJECTS_ITEM_LAYOUT_CLASS } from "@/app/projects/constants";
+import { PROJECTS_LIST_ROW_LAYOUT_CLASS } from "@/app/projects/constants";
 import { previewProjectBriefing } from "@/app/projects/project-briefing";
 import type { ProjectListItem as ProjectListItemType } from "@/lib/clients/generated/core/types.gen";
 import { cn } from "@/lib/utils";
@@ -22,12 +22,12 @@ export function ProjectListItem({ project, labels }: ProjectListItemProps) {
   const briefing = previewProjectBriefing(project.briefing);
 
   return (
-    <article className={PROJECTS_ITEM_LAYOUT_CLASS}>
+    <article className={PROJECTS_LIST_ROW_LAYOUT_CLASS}>
       <Link
         href={`/projects/${project.id}`}
         className={cn(
-          "border-border/50 bg-background/60 flex min-w-0 flex-col gap-2 rounded-lg border p-3 transition-colors active:scale-[0.995]",
-          "md:hover:bg-muted/50 md:-mx-2 md:flex-row md:items-center md:gap-4 md:rounded-lg md:border-0 md:bg-transparent md:px-2 md:py-3",
+          "-mx-2 flex min-w-0 flex-row items-center gap-4 rounded-none px-2 py-3 transition-colors",
+          "hover:bg-muted/50 active:scale-[0.995] md:rounded-lg",
         )}
       >
         <div className="flex min-w-0 flex-1 items-center gap-3">

--- a/apps/web/src/app/(app)/projects/components/project-list-item.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-list-item.tsx
@@ -26,7 +26,7 @@ export function ProjectListItem({ project, labels }: ProjectListItemProps) {
       <Link
         href={`/projects/${project.id}`}
         className={cn(
-          "-mx-2 flex min-w-0 flex-row items-center gap-4 rounded-none px-2 py-3 transition-colors",
+          "flex min-w-0 flex-row items-center gap-4 rounded-none px-2 py-3 transition-colors",
           "hover:bg-muted/50 active:scale-[0.995] md:rounded-lg",
         )}
       >

--- a/apps/web/src/app/(app)/projects/components/projects-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/projects-loading-view.test.tsx
@@ -6,8 +6,10 @@ import {
   ProjectsPageSkeleton,
 } from "@/app/projects/components/projects-loading-view";
 import {
-  PROJECTS_ITEM_LAYOUT_CLASS,
+  PROJECTS_BROWSE_DIVIDE_CLASS,
+  PROJECTS_BROWSE_LAYOUT_CLASS,
   PROJECTS_LIST_CARD_MIN_H_CLASS,
+  PROJECTS_LIST_ROW_LAYOUT_CLASS,
 } from "@/app/projects/constants";
 
 describe("ProjectsPageSkeleton", () => {
@@ -51,19 +53,34 @@ describe("ProjectsLoadingView", () => {
     const { container } = render(<ProjectsLoadingView />);
 
     const browse = screen.getByTestId("projects-loading-browse");
-    expect(browse.className).toContain("grid");
-    expect(browse.className).toContain("grid-cols-2");
-    expect(browse.className).toContain("md:grid-cols-1");
+    for (const token of PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/)) {
+      expect(browse.className).toContain(token);
+    }
     expect(browse.className).toContain(PROJECTS_LIST_CARD_MIN_H_CLASS);
+    expect(browse.className).not.toContain("grid-cols-2");
+    expect(browse.className).toContain("rounded-none");
+    expect(browse.className).toContain("md:rounded-xl");
+
+    const divide = browse.firstElementChild;
+    for (const token of PROJECTS_BROWSE_DIVIDE_CLASS.split(/\s+/)) {
+      expect(divide?.className).toContain(token);
+    }
 
     const items = browse.querySelectorAll("article");
     expect(items.length).toBe(4);
 
     for (const item of items) {
-      const card = item.firstElementChild;
-      expect(card?.className).toContain("border");
-      expect(card?.className).toContain("md:border-0");
-      for (const token of PROJECTS_ITEM_LAYOUT_CLASS.split(/\s+/)) {
+      const row = item.firstElementChild;
+      expect(row?.className).toContain("flex-row");
+      expect(row?.className).toContain("items-center");
+      expect(row?.className).toContain("gap-4");
+      expect(row?.className).toContain("rounded-none");
+      expect(row?.className).not.toContain("border-border/50");
+      expect(row?.className).not.toContain("bg-background/60");
+      expect(row?.className.split(/\s+/)).not.toContain("border");
+      // Avatar + name + briefing + two count pills; no overflow actions column.
+      expect(item.querySelectorAll('[data-slot="skeleton"]').length).toBe(5);
+      for (const token of PROJECTS_LIST_ROW_LAYOUT_CLASS.split(/\s+/)) {
         expect(item.className).toContain(token);
       }
     }

--- a/apps/web/src/app/(app)/projects/components/projects-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/projects-loading-view.test.tsx
@@ -75,6 +75,7 @@ describe("ProjectsLoadingView", () => {
       expect(row?.className).toContain("items-center");
       expect(row?.className).toContain("gap-4");
       expect(row?.className).toContain("rounded-none");
+      expect(row?.className).not.toContain("-mx-2");
       expect(row?.className).not.toContain("border-border/50");
       expect(row?.className).not.toContain("bg-background/60");
       expect(row?.className.split(/\s+/)).not.toContain("border");

--- a/apps/web/src/app/(app)/projects/components/projects-loading-view.tsx
+++ b/apps/web/src/app/(app)/projects/components/projects-loading-view.tsx
@@ -1,8 +1,9 @@
 import { LIST_MOBILE_CREATE_FAB_CLEARANCE } from "@/app/components/mobile-create-fab-geometry";
 import {
+  PROJECTS_BROWSE_DIVIDE_CLASS,
   PROJECTS_BROWSE_LAYOUT_CLASS,
-  PROJECTS_ITEM_LAYOUT_CLASS,
   PROJECTS_LIST_CARD_MIN_H_CLASS,
+  PROJECTS_LIST_ROW_LAYOUT_CLASS,
   PROJECTS_PAGE_SHELL_CLASS,
 } from "@/app/projects/constants";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -43,27 +44,24 @@ export function ProjectsLoadingView() {
           PROJECTS_LIST_CARD_MIN_H_CLASS,
         )}
       >
-        {Array.from({ length: 4 }, (_, index) => (
-          <ProjectListItemSkeleton key={index} />
-        ))}
+        <div className={PROJECTS_BROWSE_DIVIDE_CLASS}>
+          {Array.from({ length: 4 }, (_, index) => (
+            <ProjectListItemSkeleton key={index} />
+          ))}
+        </div>
       </div>
     </div>
   );
 }
 
 /**
- * Match `ProjectListItem` geometry (content-visibility + intrinsic size)
+ * Match `ProjectListItem` row geometry (content-visibility + 72px intrinsic)
  * so Instant swap does not thrash layout metrics.
  */
 function ProjectListItemSkeleton() {
   return (
-    <article className={PROJECTS_ITEM_LAYOUT_CLASS}>
-      <div
-        className={cn(
-          "border-border/50 bg-background/60 flex min-w-0 flex-col gap-2 rounded-lg border p-3",
-          "md:-mx-2 md:flex-row md:items-center md:gap-4 md:rounded-lg md:border-0 md:bg-transparent md:px-2 md:py-3",
-        )}
-      >
+    <article className={PROJECTS_LIST_ROW_LAYOUT_CLASS}>
+      <div className="-mx-2 flex min-w-0 flex-row items-center gap-4 rounded-none px-2 py-3 md:rounded-lg">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <Skeleton className="size-8 shrink-0 rounded-lg" />
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/apps/web/src/app/(app)/projects/components/projects-loading-view.tsx
+++ b/apps/web/src/app/(app)/projects/components/projects-loading-view.tsx
@@ -61,7 +61,7 @@ export function ProjectsLoadingView() {
 function ProjectListItemSkeleton() {
   return (
     <article className={PROJECTS_LIST_ROW_LAYOUT_CLASS}>
-      <div className="-mx-2 flex min-w-0 flex-row items-center gap-4 rounded-none px-2 py-3 md:rounded-lg">
+      <div className="flex min-w-0 flex-row items-center gap-4 rounded-none px-2 py-3 md:rounded-lg">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <Skeleton className="size-8 shrink-0 rounded-lg" />
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/apps/web/src/app/(app)/projects/components/projects-view.tsx
+++ b/apps/web/src/app/(app)/projects/components/projects-view.tsx
@@ -9,6 +9,7 @@ import { ListMobileCreateFab } from "@/app/components/list-mobile-create-fab";
 import { LIST_MOBILE_CREATE_FAB_CLEARANCE } from "@/app/components/mobile-create-fab-geometry";
 import { loadMoreProjects } from "@/app/projects/actions";
 import {
+  PROJECTS_BROWSE_DIVIDE_CLASS,
   PROJECTS_BROWSE_LAYOUT_CLASS,
   PROJECTS_LIST_CARD_MIN_H_CLASS,
 } from "@/app/projects/constants";
@@ -107,13 +108,15 @@ export function ProjectsView({
               PROJECTS_LIST_CARD_MIN_H_CLASS,
             )}
           >
-            {items.map((project) => (
-              <ProjectListItem
-                key={project.id}
-                project={project}
-                labels={{ counts: labels.counts }}
-              />
-            ))}
+            <div className={PROJECTS_BROWSE_DIVIDE_CLASS}>
+              {items.map((project) => (
+                <ProjectListItem
+                  key={project.id}
+                  project={project}
+                  labels={{ counts: labels.counts }}
+                />
+              ))}
+            </div>
           </div>
         ) : showEmptyState ? (
           <ProjectsEmptyState labels={labels.empty} />

--- a/apps/web/src/app/(app)/projects/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/constants.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  PROJECTS_BROWSE_DIVIDE_CLASS,
   PROJECTS_BROWSE_LAYOUT_CLASS,
   PROJECTS_DETAIL_SHELL_CLASS,
   PROJECTS_DETAIL_TOP_CLASS,
   PROJECTS_DETAIL_WORKSPACE_CLASS,
-  PROJECTS_ITEM_LAYOUT_CLASS,
   PROJECTS_LIST_CARD_MIN_H_CLASS,
   PROJECTS_LIST_ROW_LAYOUT_CLASS,
   PROJECTS_PAGE_SHELL_CLASS,
@@ -24,11 +24,13 @@ describe("projects list CLS layout constants", () => {
     expect(PROJECTS_LIST_ROW_LAYOUT_CLASS).toBe(
       "[content-visibility:auto] [contain-intrinsic-size:auto_72px]",
     );
-    expect(PROJECTS_ITEM_LAYOUT_CLASS).toBe(
-      "[content-visibility:auto] [contain-intrinsic-size:auto_148px] md:[contain-intrinsic-size:auto_72px]",
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toBe(
+      "bg-muted/30 border-border/50 -mx-6 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border",
     );
-    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("grid-cols-2");
-    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:grid-cols-1");
+    expect(PROJECTS_BROWSE_DIVIDE_CLASS).toBe("divide-border/50 divide-y px-2");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).not.toContain("grid-cols-2");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("rounded-none");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:rounded-xl");
   });
 });
 

--- a/apps/web/src/app/(app)/projects/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/constants.test.ts
@@ -25,7 +25,7 @@ describe("projects list CLS layout constants", () => {
       "[content-visibility:auto] [contain-intrinsic-size:auto_72px]",
     );
     expect(PROJECTS_BROWSE_LAYOUT_CLASS).toBe(
-      "bg-muted/30 border-border/50 -mx-6 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border",
+      "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border",
     );
     expect(PROJECTS_BROWSE_DIVIDE_CLASS).toBe("divide-border/50 divide-y px-2");
     expect(PROJECTS_BROWSE_LAYOUT_CLASS).not.toContain("grid-cols-2");

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -38,25 +38,24 @@ export const PROJECTS_DETAIL_WORKSPACE_CLASS = "mt-6 space-y-3 px-4 md:px-0";
 export const PROJECTS_LIST_CARD_MIN_H_CLASS = "min-h-[320px]";
 
 /**
- * Primary browse layout: mobile card grid, desktop stacked list chrome.
+ * Primary browse outer chrome: divided list at all breakpoints (Tasks/Drive rhythm).
+ * Square corners on mobile; `md:rounded-xl` + border on desktop.
  * Shared by live `ProjectsView` and Instant skeleton.
  */
 export const PROJECTS_BROWSE_LAYOUT_CLASS =
-  "grid grid-cols-2 gap-3 md:grid-cols-1 md:gap-0 md:divide-y md:divide-border/50 md:overflow-hidden md:rounded-xl md:border md:border-border/50 md:bg-muted/30 md:px-2";
+  "bg-muted/30 border-border/50 -mx-6 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
 
 /**
- * Row geometry shared with Drive list surfaces (72px intrinsic).
- * Prefer `PROJECTS_ITEM_LAYOUT_CLASS` for Projects browse items.
+ * Inner divide wrapper for browse rows. Shared by live list and Instant skeleton.
+ */
+export const PROJECTS_BROWSE_DIVIDE_CLASS = "divide-border/50 divide-y px-2";
+
+/**
+ * Row geometry shared by live `ProjectListItem`, Instant skeleton, and Drive lists
+ * (72px intrinsic).
  */
 export const PROJECTS_LIST_ROW_LAYOUT_CLASS =
   "[content-visibility:auto] [contain-intrinsic-size:auto_72px]";
-
-/**
- * Item geometry for Projects browse (taller cards on mobile, list rows from md).
- * Shared by live `ProjectListItem` and Instant skeleton items.
- */
-export const PROJECTS_ITEM_LAYOUT_CLASS =
-  "[content-visibility:auto] [contain-intrinsic-size:auto_148px] md:[contain-intrinsic-size:auto_72px]";
 
 /**
  * Query param value for GET /jobs and GET /tasks when listing resources

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -43,7 +43,7 @@ export const PROJECTS_LIST_CARD_MIN_H_CLASS = "min-h-[320px]";
  * Shared by live `ProjectsView` and Instant skeleton.
  */
 export const PROJECTS_BROWSE_LAYOUT_CLASS =
-  "bg-muted/30 border-border/50 -mx-6 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
+  "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
 
 /**
  * Inner divide wrapper for browse rows. Shared by live list and Instant skeleton.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Mobile projects browse cancelled main `p-4` with `-mx-6`, so the list sat wider than the shell. Rows also used `-mx-2`, which pulled content past the divide gutter.

## Scope

- `PROJECTS_BROWSE_LAYOUT_CLASS`: `-mx-6` → `-mx-4` (live `data-testid="projects-browse"` and Instant skeleton).
- Drop `-mx-2` from `ProjectListItem` and the matching Instant row skeleton.
- Unit expectations updated to match.

## Blast Radius

Projects index list chrome on mobile only. Desktop keeps `md:mx-0`.

## Verification

- `pnpm --filter web test src/app/(app)/projects/constants.test.ts src/app/(app)/projects/components/projects-loading-view.test.tsx` (12 passed)
- Pre-commit: `pnpm check` + `pnpm typecheck`
- UI proof in progress on `/projects`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c65ffb94-a3f2-49aa-884b-629875631502?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65ffb94-a3f2-49aa-884b-629875631502&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

