### PR TITLE
fix(soko-bot): stop dropping the newest exchange from the context packet

### DIFF
--- a/apps/core/src/lib/soko-bot/context-packet.test.ts
+++ b/apps/core/src/lib/soko-bot/context-packet.test.ts
@@ -572,6 +572,37 @@ describe("ContextPacketBuilder", () => {
     }
   });
 
+  it("keeps the newest exchange when trimming a packet over budget", async () => {
+    // Newest first, as the query returns them; the packet renders chronologically.
+    recentTurnFindManyMock.mockResolvedValue(
+      Array.from({ length: 12 }, (_, index) =>
+        recentTurn(`turn-${11 - index}`, "y".repeat(1_200), "y".repeat(2_500)),
+      ),
+    );
+    recentTurnCountMock.mockResolvedValue(12);
+    taskFindManyMock.mockResolvedValue(
+      Array.from({ length: 24 }, (_, index) => ({
+        ...task(`task-${index}`, "界".repeat(2_000)),
+        linksTo: [],
+        _count: { linksTo: 0 },
+      })),
+    );
+    taskCountMock.mockResolvedValue(24);
+
+    const result = await new ContextPacketBuilder().build(buildInput());
+
+    expect(result.byteSize).toBeLessThanOrEqual(
+      SOKO_BOT_CONTEXT_PACKET_MAX_BYTES,
+    );
+    // Something had to go, but the newest exchanges survive, in order.
+    expect(result.packet.recentTurns.length).toBeLessThan(12);
+    expect(result.packet.recentTurns.map((turn) => turn.id).slice(-3)).toEqual([
+      "turn-9",
+      "turn-10",
+      "turn-11",
+    ]);
+  });
+
   it("withholds the owner's private surfaces from a teammate turn", async () => {
     // A teammate mention runs as the owner and answers into the shared room,
     // so the packet must not carry what only the owner should see.

--- a/apps/core/src/lib/soko-bot/context-packet.ts
+++ b/apps/core/src/lib/soko-bot/context-packet.ts
@@ -359,21 +359,61 @@ function serializePacket(packetWithoutHash: ContextPacketWithoutHash) {
   };
 }
 
-function largestTailCollection(
+/**
+ * Collections rendered oldest-first, so the entry to drop is at the front.
+ * Every other collection is ordered most-relevant-first and drops its tail.
+ * `recentTurns` renders chronologically so the model reads the conversation in
+ * order, which puts the newest — and most relevant — exchange last.
+ */
+const OLDEST_FIRST_COLLECTIONS = new Set<PacketCollectionKey>(["recentTurns"]);
+
+/**
+ * Entries kept even when the packet is over budget. Without a floor the turn
+ * entries, being the largest, are chosen first and the whole conversation is
+ * dropped: the bot answers a direct message having forgotten what was just
+ * said. Broken only when nothing else is left to trim.
+ */
+const TRIM_FLOOR: Partial<Record<PacketCollectionKey, number>> = {
+  recentTurns: 3,
+};
+
+function droppableEntry(
   packet: ContextPacketWithoutHash,
+  key: PacketCollectionKey,
+) {
+  const collection = packet[key];
+  return OLDEST_FIRST_COLLECTIONS.has(key) ? collection[0] : collection.at(-1);
+}
+
+function largestDroppableCollection(
+  packet: ContextPacketWithoutHash,
+  respectFloor: boolean,
 ): PacketCollectionKey | null {
   let selected: PacketCollectionKey | null = null;
   let selectedSize = -1;
   for (const key of PACKET_COLLECTION_KEYS) {
-    const tail = packet[key].at(-1);
-    if (!tail) continue;
-    const size = Buffer.byteLength(JSON.stringify(tail), "utf8");
+    if (respectFloor && packet[key].length <= (TRIM_FLOOR[key] ?? 0)) continue;
+    const entry = droppableEntry(packet, key);
+    if (!entry) continue;
+    const size = Buffer.byteLength(JSON.stringify(entry), "utf8");
     if (size > selectedSize) {
       selected = key;
       selectedSize = size;
     }
   }
   return selected;
+}
+
+function dropOneEntry(
+  packet: ContextPacketWithoutHash,
+  key: PacketCollectionKey,
+): ContextPacketWithoutHash {
+  return {
+    ...packet,
+    [key]: OLDEST_FIRST_COLLECTIONS.has(key)
+      ? packet[key].slice(1)
+      : packet[key].slice(0, -1),
+  };
 }
 
 function fitPacketToBudget(
@@ -385,12 +425,11 @@ function fitPacketToBudget(
   let serialized = serializePacket(packetWithoutHash);
 
   while (serialized.byteSize > SOKO_BOT_CONTEXT_PACKET_MAX_BYTES) {
-    const collection = largestTailCollection(packetWithoutHash);
+    const collection =
+      largestDroppableCollection(packetWithoutHash, true) ??
+      largestDroppableCollection(packetWithoutHash, false);
     if (collection) {
-      packetWithoutHash = {
-        ...packetWithoutHash,
-        [collection]: packetWithoutHash[collection].slice(0, -1),
-      };
+      packetWithoutHash = dropOneEntry(packetWithoutHash, collection);
     } else if (packetWithoutHash.memory.markdown !== "# Soko Bot memory") {
       packetWithoutHash = {
         ...packetWithoutHash,


### PR DESCRIPTION
Asked whether bots see earlier messages in a direct message, I went looking. They do — but a trimming bug was throwing that history away, newest first.

## How history reaches the bot

A direct message goes to the model as typed; the conversation itself arrives in the context packet as `recentTurns` — the last 12 turns, each with the owner's message (≤1000 chars) and the bot's answer (≤2000). `chat-room-coworker-dispatch.service.ts` relies on this explicitly: *"Directs are the bot's own conversation: the control plane already rehydrates recent turns."*

## The bug

`fitPacketToBudget` shrinks an over-budget packet by repeatedly dropping the **last** entry of whichever collection has the largest one. That is right for every collection but this one: tasks, projects, jobs, coworkers, agents, and decisions are all ordered most-relevant-first, so their tail is the least important entry. `recentTurns` is deliberately reversed into chronological order so the model reads the conversation forwards — which puts the **newest** exchange at the tail.

So the trimmer deleted the most recent turn first. And because turn entries are the largest things in the packet (up to ~3KB each), `largestTailCollection` kept picking them: the conversation was emptied completely before a single task was dropped.

A test that builds a realistic over-budget packet (24 tasks, 12 full-length turns) shows `recentTurns` arriving at the model as `[]`.

## The fix

- Trim `recentTurns` from the front, so the oldest exchange goes first.
- Keep a floor of three exchanges, broken only when nothing else is left to trim — otherwise a busy workspace can still starve the conversation down to nothing.

## Verification

- New test asserts the three newest turns survive, in order; it returns `[]` without the fix
- `pnpm --filter core test` — 4505 passed
- `pnpm --filter core typecheck`, `pnpm check` — clean

## Scope

Only affects packets over the 48KB budget. Under the budget nothing changes, which is why this was invisible on small workspaces and total on busy ones.