### PR TITLE
chore: remove CODEOWNERS so reviews stay opt-in

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Global Owners
-* @mrosberghaus @francisluz


### PR DESCRIPTION
## Summary
- Delete `.github/CODEOWNERS` so GitHub no longer auto-requests reviewers on every PR
- Reviews should be requested explicitly when wanted

## Test plan
- [ ] Confirm PR has no automatic CODEOWNERS reviewers assigned
- [ ] Confirm no remaining references to CODEOWNERS in the repo


Made with [Cursor](https://cursor.com)