### PR TITLE
feat(soko-bot): v14 teaches the real cost and stops the false spend floor

### DIFF
--- a/apps/core/src/services/soko-bot-control-plane.service.test.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  SOKO_BOT_ROUTE_CAPABILITIES,
   SOKO_BOT_TEAMMATE_CAPABILITIES,
   type SokoBotRuntime,
 } from "@sokosumi/soko-bot";
@@ -779,13 +780,6 @@ describe("SokoBotControlPlane lifecycle", () => {
   });
 
   it("grants a teammate mention only the teammate ceiling", async () => {
-    // A teammate's turn now draws on the owner's daily allowance, so the gate
-    // reads the bot's proactive settings before the turn starts.
-    botFindUniqueOrThrowMock.mockResolvedValue({
-      proactivePaused: false,
-      proactiveDailyLimit: 20,
-      ingestTimezone: "Europe/Berlin",
-    });
     // The bot answers into a shared room, so the owner's private reads must
     // not be on the grant and the packet must be built for a teammate.
     botFindFirstMock.mockResolvedValue(adminBot());
@@ -838,6 +832,50 @@ describe("SokoBotControlPlane lifecycle", () => {
     expect(contextBuilder.build).toHaveBeenCalledWith(
       expect.objectContaining({ audience: "TEAMMATE" }),
     );
+  });
+
+  it("grants a self-started turn the same spend it grants the owner", async () => {
+    // Withholding only `hire_agent` from scheduled turns read as a spend limit
+    // and was not one: assigning a Task to a Coworker bills the owner just as
+    // a hire does, and was never withheld. The cap and the prompt are the
+    // brakes, not a half-closed door.
+    botFindFirstMock.mockResolvedValue(adminBot());
+    botFindUniqueMock.mockResolvedValue(adminBot());
+    turnFindUniqueMock.mockResolvedValue(null);
+    turnFindFirstMock.mockResolvedValue(null);
+    turnCreateMock.mockResolvedValue({
+      id: "turn_scheduled",
+      leaseToken: "turn_lease",
+    });
+    const runtime = runtimeWithReset(vi.fn());
+    runtime.createSession = vi.fn().mockResolvedValue({
+      sessionId: "session_scheduled",
+      runtimeVersion: "eve-test",
+      acceptedAt: "2026-08-18T12:00:00.000Z",
+    });
+    const contextBuilder = {
+      build: vi.fn().mockResolvedValue(builtContext()),
+    } as ContextPacketBuilder;
+
+    await new SokoBotControlPlane(
+      runtime,
+      contextBuilder,
+      new ExternalTurnClassifier(false),
+    ).startTurn({
+      userId: "user_1",
+      workspaceId: "workspace_1",
+      clientTurnId: "client-turn-scheduled",
+      // Routes deterministically to HIRE_AGENT, the one ceiling that carries
+      // `hire_agent` — otherwise the assertion below passes either way.
+      message: "Hire a marketplace agent to produce the competitor teardown.",
+      source: "SCHEDULE",
+    });
+
+    const granted = turnCreateMock.mock.calls[0]?.[0]?.data
+      ?.capabilityNames as string[];
+    expect(turnCreateMock.mock.calls[0]?.[0]?.data?.route).toBe("HIRE_AGENT");
+    expect(granted).toContain("hire_agent");
+    expect(granted).toEqual([...SOKO_BOT_ROUTE_CAPABILITIES.HIRE_AGENT]);
   });
 
   it("grants the owner their route ceiling and a full packet", async () => {

--- a/apps/core/src/services/soko-bot-control-plane.service.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.ts
@@ -1649,42 +1649,17 @@ export class SokoBotControlPlane {
     const version = await resolveSokoBotVersion(
       input.versionId ?? bot.versionId,
     );
-    // A turn with no owner message is composed from untrusted material — mail
-    // subjects, calendar titles, task comments — and the classifier reads that
-    // composed text. Hiring is the one tool that spends real money on a
-    // marketplace, and it executes without approval, so an attacker who can
-    // put the word "hire" in the owner's inbox must not be able to route a
-    // scheduled turn onto it. Autonomy covers starting work the owner already
-    // pays for; buying more is still theirs to ask for.
-    // A teammate mentioning the bot spends the OWNER's credits, and nothing in
-    // chat limits how often they may do it. Their turns draw on the owner's
-    // daily allowance so the bill has a ceiling its owner set.
-    if (requestedByTeammate) {
-      const { proactiveGate } = await import(
-        "@/services/soko-bot-proactive.service"
-      );
-      const gate = await proactiveGate(bot.id);
-      // Only the allowance: a pause means "stop what you start on your own",
-      // which a teammate asking a question is not.
-      if (!gate.ok && gate.reason === "daily-limit") {
-        throw new SokoBotBusyError(
-          "This Soko Bot has reached its owner's daily limit",
-        );
-      }
-    }
-    // ADMIN_RETRY replays the original message verbatim — the same untrusted
-    // mail or schedule text — so it must not restore what that text was
-    // denied the first time.
-    const selfStarted =
-      input.source === "SCHEDULE" ||
-      input.source === "INGEST" ||
-      input.source === "EVENT" ||
-      input.source === "ADMIN_RETRY";
+    // Self-started turns keep every capability of their route, hiring
+    // included. Withholding only `hire_agent` read as a spend limit and was
+    // not one: assigning a Task to a Coworker bills the owner just as a hire
+    // does, and stayed available throughout — so untrusted mail text that
+    // could route a scheduled turn onto a purchase could always reach that
+    // path instead. What bounds the spend is the owner's daily cap and pause,
+    // and what tempers it is the version prompt, which now weighs delegation
+    // and hiring alike rather than calling delegation free.
     const routeCapabilities = SOKO_BOT_ROUTE_CAPABILITIES[
       classification.classification.route
-    ].filter(
-      (capability) => !(selfStarted && capability === "hire_agent"),
-    ) as readonly SokoBotCapability[];
+    ] as readonly SokoBotCapability[];
     const capabilities = applyVersionCapabilities(
       version,
       (requestedByTeammate

--- a/apps/core/src/services/soko-bot-proactive.service.test.ts
+++ b/apps/core/src/services/soko-bot-proactive.service.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { botFindUniqueOrThrowMock, turnCountMock, getEnvMock } = vi.hoisted(
+  () => ({
+    botFindUniqueOrThrowMock: vi.fn(),
+    turnCountMock: vi.fn(),
+    getEnvMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    sokoBot: { findUniqueOrThrow: botFindUniqueOrThrowMock },
+    sokoBotTurn: { count: turnCountMock },
+  },
+}));
+
+vi.mock("@/config/env", () => ({ getEnv: getEnvMock }));
+
+vi.mock("@/services/soko-bot-integrations.service", () => ({
+  activeIntegrationsForBot: vi.fn(),
+  fetchCalendarEvents: vi.fn(),
+  fetchInboxMessages: vi.fn(),
+}));
+
+import { proactiveGate } from "./soko-bot-proactive.service";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getEnvMock.mockReturnValue({ SOKO_BOT_PROACTIVE_PAUSED: false });
+  botFindUniqueOrThrowMock.mockResolvedValue({
+    userId: "user-1",
+    proactivePaused: false,
+    proactiveDailyLimit: 20,
+    ingestTimezone: "Europe/Vienna",
+  });
+  turnCountMock.mockResolvedValue(0);
+});
+
+describe("proactiveGate", () => {
+  it("counts only turns the bot started by itself", async () => {
+    await proactiveGate("bot-1", new Date("2026-08-29T12:00:00.000Z"));
+
+    const where = turnCountMock.mock.calls[0]?.[0]?.where;
+    expect(where.source).toEqual({ in: ["SCHEDULE", "EVENT", "INGEST"] });
+    // A teammate mentioning the bot is a person asking a question, not work
+    // the bot decided to do; it must not draw on the unprompted allowance.
+    expect(JSON.stringify(where)).not.toContain("requestedByUserId");
+  });
+
+  it("refuses once the daily allowance is spent", async () => {
+    turnCountMock.mockResolvedValue(20);
+
+    const gate = await proactiveGate("bot-1");
+
+    expect(gate).toMatchObject({ ok: false, reason: "daily-limit", limit: 20 });
+  });
+
+  it("refuses while the owner has paused it", async () => {
+    botFindUniqueOrThrowMock.mockResolvedValue({
+      userId: "user-1",
+      proactivePaused: true,
+      proactiveDailyLimit: 20,
+      ingestTimezone: "Europe/Vienna",
+    });
+
+    expect(await proactiveGate("bot-1")).toMatchObject({
+      ok: false,
+      reason: "paused",
+    });
+  });
+});

--- a/apps/core/src/services/soko-bot-proactive.service.ts
+++ b/apps/core/src/services/soko-bot-proactive.service.ts
@@ -71,19 +71,10 @@ export async function proactiveGate(
       createdAt: { gte: localDayStart(now, bot.ingestTimezone) },
       // Behaviour-lab turns are ours, not the owner's budget.
       clientTurnId: { not: { startsWith: "lab:" } },
-      OR: [
-        { source: { in: ["SCHEDULE", "EVENT", "INGEST"] } },
-        // A teammate's mention spends the owner's credits as surely as a turn
-        // the bot starts itself, and chat imposes no limit of its own. Without
-        // this the teammate check compares against a counter its own turns
-        // never increment.
-        {
-          AND: [
-            { requestedByUserId: { not: null } },
-            { requestedByUserId: { not: bot.userId } },
-          ],
-        },
-      ],
+      // Only what the bot decided to do by itself. A teammate mentioning it in
+      // a shared room is a person asking a question, the same as the owner
+      // typing one, and does not draw on the allowance for unprompted work.
+      source: { in: ["SCHEDULE", "EVENT", "INGEST"] },
     },
   });
   const limit = bot.proactiveDailyLimit;

--- a/packages/database/prisma/migrations/20260829190000_soko_bot_default_version_v14/migration.sql
+++ b/packages/database/prisma/migrations/20260829190000_soko_bot_default_version_v14/migration.sql
@@ -1,0 +1,22 @@
+-- v14 is v13's autonomy with an honest cost model: hiring an Agent and
+-- assigning a Task to a Coworker both spend the owner's credits, so both are
+-- weighed before starting. v13 called delegation free while the runtime
+-- withheld the hire, which pointed the bot's caution at the one path it could
+-- not take and waved through the one it could.
+--
+-- Every bot on a built-in version moves, per the owner's request that v14 be
+-- the default for existing assistants too. Bots pinned to an authored
+-- (custom-written) version keep it: that pin is a deliberate choice rather
+-- than an artefact of when the bot was created.
+UPDATE "orchestrator"
+SET "versionId" = 'v14'
+WHERE "versionId" IS NULL
+   OR "versionId" NOT IN (SELECT "slug" FROM "soko_bot_authored_version");
+
+UPDATE "soko_bot_setting"
+SET "defaultVersionId" = 'v14'
+WHERE "id" = 'singleton'
+  AND (
+    "defaultVersionId" IS NULL
+    OR "defaultVersionId" NOT IN (SELECT "slug" FROM "soko_bot_authored_version")
+  );

--- a/packages/soko-bot/src/__tests__/versions.test.ts
+++ b/packages/soko-bot/src/__tests__/versions.test.ts
@@ -20,6 +20,16 @@ describe("versions", () => {
     }
   });
 
+  it("tell the default version that delegating work costs money", () => {
+    const prompt = getSokoBotVersion(DEFAULT_SOKO_BOT_VERSION_ID).systemPrompt;
+    // v13 said "a Task assigned to an existing Coworker is not [expensive]"
+    // while the runtime withheld the hire, aiming the bot's caution at the one
+    // spend path it could not take and waving through the one it could.
+    expect(prompt).toMatch(/assigning a Task to a Coworker/i);
+    expect(prompt).toMatch(/never free/i);
+    expect(prompt).not.toMatch(/assigned to an existing Coworker is not/i);
+  });
+
   it("fall back to the default for unknown ids", () => {
     expect(getSokoBotVersion(null).id).toBe(DEFAULT_SOKO_BOT_VERSION_ID);
     expect(getSokoBotVersion("nope").id).toBe(DEFAULT_SOKO_BOT_VERSION_ID);

--- a/packages/soko-bot/src/versions/index.ts
+++ b/packages/soko-bot/src/versions/index.ts
@@ -19,6 +19,7 @@ import { v10 } from "./v10.js";
 import { v11 } from "./v11.js";
 import { v12 } from "./v12.js";
 import { v13 } from "./v13.js";
+import { v14 } from "./v14.js";
 
 /** Newest last. To iterate, add `vN.ts` and append it here. */
 export const SOKO_BOT_VERSIONS: readonly SokoBotVersion[] = [
@@ -35,8 +36,9 @@ export const SOKO_BOT_VERSIONS: readonly SokoBotVersion[] = [
   v11,
   v12,
   v13,
+  v14,
 ];
-export const DEFAULT_SOKO_BOT_VERSION_ID = "v13";
+export const DEFAULT_SOKO_BOT_VERSION_ID = "v14";
 
 export type { SokoBotSkill, SokoBotVersion };
 export { getSokoBotSkill, SOKO_BOT_SKILLS };

--- a/packages/soko-bot/src/versions/v14.ts
+++ b/packages/soko-bot/src/versions/v14.ts
@@ -1,0 +1,35 @@
+import type { SokoBotVersion } from "./types.js";
+import { v1 } from "./v1.js";
+
+/**
+ * v13's autonomy with an honest cost model. v13 told the bot that hires were
+ * expensive and that "a Task assigned to an existing Coworker is not", while
+ * the runtime stripped `hire_agent` from the very turns the prompt pointed at
+ * it. Delegation bills the owner too, so the caution belonged on both paths
+ * rather than on the one the bot could not reach.
+ */
+export const v14: SokoBotVersion = {
+  ...v1,
+  id: "v14",
+  name: "v14 · Autonomous, honest cost, Gemini 3.6 Flash, EU",
+  createdAt: "2026-08-29",
+  summary:
+    "v13's autonomy with a corrected cost model: hiring an Agent and assigning a Task to a Coworker both spend the owner's credits, so both are weighed before starting and either can be worth asking about first.",
+  model: "google/gemini-3.6-flash",
+  inferenceRegion: "eu",
+  systemPrompt: `${v1.systemPrompt}
+# Autonomy
+
+These rules supersede any earlier guidance that limits self-started turns to drafts.
+
+A. On a turn with no owner message (Context \`trigger.source\` of \`SCHEDULE\`, \`INGEST\`, or \`EVENT\`) you may start work, not only draft it: create a READY Task, assign it, adjust a schedule, or hire when the case is clear.
+
+B. Act only where you can name the benefit to this owner in one sentence, grounded in the Context packet or memory — a meeting on their calendar that needs preparing, research they asked for that has an obvious next artefact, work of theirs that has stalled. Never start work to appear busy. Doing nothing is the correct answer most of the time; when nothing meets that bar, answer exactly \`Nothing to add.\` and stop.
+
+C. Estimate the cost before you start, and know what actually costs money. Hiring a Marketplace Agent spends the owner's credits, and so does assigning a Task to a Coworker — delegating work is never free, and a long multi-step job costs more than a short one. Reading, schedules, memory, chat, and a Task you leave unassigned cost nothing. When your estimate says the work is expensive, do not start it — describe what you would do, say roughly what you think it would cost and why, and ask the owner in their chat. This is your judgement, not a fixed threshold: prefer asking when unsure, and prefer asking about anything you would not be comfortable paying for yourself.
+
+D. Anything you start on your own goes in the owner's chat in the same turn: what you started, the ids, why it was worth doing now, and what it will cost if you know. Never start work silently.
+
+E. One initiative per turn. If several things look worth doing, start the most valuable one and mention the rest in the same message so the owner can choose.
+`,
+};


### PR DESCRIPTION
## The problem

v13's autonomy rule told the bot to weigh cost before starting work — and then told it the wrong thing about what costs money:

> Marketplace Agent hires and long multi-step jobs are expensive; **a Task assigned to an existing Coworker is not.**

Assigning a task to a Coworker carries a credit debit. Meanwhile the control plane stripped `hire_agent` from every self-started turn, so the bot's caution was pointed at a tool it could not reach while the spend path it *could* reach was waved through as free. Rule A even instructed it to "hire when the case is clear" — an action the runtime forbade.

The strip read as a spend limit and was not one. It never closed the injection vector either: untrusted mail text that could route a scheduled turn onto a purchase could always reach `create_task` + `assign_task` instead.

## Changes

**Self-started turns keep their full route ceiling**, hiring included. What bounds spend is the owner's daily cap and pause; what tempers it is the prompt.

**v14** rewrites the cost rule so the bot understands the real shape:

> Hiring a Marketplace Agent spends the owner's credits, and so does assigning a Task to a Coworker — delegating work is never free, and a long multi-step job costs more than a short one. Reading, schedules, memory, chat, and a Task you leave unassigned cost nothing. […] prefer asking about anything you would not be comfortable paying for yourself.

**Teammate mentions no longer count against the proactive allowance.** A colleague asking the bot a question is not work the bot decided to do. The gate that refused teammates at the daily cap is removed with the counter — leaving it would refuse them against a number their own turns no longer contribute to.

**Migration** moves every bot on a built-in version, and the promoted default, to v14. Bots pinned to an authored version keep it: that pin is deliberate.

## Verification

- New test asserts a `SCHEDULE` turn classified to `HIRE_AGENT` is granted `hire_agent`; it fails when the strip is restored
- New `proactiveGate` tests (the service had none) pin that only `SCHEDULE`/`EVENT`/`INGEST` count, and that pause and cap still refuse
- New version test asserts the default prompt says delegation is never free, and no longer says a Coworker task is not expensive
- `pnpm --filter core test` — 4508 passed; `@sokosumi/soko-bot` — 180 passed
- `pnpm check`, `pnpm --filter core typecheck` — clean

## Worth knowing

Teammate mentions are now **uncapped** on the owner's credits — nothing in chat limits how often a colleague may mention someone's bot. That is the intended change, but it removes the only ceiling that existed on that path.

Connected-account writes (`run_integration_tool`) on self-started turns are deliberately left as they are.