### PR TITLE
perf(soko-bot): judge turns with a cheaper model

### DIFF
--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -92,7 +92,7 @@ const baseEnvSchema = z.object({
   /** Optional GitHub token for skill installs (raises the anonymous API rate limit). */
   GITHUB_TOKEN: z.string().min(1).optional(),
   /** Judge model for lab runs and per-turn quality scores (AI Gateway id). */
-  SOKO_BOT_JUDGE_MODEL: z.string().min(1).default("openai/gpt-5.5"),
+  SOKO_BOT_JUDGE_MODEL: z.string().min(1).default("anthropic/claude-haiku-4.5"),
   /** Score every completed turn with the judge model. */
   SOKO_BOT_TURN_JUDGE_ENABLED: z
     .enum(["true", "false"])

--- a/apps/core/src/schemas/soko-bot.schema.ts
+++ b/apps/core/src/schemas/soko-bot.schema.ts
@@ -197,7 +197,7 @@ export const sokoBotTurnSchema = z
     // Named schemas must be unioned with null, not `.nullable()`, or the
     // generated client's transformer breaks.
     qualityVerdict: z.union([sokoBotQualityVerdictSchema, z.null()]).optional(),
-    /** Judge model that graded the turn, e.g. "openai/gpt-5.5". */
+    /** Judge model that graded the turn, e.g. "anthropic/claude-haiku-4.5". */
     qualityModel: z.string().nullable().optional(),
     judgedAt: dateTimeSchema.nullable().optional(),
     userMessage: z.string(),

--- a/docs/soko-bot/implementation-plan.md
+++ b/docs/soko-bot/implementation-plan.md
@@ -814,7 +814,7 @@ from other users' listings (`buildSokoBotVisibilityWhere`).
 
 ## Lab judge (2026-08-25)
 
-Every lab run is graded twice: deterministic checks (route, tools, ids, failed calls) and a judge model (`SOKO_BOT_JUDGE_MODEL`, default `openai/gpt-5.5`, via the AI Gateway; `apps/core/src/services/soko-bot-lab-judge.service.ts`). The judge reads the stored transcript — prompt or coworker trigger, every tool call with input and result, the final answer — against the scenario's `rubric` (in `packages/soko-bot/src/scenarios.ts`) and the shared `SOKO_BOT_JUDGE_RUBRIC`, and returns 1–5 scores for delegation, follow-through, judgment, honesty plus a pass/weak/fail verdict and concrete issues. Honesty is graded against tool results, so any unbacked claim fails the run. Console: `POST /v1/soko-bots/me/lab/judge`; runner: on by default, `--no-judge` to skip.
+Every lab run is graded twice: deterministic checks (route, tools, ids, failed calls) and a judge model (`SOKO_BOT_JUDGE_MODEL`, default `anthropic/claude-haiku-4.5`, via the AI Gateway; `apps/core/src/services/soko-bot-lab-judge.service.ts`). The judge reads the stored transcript — prompt or coworker trigger, every tool call with input and result, the final answer — against the scenario's `rubric` (in `packages/soko-bot/src/scenarios.ts`) and the shared `SOKO_BOT_JUDGE_RUBRIC`, and returns 1–5 scores for delegation, follow-through, judgment, honesty plus a pass/weak/fail verdict and concrete issues. Honesty is graded against tool results, so any unbacked claim fails the run. Console: `POST /v1/soko-bots/me/lab/judge`; runner: on by default, `--no-judge` to skip.
 
 ## Quality scores everywhere (2026-08-26)
 


### PR DESCRIPTION
Every completed turn is scored by the judge (`SOKO_BOT_TURN_JUDGE_ENABLED` is on by default), so the judge model sets the per-turn cost floor. This moves the default from `openai/gpt-5.5` to `anthropic/claude-haiku-4.5`.

## Why Haiku and not something cheaper

I ran all three candidates through the real rubric and schema on three turns — one clearly good, one ambiguous, one that claims something the tool results do not show:

| turn | gpt-5.5 | haiku-4.5 | gemini-3.6-flash |
| --- | --- | --- | --- |
| good (checked status, set a check-in) | 5 | **5** | 5 |
| ambiguous (reported status, chased nobody) | 4 | **4** | 5 |
| dishonest (tool call failed, answer invented) | 1 | **1** | 1 |

Everything agrees at the ends. They only separate in the middle, and that is the part worth paying for: Haiku reproduces gpt-5.5's overall score there, Gemini rates it a clean pass. The honesty cap fires correctly on all three models.

## One model, not two

The lab judge and the per-turn judge deliberately keep sharing `SOKO_BOT_JUDGE_MODEL`. Both write `sokoBotTurn.qualityScore`, and the admin quality overview averages that column and compares it across bot versions — grading some turns with one model and some with another would confound every comparison in that view.

## Verification

- Live probe of all three models against `sokoBotJudgeVerdictSchema` via the AI Gateway; Haiku returns a valid structured verdict (~8s, ~1.4k tokens)
- `pnpm check` (Biome) — clean
- `pnpm --filter core typecheck` — clean
- `pnpm --filter core test` — 4504 passed

## Note for deploy

This changes a **default**. If `SOKO_BOT_JUDGE_MODEL` is set explicitly in the Core production environment, that value still wins and nothing changes until it is unset or updated.

Scores recorded before this lands were produced by gpt-5.5. `qualityModel` is stored per turn so the provenance survives, but the overview's rolling average and the per-version comparison will straddle the switch for the next 30 days.