### PR TITLE
fix(core): require x402 credits whenever the key is usage limited

### DIFF
--- a/apps/core/src/services/agent-sync.x402-readiness.compose.test.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.compose.test.ts
@@ -169,23 +169,21 @@ describe("composeX402ReadySources", () => {
       consoleWarnSpy.mockRestore();
     });
 
-    it("keeps a grandfathered key payable and warns that no cap is real", () => {
-      // The node leaves such a key uncapped and settles its payments, so
-      // treating it as unready would hide agents the node would pay. It still
-      // warns: an operator who believes they set a cap has not.
+    it("drops the pair when the key holds no eip155 credit row at all", () => {
+      // Was the opposite assertion: the node used to grandfather such a key to
+      // uncapped spend, so this gate let it through and warned instead. The
+      // node now refuses every payment it makes, so the pair is not payable
+      // and must not be listed.
       const consoleWarnSpy = vi
         .spyOn(console, "warn")
         .mockImplementation(() => undefined);
       expect(
         composeX402ReadySources([availableNetwork()], "Preprod", {
-          caps: keySpendCaps({
-            usageLimited: true,
-            grandfatheredUncapped: true,
-          }),
+          caps: keySpendCaps({ usageLimited: true }),
         }),
-      ).toEqual([READY_SOURCE]);
+      ).toEqual([]);
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("UNCAPPED key"),
+        expect.stringContaining("has no remaining usage credits"),
       );
       consoleWarnSpy.mockRestore();
     });

--- a/apps/core/src/services/agent-sync.x402-readiness.compose.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.compose.ts
@@ -217,14 +217,12 @@ export function computeEnabledPricedNetworks(
  * On (4), masumi ADR 0016: the node caps x402 spend on the API KEY, not on a
  * wallet. `usageLimited` off means uncapped. On, it requires a positive
  * balance for unit `<caip2Network>:<asset>`, byte-identical to this pair
- * key, which is why the gate is a map lookup. The one exception is the node's
- * own grandfathering: a `usageLimited` key holding NO `eip155:` row at all is
- * uncapped on the node and really can pay, so treating it as unready would
- * hide agents the node would happily settle. It warns instead, because an
- * operator who believes they set a cap has not. The gate asks whether the
- * unit holds credit, never whether it holds enough: no price exists at sync
- * time, so a nearly exhausted unit stays listed and the node refuses the
- * charge with a 402 instead.
+ * key, which is why the gate is a map lookup. No exception for a key holding
+ * no `eip155:` row at all: the node used to grandfather that key to uncapped
+ * spend, so this gate let it through, and it now refuses the payment instead.
+ * The gate asks whether the unit holds credit, never whether it holds enough:
+ * no price exists at sync time, so a nearly exhausted unit stays listed and
+ * the node refuses the charge with a 402 instead.
  *
  * On (3), any funded wallet is an equally valid signer now that the cap is
  * key-global: nothing binds a chain's spend to one wallet any more. The
@@ -301,7 +299,7 @@ export function composeX402ReadySources(
     if (!spendCaps) {
       continue;
     }
-    if (spendCaps.usageLimited && !spendCaps.grandfatheredUncapped) {
+    if (spendCaps.usageLimited) {
       // Presence, not sufficiency. The node debits by comparing the SUM of
       // the unit's credit rows against the payment amount, while readiness
       // runs before any price is known. A unit holding one base unit still
@@ -350,12 +348,6 @@ export function composeX402ReadySources(
         `[sync/agents] x402 pair ${pairLabel} has no usable Purchasing wallet, so it cannot be buy-side ready. The node's listing exposes none that Soko's key can reach on this chain, or none holding both native gas and the priced token; create, scope, and fund one`,
       );
       continue;
-    }
-
-    if (spendCaps.grandfatheredUncapped) {
-      console.warn(
-        `[sync/agents] x402 pair ${pairLabel} is buy-side ready on an UNCAPPED key: the key is usageLimited but holds no eip155 credit row, so the payment node grandfathers it and enforces no x402 spend cap. Grant credits for unit ${pairLabel} to make the cap real`,
-      );
     }
 
     readySources.push({

--- a/apps/core/src/services/agent-sync.x402-readiness.compose.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.compose.ts
@@ -217,9 +217,11 @@ export function computeEnabledPricedNetworks(
  * On (4), masumi ADR 0016: the node caps x402 spend on the API KEY, not on a
  * wallet. `usageLimited` off means uncapped. On, it requires a positive
  * balance for unit `<caip2Network>:<asset>`, byte-identical to this pair
- * key, which is why the gate is a map lookup. No exception for a key holding
- * no `eip155:` row at all: the node used to grandfather that key to uncapped
- * spend, so this gate let it through, and it now refuses the payment instead.
+ * key, which is why the gate is a map lookup. There is no exception for a key
+ * holding no `eip155:` row at all. The node used to grandfather such a key to
+ * uncapped spend, which is why this gate once let it through; the node now
+ * refuses its payments, so listing the pair would advertise an agent that
+ * cannot be hired.
  * The gate asks whether the unit holds credit, never whether it holds enough:
  * no price exists at sync time, so a nearly exhausted unit stays listed and
  * the node refuses the charge with a 402 instead.

--- a/apps/core/src/services/agent-sync.x402-readiness.fixtures.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.fixtures.ts
@@ -34,7 +34,6 @@ export function keySpendCaps(
   return {
     usageLimited: false,
     creditsByUnit: new Map<string, bigint>(),
-    grandfatheredUncapped: false,
     ...overrides,
   };
 }

--- a/apps/core/src/services/agent-sync.x402-readiness.test.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.test.ts
@@ -293,40 +293,27 @@ describe("syncX402BuySideReadiness", () => {
     );
   });
 
-  it("pages when payable pairs are recorded on an uncapped key", async () => {
-    // The gap this closes. A usageLimited key with no eip155 credit row is
-    // grandfathered uncapped by the node, so these pairs really are payable,
-    // with no ceiling, while the operator believes a cap is on. The
-    // zero-pairs page cannot cover it: there ARE ready pairs.
+  it("records no payable pair for a usage-limited key with no credit rows", async () => {
+    // Was the opposite assertion. The node used to grandfather such a key to
+    // uncapped x402 spend, so these pairs really were payable and readiness
+    // listed them and paged about the missing ceiling. The node now refuses
+    // every payment the key makes, so listing the pair would advertise agents
+    // that cannot be hired.
     const consoleWarnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
     getX402KeySpendCapsMock.mockResolvedValue(
-      ok(keySpendCaps({ usageLimited: true, grandfatheredUncapped: true })),
+      ok(keySpendCaps({ usageLimited: true })),
     );
 
     await expect(syncX402BuySideReadiness()).resolves.toBe(true);
 
-    expect(captureMessageMock).toHaveBeenCalledTimes(1);
-    expect(captureMessageMock.mock.calls[0][0]).toContain("UNCAPPED");
-    expect(captureMessageMock.mock.calls[0][1]).toBe("warning");
-    consoleWarnSpy.mockRestore();
-  });
-
-  it("does not page for an uncapped key on a Vercel preview", async () => {
-    // Preview runs a deliberately non-admin key (SOK-860). Paging from there
-    // is the noise that alert suppression exists to stop.
-    const consoleWarnSpy = vi
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
-    envState.VERCEL_ENV = "preview";
-    getX402KeySpendCapsMock.mockResolvedValue(
-      ok(keySpendCaps({ usageLimited: true, grandfatheredUncapped: true })),
+    expect(syncMetadataUpsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: X402_BUY_SIDE_READINESS_KEY },
+        update: expect.objectContaining({ cursorId: "[]" }),
+      }),
     );
-
-    await expect(syncX402BuySideReadiness()).resolves.toBe(true);
-
-    expect(captureMessageMock).not.toHaveBeenCalled();
     consoleWarnSpy.mockRestore();
   });
 
@@ -338,26 +325,6 @@ describe("syncX402BuySideReadiness", () => {
     await expect(syncX402BuySideReadiness()).resolves.toBe(true);
 
     expect(captureMessageMock).not.toHaveBeenCalled();
-  });
-
-  it("does not re-page for an uncapped key when readiness did not change", async () => {
-    // Latched on the transition like the zero-pairs page, so a lasting
-    // misconfiguration does not spam. The per-pair warn log still repeats.
-    const consoleWarnSpy = vi
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
-    getX402KeySpendCapsMock.mockResolvedValue(
-      ok(keySpendCaps({ usageLimited: true, grandfatheredUncapped: true })),
-    );
-    syncMetadataFindUniqueMock.mockResolvedValue({
-      cursorId: JSON.stringify([READY_SOURCE]),
-      lastSyncedAt: new Date(),
-    });
-
-    await expect(syncX402BuySideReadiness()).resolves.toBe(false);
-
-    expect(captureMessageMock).not.toHaveBeenCalled();
-    consoleWarnSpy.mockRestore();
   });
 
   it("reports no change when the cache holds the same pair set", async () => {
@@ -401,7 +368,6 @@ describe("syncX402BuySideReadiness", () => {
           },
         ],
         usageLimited: false,
-        grandfatheredUncapped: false,
         creditUnits: [],
         purchasingWalletCount: 0,
         purchasingWalletNetworks: [],

--- a/apps/core/src/services/agent-sync.x402-readiness.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.ts
@@ -119,7 +119,6 @@ function summarizeEmptyX402Readiness(
       defaultAssetDecimals: network.defaultAssetDecimals,
     })),
     usageLimited: spendCaps?.usageLimited ?? null,
-    grandfatheredUncapped: spendCaps?.grandfatheredUncapped ?? null,
     creditUnits: Array.from(spendCaps?.creditsByUnit ?? [])
       .slice(0, 20)
       .map(([unit, amount]) => ({ unit, hasRemaining: amount > 0n })),
@@ -350,25 +349,6 @@ export async function syncX402BuySideReadiness(
     });
   }
 
-  if (readySources.length > 0 && keySpendCaps?.grandfatheredUncapped) {
-    // The node grandfathers a usageLimited key that holds no eip155 credit
-    // row: it enforces NO x402 spend cap at all, so every pair recorded above
-    // is payable without a ceiling while the operator believes a cap is on.
-    // compose warns per pair, but a warn line is not a signal anyone watches,
-    // and the zero-pairs page below cannot cover this by construction: the
-    // whole point of this state is that there ARE ready pairs.
-    //
-    // Latched on the transition like that page, so a lasting misconfiguration
-    // does not spam; the per-pair warn log repeats every cycle regardless.
-    // Preview runs a deliberately non-admin key (SOK-860) and must not page.
-    if (readinessChanged && !isX402ReadinessPreviewDeploy()) {
-      Sentry.captureMessage(
-        "x402 buy-side readiness recorded payable pairs on an UNCAPPED payment-node API key. The key is usageLimited but holds no eip155 credit row, so the node grandfathers it and enforces no x402 spend cap: Soko will sign x402 payments with no ceiling. Grant credits for the listed units with PATCH /api/v1/api-key to make the intended cap real, or clear usageLimited on the key if uncapped is deliberate. The sync warn log names every affected pair",
-        "warning",
-      );
-    }
-  }
-
   if (readySources.length === 0) {
     console.warn(
       "[sync/agents] No x402 (network, asset) pair is buy-side ready; fixed-price x402 agents stay unlisted and dynamic agents remain visible as non-payable previews",
@@ -393,7 +373,7 @@ export async function syncX402BuySideReadiness(
         // The likeliest new cause is an operator one, not an outage: a chain
         // whose `defaultAssetDecimals` is still null publishes no scale, and
         // an unpriceable asset is deliberately not recorded ready.
-        "x402 buy-side readiness reports no payable (network, asset) pair. Fixed-price x402 agents are hidden and dynamic agents are preview-only. Check four things. 1) The node publishes a confirmed defaultAssetDecimals for each enabled chain. 2) The chain is in this environment's CAIP-2 allowlist and its priced asset is in X402_TRUSTED_EXACT_EVM_DOMAINS (both in apps/core/src/helpers/x402-readiness.ts; the sync warn log names any untrusted pair). 3) Soko's key carries pay or admin permission and the node lists at least one Purchasing wallet it can reach on that chain, funded with native gas and the priced token (the sync warn log names the chain when the listing is empty or every wallet is unfunded). A read-only key can read the wallet listing but can never sign a payment, so Soko treats it as having no wallets at all. 4) If Soko's key is usage limited, it holds remaining credits for unit <caip2Network>:<asset> on that chain; grant them with PATCH /api/v1/api-key. A usage-limited key with NO eip155 credit row at all is grandfathered uncapped by the node and stays payable, so an operator who expected a cap there has not set one",
+        "x402 buy-side readiness reports no payable (network, asset) pair. Fixed-price x402 agents are hidden and dynamic agents are preview-only. Check four things. 1) The node publishes a confirmed defaultAssetDecimals for each enabled chain. 2) The chain is in this environment's CAIP-2 allowlist and its priced asset is in X402_TRUSTED_EXACT_EVM_DOMAINS (both in apps/core/src/helpers/x402-readiness.ts; the sync warn log names any untrusted pair). 3) Soko's key carries pay or admin permission and the node lists at least one Purchasing wallet it can reach on that chain, funded with native gas and the priced token (the sync warn log names the chain when the listing is empty or every wallet is unfunded). A read-only key can read the wallet listing but can never sign a payment, so Soko treats it as having no wallets at all. 4) If Soko's key is usage limited, it holds remaining credits for unit <caip2Network>:<asset> on that chain; grant them with PATCH /api/v1/api-key. A usage-limited key with NO eip155 credit row at all cannot pay on any chain: the node refuses every x402 payment it makes until one unit holds credit",
         "error",
       );
     }

--- a/packages/masumi/src/clients/masumi-payment-x402.ts
+++ b/packages/masumi/src/clients/masumi-payment-x402.ts
@@ -49,12 +49,6 @@ export interface X402KeySpendCaps {
    * debit path does.
    */
   creditsByUnit: ReadonlyMap<string, bigint>;
-  /**
-   * The key is `usageLimited` but holds NO `eip155:` row at all, so the node
-   * grandfathers it to uncapped x402 spend and warns per payment. Distinct
-   * from "capped at zero": this key can pay, a zero-credit one cannot.
-   */
-  grandfatheredUncapped: boolean;
 }
 
 /** One managed EVM wallet visible to the calling key (`GET /x402/wallets`). */
@@ -112,11 +106,10 @@ const x402AvailableNetworkSchema: z.ZodType<X402AvailableNetwork> = z.object({
  * One `RemainingUsageCredits` row from `GET /api-key-status`.
  *
  * Shape only. The node really can hold an `amount` that is not a base-unit
- * integer, and such a row is judged per unit below (it ends grandfathering
- * but adds nothing to its unit's sum) rather than failing the whole read, so
- * the digit check deliberately stays out of this schema. Validating the shape
- * here is what keeps an absent or version-skewed array from reading as "this
- * key holds no credits".
+ * integer, and such a row adds nothing to its unit's sum below rather than
+ * failing the whole read, so the digit check deliberately stays out of this
+ * schema. Validating the shape here is what keeps an absent or version-skewed
+ * array from reading as "this key holds no credits".
  */
 const apiKeyUsageCreditSchema = z.object({
   unit: z.string(),
@@ -502,9 +495,9 @@ export function createX402PaymentMethods(
         // Zod, like every other node read here, and for the same reason the
         // flag above is guarded: `RemainingUsageCredits` is required, so an
         // absent or malformed array is version skew, never "this key holds no
-        // credits". Reading it as an empty list would set
-        // `grandfatheredUncapped` on a usageLimited key and mark every pair
-        // ready that the node would then refuse with a 402.
+        // credits". Erroring keeps the two apart. Reading skew as an empty list
+        // would delist every x402 pair on a usageLimited key and report it as a
+        // funding problem the operator does not have.
         const creditRows = z
           .array(apiKeyUsageCreditSchema)
           .max(MAX_USAGE_CREDIT_ROWS)
@@ -515,17 +508,11 @@ export function createX402PaymentMethods(
           );
         }
         const creditsByUnit = new Map<string, bigint>();
-        let sawEvmRow = false;
         for (const row of creditRows.data) {
           const unit = row.unit.toLowerCase();
           if (!unit.startsWith("eip155:")) {
             continue;
           }
-          // Any eip155 row at all ends grandfathering on the node, including
-          // one this loop then drops as unparsable: the node COUNTS those
-          // rows, it does not parse them. Reading that as still-grandfathered
-          // would call a hard-capped key uncapped.
-          sawEvmRow = true;
           // Length first: an over-long amount is dropped exactly like an
           // unparsable one, so its unit reads as zero and the pair delists.
           // Checking before BigInt is the point, since that is the
@@ -541,11 +528,7 @@ export function createX402PaymentMethods(
             (creditsByUnit.get(unit) ?? 0n) + BigInt(row.amount),
           );
         }
-        return ok({
-          usageLimited: status.usageLimited,
-          creditsByUnit,
-          grandfatheredUncapped: status.usageLimited && !sawEvmRow,
-        });
+        return ok({ usageLimited: status.usageLimited, creditsByUnit });
       } catch (error) {
         return err(String(error) || "Failed to get x402 key spend caps");
       }

--- a/packages/masumi/src/clients/masumi-payment.client.x402.test.ts
+++ b/packages/masumi/src/clients/masumi-payment.client.x402.test.ts
@@ -221,7 +221,6 @@ describe("getX402KeySpendCaps", () => {
     expect(result.isOk()).toBe(true);
     const caps = result.isOk() ? result.value : null;
     expect(caps?.usageLimited).toBe(true);
-    expect(caps?.grandfatheredUncapped).toBe(false);
     expect(
       caps?.creditsByUnit.get(
         `eip155:84532:${USDC_BASE_SEPOLIA.toLowerCase()}`,
@@ -249,9 +248,10 @@ describe("getX402KeySpendCaps", () => {
     expect(caps?.creditsByUnit.has("lovelace")).toBe(false);
   });
 
-  it("reports a usage-limited key with no eip155 row as grandfathered uncapped", async () => {
-    // The node keeps such a key payable and only warns, so calling it capped
-    // would hide agents the node would settle.
+  it("reports no EVM credit for a key funded only on the Cardano rail", async () => {
+    // The node refuses every x402 payment such a key makes. It once
+    // grandfathered it to uncapped spend instead, which is why this case has
+    // its own test.
     getApiKeyStatusMock.mockResolvedValue(
       statusResponse({
         usageLimited: true,
@@ -261,13 +261,15 @@ describe("getX402KeySpendCaps", () => {
 
     const result = await createClient().getX402KeySpendCaps();
 
-    expect(result.isOk() && result.value.grandfatheredUncapped).toBe(true);
+    const caps = result.isOk() ? result.value : null;
+    expect(caps?.usageLimited).toBe(true);
+    expect(caps?.creditsByUnit.size).toBe(0);
   });
 
-  it("ends grandfathering on an eip155 row it cannot parse", async () => {
-    // The node COUNTS eip155 rows to decide grandfathering, it does not parse
-    // them. Reading an unparsable row as "still grandfathered" would call a
-    // hard-capped key uncapped and mark an unpayable pair ready.
+  it("drops an eip155 row it cannot parse", async () => {
+    // An unparsable amount adds nothing to its unit's sum, so the unit reads
+    // zero and the pair delists. Treating it as credit would list a pair the
+    // node refuses.
     getApiKeyStatusMock.mockResolvedValue(
       statusResponse({
         usageLimited: true,
@@ -280,14 +282,13 @@ describe("getX402KeySpendCaps", () => {
     const result = await createClient().getX402KeySpendCaps();
 
     const caps = result.isOk() ? result.value : null;
-    expect(caps?.grandfatheredUncapped).toBe(false);
     expect(caps?.creditsByUnit.size).toBe(0);
   });
 
   it("drops an eip155 row whose amount is longer than any real balance", async () => {
     // 200 digits cannot be a uint256 balance, and BigInt() is superlinear in
-    // digit count. Dropping the row costs the sync worker nothing and still
-    // ends grandfathering, so the unit reads zero and the pair delists.
+    // digit count. Dropping the row costs the sync worker nothing, so the unit
+    // reads zero and the pair delists.
     getApiKeyStatusMock.mockResolvedValue(
       statusResponse({
         usageLimited: true,
@@ -303,7 +304,6 @@ describe("getX402KeySpendCaps", () => {
     const result = await createClient().getX402KeySpendCaps();
 
     const caps = result.isOk() ? result.value : null;
-    expect(caps?.grandfatheredUncapped).toBe(false);
     expect(caps?.creditsByUnit.size).toBe(0);
   });
 
@@ -326,7 +326,7 @@ describe("getX402KeySpendCaps", () => {
     expect(result.isErr() && result.error).toContain("RemainingUsageCredits");
   });
 
-  it("reports an unlimited key as uncapped and not grandfathered", async () => {
+  it("reports an unlimited key as uncapped", async () => {
     getApiKeyStatusMock.mockResolvedValue(
       statusResponse({ usageLimited: false }),
     );
@@ -335,13 +335,13 @@ describe("getX402KeySpendCaps", () => {
 
     const caps = result.isOk() ? result.value : null;
     expect(caps?.usageLimited).toBe(false);
-    expect(caps?.grandfatheredUncapped).toBe(false);
+    expect(caps?.creditsByUnit.size).toBe(0);
   });
 
   it("fails closed when the node answers 200 without the credit rows", async () => {
     // RemainingUsageCredits is required, so an absent array is version skew,
-    // never "this key holds no credits". Reading it as empty would call a
-    // usage-limited key grandfathered and mark every pair ready.
+    // never "this key holds no credits". Reading it as empty would delist
+    // every x402 pair and report a funding problem the operator does not have.
     getApiKeyStatusMock.mockResolvedValue(
       statusResponse({
         usageLimited: true,


### PR DESCRIPTION
## What changes

x402 buy-side readiness now requires a positive credit balance for `<caip2Network>:<asset>` whenever Soko's payment-node API key is `usageLimited`. The `grandfatheredUncapped` exception is gone, along with the Sentry page and the per-pair warn that only existed to describe it.

## Why

The exception mirrored a rule in the payment node. A `usageLimited` key holding no `eip155:` row at all was grandfathered to uncapped x402 spend, so it really could pay, and treating it as unready would have hidden agents the node would settle.

masumi-network/masumi-payment-service#805 removes that grandfathering: such a key is now refused with `402 Insufficient usage credits`. Once it ships, this gate would list every pair as buy-side ready and every hire would fail at pay time. The failure is silent at sync time and only shows when a user tries to hire.

## Merge order

This must ship before the node change. Ordered the other way, Soko advertises agents that cannot be hired.

Landing this first is safe on its own. Against a node that still grandfathers, the only effect is that a `usageLimited` key with no EVM credits stops listing pairs it could technically pay for, which is the state the operator already believed they had configured.

## Verification

- `pnpm --filter core test`: `451 passed | 2 skipped`, `4547 tests passed | 6 skipped`.
- `pnpm --filter @sokosumi/masumi test`: `17 files passed`, `393 tests passed`.
- `pnpm --filter core typecheck` and `pnpm --filter @sokosumi/masumi typecheck`: clean.
- `pnpm check`: clean, 3713 files.
- Mutation check: restoring the exception (`usageLimited && creditsByUnit.size > 0`) fails exactly the two tests that encode the new rule, and nothing else.

Note for reviewers: `pnpm typecheck` at the repo root fails on `apps/web/.next/types/validator.ts`, a stale build artifact from 28 August that names routes absent from `main` (`composio/callback`, `personal-assistant/chat`). It is unrelated to this change and clears on the next web build.

## Tests changed

Three tests asserted the old behaviour and now assert the new one:

- `agent-sync.x402-readiness.compose.test.ts`: the no-credit-row pair is dropped instead of listed with an UNCAPPED warning.
- `agent-sync.x402-readiness.test.ts`: the sync records an empty pair set instead of paging about an uncapped key.
- `masumi-payment.client.x402.test.ts`: a Cardano-only key reports no EVM credit instead of reporting itself grandfathered.
