### PR TITLE
fix(soko-bot): stop a direct room becoming standing permission

### DIFF
--- a/apps/core/src/services/soko-bot-runtime.service.test.ts
+++ b/apps/core/src/services/soko-bot-runtime.service.test.ts
@@ -8,6 +8,7 @@ const {
   botFindUniqueMock,
   chatRoomFindFirstMock,
   chatRoomDeleteManyMock,
+  chatRoomUserMemberFindFirstMock,
   workspaceFindUniqueMock,
   chatRoomFindManyMock,
   chatMessageFindManyMock,
@@ -77,6 +78,7 @@ const {
   botFindUniqueMock: vi.fn(),
   chatRoomFindFirstMock: vi.fn(),
   chatRoomDeleteManyMock: vi.fn(),
+  chatRoomUserMemberFindFirstMock: vi.fn(),
   workspaceFindUniqueMock: vi.fn(),
   chatRoomFindManyMock: vi.fn(),
   chatMessageFindManyMock: vi.fn(),
@@ -160,6 +162,7 @@ vi.mock("@/lib/db/prisma", () => ({
       findMany: chatRoomFindManyMock,
       deleteMany: chatRoomDeleteManyMock,
     },
+    chatRoomUserMember: { findFirst: chatRoomUserMemberFindFirstMock },
     chatRoomMessage: {
       findMany: chatMessageFindManyMock,
       count: chatMessageCountMock,
@@ -2398,7 +2401,11 @@ describe("post_chat chain depth", () => {
     getEnvMock.mockReturnValue({ SOKO_BOT_ENABLED: true });
     botFindUniqueMock.mockResolvedValue({ coworker: { id: "cow_self" } });
     workspaceFindUniqueMock.mockResolvedValue({ organizationId: "org_1" });
-    chatRoomFindFirstMock.mockResolvedValue({ id: "room_1", name: "Launch" });
+    chatRoomFindFirstMock.mockResolvedValue({
+      id: "room_1",
+      name: "Launch",
+      kind: "channel",
+    });
     // Where the chain was started, for the origin-room check on depth > 0.
     turnFindUniqueMock.mockResolvedValue({
       userMessage: "Check the tasks",
@@ -2432,6 +2439,64 @@ describe("post_chat chain depth", () => {
     );
     return { turn: { ...SCOPE_TURN, chainDepth } } as never;
   }
+
+  it("refuses an unattended post into a colleague's direct", async () => {
+    // Nobody can leave a direct, so being in one must not become a standing
+    // licence to write in it: one instruction to reach Nina would otherwise
+    // let every later stand-up reach her again with nobody asking.
+    armPostChat(0);
+    chatRoomFindFirstMock.mockResolvedValue({
+      id: "room_direct",
+      name: "Nina",
+      kind: "direct",
+    });
+    chatRoomUserMemberFindFirstMock.mockResolvedValue(null);
+
+    await expect(
+      new SokoBotRuntimeService()["postChat"](
+        { turn: { ...SCOPE_TURN, source: "SCHEDULE", chainDepth: 0 } } as never,
+        { roomId: "room_direct", content: "Morning, any update?" },
+      ),
+    ).rejects.toThrow(/turns your owner asked for/i);
+    expect(transactionChatMessageCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("still briefs the owner in their own direct unprompted", async () => {
+    // The whole point of a scheduled turn, so the owner's room is exempt.
+    armPostChat(0);
+    chatRoomFindFirstMock.mockResolvedValue({
+      id: "room_owner",
+      name: "Ada",
+      kind: "direct",
+    });
+    chatRoomUserMemberFindFirstMock.mockResolvedValue({ id: "member_1" });
+
+    await new SokoBotRuntimeService()["postChat"](
+      { turn: { ...SCOPE_TURN, source: "SCHEDULE", chainDepth: 0 } } as never,
+      { roomId: "room_owner", content: "Here is your stand-up." },
+    );
+
+    expect(transactionChatMessageCreateMock).toHaveBeenCalled();
+  });
+
+  it("leaves channels alone on an unattended turn", async () => {
+    // A person can leave or mute a channel, and a bot added to a project room
+    // is expected to speak in it.
+    armPostChat(0);
+    chatRoomFindFirstMock.mockResolvedValue({
+      id: "room_1",
+      name: "Launch",
+      kind: "channel",
+    });
+
+    await new SokoBotRuntimeService()["postChat"](
+      { turn: { ...SCOPE_TURN, source: "SCHEDULE", chainDepth: 0 } } as never,
+      { roomId: "room_1", content: "Nightly digest." },
+    );
+
+    expect(transactionChatMessageCreateMock).toHaveBeenCalled();
+    expect(chatRoomUserMemberFindFirstMock).not.toHaveBeenCalled();
+  });
 
   it("summons the bot it addresses, one hop deeper", async () => {
     const authorized = armPostChat(0);

--- a/apps/core/src/services/soko-bot-runtime.service.ts
+++ b/apps/core/src/services/soko-bot-runtime.service.ts
@@ -831,7 +831,12 @@ export class SokoBotRuntimeService {
   private async requireChatMembership(
     authorized: AuthorizedSokoBotRuntime,
     roomId: string,
-  ): Promise<{ id: string; name: string; coworkerId: string }> {
+  ): Promise<{
+    id: string;
+    name: string;
+    kind: string;
+    coworkerId: string;
+  }> {
     const coworkerId = await this.chatCoworkerId(authorized);
     const room = coworkerId
       ? await prisma.chatRoom.findFirst({
@@ -839,7 +844,7 @@ export class SokoBotRuntimeService {
             ...(await this.chatRoomScope(authorized, coworkerId)),
             id: roomId,
           },
-          select: { id: true, name: true },
+          select: { id: true, name: true, kind: true },
         })
       : null;
     if (!room || !coworkerId) {
@@ -847,7 +852,7 @@ export class SokoBotRuntimeService {
         "You are not a member of that chat room",
       );
     }
-    return { id: room.id, name: room.name, coworkerId };
+    return { id: room.id, name: room.name, kind: room.kind, coworkerId };
   }
 
   /**
@@ -1034,6 +1039,39 @@ export class SokoBotRuntimeService {
     };
   }
 
+  /**
+   * A direct room is permanent — nobody can leave or archive one — so being in
+   * it must not become standing permission to write in it.
+   *
+   * `open_direct_chat` is deliberately limited to turns the owner asked for.
+   * The room it leaves behind outlived that limit: every later schedule,
+   * ingest or event turn found the room through `list_chats` and could reach
+   * that colleague again with nobody having asked for it. One instruction to
+   * write to Nina became a standing licence to keep writing to her.
+   *
+   * The owner's own direct is exempt, because briefing them there unprompted
+   * is the entire point of a scheduled turn. Channels are exempt too: a person
+   * can leave or mute one, and a bot added to a project room is expected to
+   * speak in it.
+   */
+  private async requireUnattendedPostIsAllowed(
+    authorized: AuthorizedSokoBotRuntime,
+    room: { id: string; kind: string },
+  ) {
+    if (authorized.turn.source === "CHAT" || room.kind !== "direct") {
+      return;
+    }
+    const ownerIsMember = await prisma.chatRoomUserMember.findFirst({
+      where: { roomId: room.id, userId: authorized.turn.userId },
+      select: { id: true },
+    });
+    if (!ownerIsMember) {
+      throw new SokoBotRuntimeAuthorizationError(
+        "Writing to a colleague is for turns your owner asked for. Raise it in your owner's chat instead.",
+      );
+    }
+  }
+
   /** Post into a room the bot belongs to, as the bot's coworker identity. */
   private async postChat(
     authorized: AuthorizedSokoBotRuntime,
@@ -1060,6 +1098,7 @@ export class SokoBotRuntimeService {
       }
     }
     const room = await this.requireChatMembership(authorized, input.roomId);
+    await this.requireUnattendedPostIsAllowed(authorized, room);
     // Who this post summons. A bot may address another bot, but every hop is
     // counted: past the ceiling the message still posts and simply stops being
     // a summons, so an unattended exchange cannot run for ever.

--- a/packages/soko-bot/src/__tests__/policy.test.ts
+++ b/packages/soko-bot/src/__tests__/policy.test.ts
@@ -262,6 +262,12 @@ describe("negated intent covers opening a chat", () => {
       // prohibition reaches the verb in.
       "Wait until I approve before getting in touch with Nina",
       "Wait until I approve before dropping a line to Nina",
+      // Undoing is a mutation: MANAGE_WORK grants delete_schedule, so a
+      // prohibition using these verbs has to be heard as one.
+      "Don't cancel my weekly reminder",
+      "Don't stop the daily check-in",
+      "Don't delete that schedule",
+      "Don't pause the stand-up yet",
     ]) {
       expect(hasSokoBotNegatedMutationIntent(message)).toBe(true);
     }

--- a/packages/soko-bot/src/__tests__/policy.test.ts
+++ b/packages/soko-bot/src/__tests__/policy.test.ts
@@ -293,6 +293,10 @@ describe("negated intent covers opening a chat", () => {
       "Don't hold off on messaging Nina",
       "Don't wait until Friday to post",
       "I won't wait until approval before messaging Nina; send it now",
+      // "stop" and "pause" only urge the work on with a preposition after
+      // them, which is what separates these from the prohibitions above.
+      "Don't pause before changing the daily reminder; change it now",
+      "Don't stop to ask Nina, just book it",
     ]) {
       expect(hasSokoBotNegatedMutationIntent(message)).toBe(false);
     }

--- a/packages/soko-bot/src/policy.ts
+++ b/packages/soko-bot/src/policy.ts
@@ -243,6 +243,17 @@ const MUTATION_VERBS = [
   "check with",
   "follow up with",
   "loop in",
+  // Undoing something is a mutation too. The classifier reads exactly these
+  // verbs as a change to the bot's own schedules and routes them to
+  // MANAGE_WORK, which grants delete_schedule — so without them "don't cancel
+  // my weekly reminder" was heard as no prohibition at all.
+  "cancel",
+  "stop",
+  "remove",
+  "pause",
+  "delete",
+  "change",
+  "move",
 ];
 
 /**

--- a/packages/soko-bot/src/policy.ts
+++ b/packages/soko-bot/src/policy.ts
@@ -297,13 +297,15 @@ const NEGATED_MUTATION_INTENT = new RegExp(
 
 /**
  * "Don't wait", "do not delay", "don't forget" are the owner pressing for the
- * thing to happen. Every word in them is a word a prohibition uses, so they
+ * thing to happen. "Stop" and "pause" go both ways and are only anti-delay
+ * with a preposition after them: "don't stop to ask Nina" urges the work on,
+ * where "don't stop the daily check-in" forbids ending it. Every word in them is a word a prohibition uses, so they
  * are cut out before the sentence is read rather than guarded against inside
  * it: that way "don't forget to message Nina, but don't post it publicly yet"
  * still lands on the half that is a real refusal.
  */
 const ANTI_DELAY =
-  /\b(?:don't|do not|won't|will not|never|no need to)\s+(?:wait|delay|hold off(?: on)?|hesitate|forget)\b/gi;
+  /\b(?:don't|do not|won't|will not|never|no need to)\s+(?:(?:wait|delay|hold off(?: on)?|hesitate|forget)\b|(?:pause|stop)\s+(?:before|to)\b)/gi;
 
 /** True when user explicitly says a mutation must not happen yet. */
 export function hasSokoBotNegatedMutationIntent(message: string): boolean {


### PR DESCRIPTION
Two holes a Codex review of #4032 found on `main`, both live today.

## A direct room was standing permission

`open_direct_chat` is deliberately limited to turns the owner asked for — a schedule can never approach a new colleague. But the room it leaves behind outlived that limit. `postChat` guarded only chain depth, never the turn's `source`, so every later `SCHEDULE` / `INGEST` / `EVENT` turn could find the room through `list_chats` and write to that colleague again with nobody having asked.

One instruction to reach Nina became a standing licence to keep reaching her. Nobody can leave a direct room, so the person on the other end has no way out of it.

**Rule now:** an unattended turn may not post into a direct the owner is not in.

- **The owner's own direct stays open** — briefing them there unprompted is precisely what a scheduled turn is for.
- **Channels stay open** — a person can leave or mute one, and a bot added to a project room is expected to speak in it.

The check is exact rather than heuristic: `createDirectRoomRecord` writes the counterpart as the room's sole `ChatRoomUserMember`, so a bot↔colleague direct has the colleague there and the owner's own direct has the owner.

> **Open question for review:** channels are exempt on the reasoning above. If a scheduled turn posting unprompted into a shared channel is also unwanted, the rule tightens to "rooms the owner is a member of" — one clause. I left it out because the irreversible case is the direct.

## "Don't cancel my weekly reminder" was heard as no prohibition

The negation guard's vocabulary had no verb for *undoing* something. The classifier reads `cancel|stop|remove|pause|change|move|delete` as a change to the bot's own schedules and routes them to `MANAGE_WORK`, which grants `delete_schedule` — while `hasSokoBotNegatedMutationIntent` returned false, so the runtime's negation guard never fired and the bot could cancel the reminder it had just been told not to touch.

`delete_schedule`, `create_schedule` and `update_schedule` were already in `NEGATABLE_WRITE_CAPABILITIES`; the guard simply never fired. Adding the verbs is the whole fix.

## Verification

- `pnpm check` — clean
- `pnpm typecheck` — 19/19
- `pnpm test` — full suite green; new cases cover the colleague direct being refused, the owner's direct still working, channels untouched, and the schedule prohibitions

Not covered by tests: the classifier→capability→guard chain end to end. Each link is tested in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt6But7wNmMpRx4C7ykdnV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unattended bot posts from appearing in colleagues’ direct rooms without the owner’s membership.
  * Continued allowing posts in the owner’s direct rooms and eligible channels.
  * Improved recognition of commands that cancel, stop, pause, delete, change, or move scheduled actions, while avoiding false positives for urgency phrases.
* **Tests**
  * Added coverage for direct-room posting restrictions and schedule cancellation language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->