### PR TITLE
fix(masumi): treat a bare node "Insufficient funds" as retryable

### DIFF
--- a/packages/masumi/src/clients/masumi-payment.client.test.ts
+++ b/packages/masumi/src/clients/masumi-payment.client.test.ts
@@ -729,6 +729,34 @@ describe("createPurchase failure classification", () => {
   // A `permanent` verdict is terminal on the task-payment rail: it refunds the
   // claim, drops it out of PENDING and the unique index blocks resubmission.
   // Credential/routing failures must therefore stay retryable.
+  it("classifies node 400 Insufficient funds as ambiguous, not a payload refusal", async () => {
+    postPurchaseMock.mockResolvedValue({
+      data: undefined,
+      error: { status: "error", error: { message: "Insufficient funds" } },
+      response: { status: 400 },
+    });
+    const client = createPaymentClient(
+      "Preprod",
+      "https://payment.example.com",
+      "api-key",
+    );
+
+    const result = await client.createPurchase(
+      "agent1",
+      startJobResponse,
+      {},
+      "aabbccddeeff00112233",
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error).toMatchObject({
+      kind: "ambiguous",
+      status: 400,
+      message:
+        "Failed to create purchase request (status 400): Insufficient funds",
+    });
+  });
+
   it.each([401, 403, 404])(
     "classifies %i as ambiguous, not a permanent rejection",
     async (status: number) => {
@@ -1156,6 +1184,74 @@ describe("createPurchaseFromMasumiTaskPayment", () => {
     expect(postPurchaseResolveBlockchainIdentifierMock).toHaveBeenCalledTimes(
       1,
     );
+  });
+
+  it("classifies node 400 Insufficient funds as ambiguous, not a payload refusal", async () => {
+    postPurchaseMock.mockResolvedValue({
+      data: undefined,
+      error: { error: { message: "Insufficient funds" } },
+      response: { status: 400 },
+    });
+    const client = createPaymentClient(
+      "Preprod",
+      "https://payment.example.com",
+      "api-key",
+    );
+
+    const result = await client.createPurchaseFromMasumiTaskPayment({
+      blockchainIdentifier: "chain1",
+      agentIdentifier: "agent1",
+      sellerVkey: "vkey1",
+      submitResultTime: "1775681853000",
+      payByTime: "1775737949000",
+      unlockTime: "1775763149000",
+      externalDisputeUnlockTime: "1775784749000",
+      inputHash: "abc",
+      Amounts: [{ amount: "1000000", unit: "" }],
+      identifierFromPurchaser: "aabbccddeeff00112233",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error).toMatchObject({
+      kind: "ambiguous",
+      status: 400,
+      message:
+        "Failed to create purchase request (status 400): Insufficient funds",
+    });
+  });
+
+  it("classifies node 400 Buyer has insufficient funds as permanent", async () => {
+    postPurchaseMock.mockResolvedValue({
+      data: undefined,
+      error: {
+        error: { message: "Buyer has insufficient funds. Missing: ada" },
+      },
+      response: { status: 400 },
+    });
+    const client = createPaymentClient(
+      "Preprod",
+      "https://payment.example.com",
+      "api-key",
+    );
+
+    const result = await client.createPurchaseFromMasumiTaskPayment({
+      blockchainIdentifier: "chain1",
+      agentIdentifier: "agent1",
+      sellerVkey: "vkey1",
+      submitResultTime: "1775681853000",
+      payByTime: "1775737949000",
+      unlockTime: "1775763149000",
+      externalDisputeUnlockTime: "1775784749000",
+      inputHash: "abc",
+      Amounts: [{ amount: "1000000", unit: "" }],
+      identifierFromPurchaser: "aabbccddeeff00112233",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error).toMatchObject({
+      kind: "permanent",
+      status: 400,
+    });
   });
 
   it("classifies node 400 as a permanent task purchase failure", async () => {

--- a/packages/masumi/src/clients/masumi-payment.client.ts
+++ b/packages/masumi/src/clients/masumi-payment.client.ts
@@ -10,7 +10,7 @@ import {
   toMasumiPaymentNodeAmounts,
 } from "../utils/payment-amounts.js";
 import { createX402PaymentMethods } from "./masumi-payment-x402.js";
-import { extractNodeErrorMessage } from "./node-error.js";
+import { extractNodeErrorMessage, readNodeErrorMessage } from "./node-error.js";
 import { createClient } from "./openapi/generated/payment/client/index.js";
 import {
   getRailReadiness,
@@ -98,9 +98,20 @@ export interface PurchaseFailure {
  */
 const RETRYABLE_INFRASTRUCTURE_STATUSES = new Set([401, 403, 404, 408, 429]);
 
+/**
+ * Payment-node usage-limited API-key debit. The same POST succeeds after a
+ * top-up, so this is not a payload refusal. Distinct from x402's
+ * "Buyer has insufficient funds. Missing:".
+ */
+const PAYMENT_NODE_USAGE_CREDITS_EXHAUSTED = "Insufficient funds";
+
 function classifyPurchaseFailureKind(
   status: number | undefined,
+  nodeMessage: string | null,
 ): PurchaseFailure["kind"] {
+  if (nodeMessage === PAYMENT_NODE_USAGE_CREDITS_EXHAUSTED) {
+    return "ambiguous";
+  }
   return status !== undefined &&
     status >= 400 &&
     status < 500 &&
@@ -481,7 +492,10 @@ export function createPaymentClient(
           console.error("Failed to create purchase request", response.error);
           const status = response.response?.status;
           return err({
-            kind: classifyPurchaseFailureKind(status),
+            kind: classifyPurchaseFailureKind(
+              status,
+              readNodeErrorMessage(response.error),
+            ),
             message: `Failed to create purchase request (status ${status ?? "unknown"}): ${extractNodeErrorMessage(response.error)}`,
             status,
           });
@@ -544,7 +558,10 @@ export function createPaymentClient(
           // The event is already charged when this error surfaces. Carry the
           // node's status and reason into compensation and alerting.
           return err({
-            kind: classifyPurchaseFailureKind(status),
+            kind: classifyPurchaseFailureKind(
+              status,
+              readNodeErrorMessage(response.error),
+            ),
             message: `Failed to create purchase request (status ${status ?? "unknown"}): ${extractNodeErrorMessage(response.error)}`,
             status,
           });


### PR DESCRIPTION
Replaces #3974, which was green but sat on the retired `src/clients/__tests__/` path and showed as conflicting.

## Why

The payment node answers `400 "Insufficient funds"` when a **usage-limited API key** has no credit left to debit. `classifyPurchaseFailureKind` read every 4xx outside `RETRYABLE_INFRASTRUCTURE_STATUSES` as `permanent`, so that answer refunded the claim and dropped it out of `PENDING`. The unique index then blocks resubmission, which turns an operator top-up into a dead purchase.

It is not a payload refusal. The identical POST succeeds once the key is topped up, so the verdict is `ambiguous` and the claim is retried.

This is the same credit pool `getX402KeySpendCaps` reads ahead of time on the x402 buy side (#3986). Different rail, same exhaustion.

## The exactness is load-bearing

Matched with `===`, never a substring, to keep it away from x402's `"Buyer has insufficient funds. Missing: ada"`. That one really is terminal for the request as sent and stays `permanent`.

Both `createPurchase` and `createPurchaseFromMasumiTaskPayment` classify through the same helper, so both call sites pass the node message.

## Verification

- `pnpm --filter @sokosumi/masumi test`: `396 passed`
- `pnpm check` clean on 3678 files, `pnpm typecheck` 19/19

Mutation tested, each mutation failing only its intended test:

| Mutation | Test that failed |
| --- | --- |
| drop the `Insufficient funds` branch | both `classifies node 400 Insufficient funds as ambiguous` cases |
| loosen `===` to a case-insensitive substring | `classifies node 400 Buyer has insufficient funds as permanent` |