### PR TITLE
fix(core): stop x402 readiness paging from preview deploys

### DIFF
--- a/apps/core/src/services/agent-sync.x402-readiness.test.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.test.ts
@@ -29,6 +29,8 @@ const {
       | "preview"
       | "development"
       | undefined,
+    VERCEL_URL: undefined as string | undefined,
+    VERCEL_BRANCH_URL: undefined as string | undefined,
   },
   getX402AvailableNetworksMock: vi.fn(),
   getX402KeySpendCapsMock: vi.fn(),
@@ -71,6 +73,7 @@ vi.mock("@/lib/db/prisma", () => ({
 
 import {
   boundCheckErrorForLogging,
+  isX402ReadinessPreviewDeploy,
   syncX402BuySideReadiness,
 } from "./agent-sync.x402-readiness";
 import {
@@ -89,6 +92,8 @@ describe("syncX402BuySideReadiness", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     envState.VERCEL_ENV = undefined;
+    envState.VERCEL_URL = undefined;
+    envState.VERCEL_BRANCH_URL = undefined;
     syncMetadataCreateManyMock.mockResolvedValue({ count: 1 });
     syncMetadataDeleteManyMock.mockResolvedValue({ count: 0 });
     syncMetadataFindUniqueMock.mockResolvedValue(null);
@@ -410,6 +415,76 @@ describe("syncX402BuySideReadiness", () => {
       lastSyncedAt: new Date(),
     });
     await expect(syncX402BuySideReadiness()).resolves.toBe(false);
+    expect(captureMessageMock).toHaveBeenCalledTimes(1);
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("does not page for zero ready pairs on a Vercel preview", async () => {
+    // A preview cron runs a deliberately non-admin key (SOK-860), so zero
+    // ready pairs is the EXPECTED result there. Paging on it floods CORE-39.
+    // The warn and the cache write stay, so fail-closed listing is unchanged.
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    envState.VERCEL_ENV = "preview";
+    getX402PurchasingWalletsMock.mockResolvedValue(ok([]));
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      cursorId: JSON.stringify([READY_SOURCE]),
+      lastSyncedAt: new Date(),
+    });
+
+    await expect(syncX402BuySideReadiness()).resolves.toBe(true);
+
+    expect(captureMessageMock).not.toHaveBeenCalled();
+    expect(syncMetadataUpsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: X402_BUY_SIDE_READINESS_KEY },
+        update: expect.objectContaining({ cursorId: "[]" }),
+      }),
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("does not page for zero ready pairs on a preview HOST that claims production", async () => {
+    // The reason the host is checked at all: CORE-37 kept paging from
+    // sokosumi-core-mainnet-*.preview.sokosumi.com on a release that already
+    // gated on VERCEL_ENV alone.
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    envState.VERCEL_ENV = "production";
+    envState.VERCEL_URL =
+      "https://sokosumi-core-mainnet-e99rlf2xt.preview.sokosumi.com";
+    getX402PurchasingWalletsMock.mockResolvedValue(ok([]));
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      cursorId: JSON.stringify([READY_SOURCE]),
+      lastSyncedAt: new Date(),
+    });
+
+    await expect(syncX402BuySideReadiness()).resolves.toBe(true);
+
+    expect(captureMessageMock).not.toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("still pages for zero ready pairs on a real production host", async () => {
+    // The guard above must not swallow the alert it exists to deliver.
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    envState.VERCEL_ENV = "production";
+    envState.VERCEL_URL = "https://core.sokosumi.com";
+    getX402PurchasingWalletsMock.mockResolvedValue(ok([]));
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      cursorId: JSON.stringify([READY_SOURCE]),
+      lastSyncedAt: new Date(),
+    });
+
+    await expect(syncX402BuySideReadiness()).resolves.toBe(true);
+
     expect(captureMessageMock).toHaveBeenCalledTimes(1);
 
     consoleWarnSpy.mockRestore();
@@ -785,5 +860,61 @@ describe("syncX402BuySideReadiness", () => {
       expect.anything(),
       expect.objectContaining({ signal }),
     );
+  });
+});
+
+describe("isX402ReadinessPreviewDeploy", () => {
+  beforeEach(() => {
+    envState.VERCEL_ENV = undefined;
+    envState.VERCEL_URL = undefined;
+    envState.VERCEL_BRANCH_URL = undefined;
+  });
+
+  it("matches VERCEL_ENV preview with no host set", () => {
+    envState.VERCEL_ENV = "preview";
+
+    expect(isX402ReadinessPreviewDeploy()).toBe(true);
+  });
+
+  it("matches the branch alias, which carries the suffix before VERCEL_URL does", () => {
+    envState.VERCEL_ENV = "production";
+    envState.VERCEL_BRANCH_URL =
+      "sokosumi-core-mainnet-git-main.preview.sokosumi.com";
+
+    expect(isX402ReadinessPreviewDeploy()).toBe(true);
+  });
+
+  it("does not match a host that merely ends in sokosumi.com", () => {
+    // core.sokosumi.com is production. Matching the bare apex would silence
+    // every real alert, which is the opposite of the bug being fixed.
+    envState.VERCEL_ENV = "production";
+    envState.VERCEL_URL = "https://core.sokosumi.com";
+
+    expect(isX402ReadinessPreviewDeploy()).toBe(false);
+  });
+
+  it("does not match a lookalike host that only contains the suffix", () => {
+    // Parsing the URL, rather than a substring test on the raw value, is what
+    // keeps a path or a subdomain-shaped tail from reading as the suffix.
+    envState.VERCEL_ENV = "production";
+    envState.VERCEL_URL = "https://core.sokosumi.com/x.preview.sokosumi.com";
+
+    expect(isX402ReadinessPreviewDeploy()).toBe(false);
+
+    envState.VERCEL_URL = "https://notpreview.sokosumi.com";
+
+    expect(isX402ReadinessPreviewDeploy()).toBe(false);
+  });
+
+  it("treats an unparsable or absent host as not preview", () => {
+    // Fail toward paging. A malformed VERCEL_URL must never buy silence.
+    envState.VERCEL_ENV = "production";
+    envState.VERCEL_URL = "::::";
+
+    expect(isX402ReadinessPreviewDeploy()).toBe(false);
+
+    envState.VERCEL_URL = undefined;
+
+    expect(isX402ReadinessPreviewDeploy()).toBe(false);
   });
 });

--- a/apps/core/src/services/agent-sync.x402-readiness.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.ts
@@ -33,6 +33,53 @@ const MAX_CHECK_ERROR_ITEM_LENGTH = 200;
 const MAX_CHECK_ERROR_TOTAL_LENGTH = 2_000;
 
 /**
+ * Vercel's Preview Deployment Suffix for this team (`apps/core/AGENTS.md`,
+ * mirrored by the `https://*.preview.sokosumi.com` trustedOrigins entry in
+ * `lib/auth.ts`). A Core host on this suffix is a preview deployment by
+ * definition, so matching it can never silence a production alert.
+ */
+const PREVIEW_DEPLOYMENT_HOST_SUFFIX = ".preview.sokosumi.com";
+
+function hasPreviewHost(candidate: string | undefined): boolean {
+  if (!candidate) {
+    return false;
+  }
+  try {
+    const href = candidate.includes("://") ? candidate : `https://${candidate}`;
+    return new URL(href).hostname.endsWith(PREVIEW_DEPLOYMENT_HOST_SUFFIX);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether this deploy must warn and write its markers but never page Sentry.
+ *
+ * Preview mainnet crons run a deliberately non-admin `PAYMENT_API_KEY`, so
+ * they report unready pairs that live mainnet does not have. Fail-closed
+ * listing and pay behavior are unchanged here; only the page is suppressed.
+ *
+ * `VERCEL_ENV` is the primary signal, never `SENTRY_ENVIRONMENT`: the mainnet
+ * project sets that one to "production" on preview hosts too.
+ *
+ * The host fallback exists because `VERCEL_ENV` alone did not hold. CORE-37
+ * kept paging from `sokosumi-core-mainnet-*.preview.sokosumi.com` on a
+ * release that already carried the VERCEL_ENV-only gate. That is REPORTED
+ * from the Sentry issue behind PR #3956 and is not reproduced by these tests,
+ * so the fallback is written to be safe whether or not it is needed: the
+ * suffix IS this team's preview deployment suffix, so production Core never
+ * answers on it.
+ */
+export function isX402ReadinessPreviewDeploy(): boolean {
+  const env = getEnv();
+  return (
+    env.VERCEL_ENV === "preview" ||
+    hasPreviewHost(env.VERCEL_URL) ||
+    hasPreviewHost(env.VERCEL_BRANCH_URL)
+  );
+}
+
+/**
  * Exported for tests only: the total cap is unreachable through the public
  * entry point without fabricating dozens of erring wallet balance fetches
  * (three endpoint errors item-capped cannot exceed it), so it is pinned here.
@@ -215,14 +262,11 @@ export async function syncX402BuySideReadiness(
       // recorded: silence would otherwise be indistinguishable from a
       // healthy deployment that simply has no x402 agents.
       //
-      // Preview deploys (VERCEL_ENV === "preview") still warn and write the
-      // failure marker so fail-closed listing/pay behavior is unchanged, but
-      // they must not page Sentry — preview mainnet crons with a non-admin
-      // PAYMENT_API_KEY were flooding CORE-37 while live mainnet was fine.
-      // Use VERCEL_ENV, not SENTRY_ENVIRONMENT (mainnet project sets the
-      // latter to "production" on preview hosts too).
+      // Preview deploys still warn and write the failure marker, so
+      // fail-closed listing and pay behavior is unchanged; they just must not
+      // page. See isX402ReadinessPreviewDeploy for why the host is checked.
       if (
-        getEnv().VERCEL_ENV !== "preview" &&
+        !isX402ReadinessPreviewDeploy() &&
         (marker.count > 0 || hasNeverBeenRecorded)
       ) {
         Sentry.captureException(
@@ -317,7 +361,7 @@ export async function syncX402BuySideReadiness(
     // Latched on the transition like that page, so a lasting misconfiguration
     // does not spam; the per-pair warn log repeats every cycle regardless.
     // Preview runs a deliberately non-admin key (SOK-860) and must not page.
-    if (readinessChanged && getEnv().VERCEL_ENV !== "preview") {
+    if (readinessChanged && !isX402ReadinessPreviewDeploy()) {
       Sentry.captureMessage(
         "x402 buy-side readiness recorded payable pairs on an UNCAPPED payment-node API key. The key is usageLimited but holds no eip155 credit row, so the node grandfathers it and enforces no x402 spend cap: Soko will sign x402 payments with no ceiling. Grant credits for the listed units with PATCH /api/v1/api-key to make the intended cap real, or clear usageLimited on the key if uncapped is deliberate. The sync warn log names every affected pair",
         "warning",
@@ -341,8 +385,10 @@ export async function syncX402BuySideReadiness(
     // entry just as effectively as a failed check, so it must page too.
     // Authenticated callers may still discover dynamic agents, but the listing
     // marks them non-payable until a priced ready pair returns.
-    // Page only on the transition so a lasting outage does not spam.
-    if (readinessChanged) {
+    // Page only on the transition so a lasting outage does not spam, and
+    // never from a preview deploy: its non-admin key makes zero ready pairs
+    // the EXPECTED result there, which is what flooded CORE-39.
+    if (readinessChanged && !isX402ReadinessPreviewDeploy()) {
       Sentry.captureMessage(
         // The likeliest new cause is an operator one, not an outage: a chain
         // whose `defaultAssetDecimals` is still null publishes no scale, and


### PR DESCRIPTION
Replaces #3956, whose tests still drove the `getX402Budgets` client method that #3986 removed. Merged onto current `main` it fails `3 failed | 31 passed` with `ReferenceError: getX402BudgetsMock is not defined`.

## Why

The zero-ready-pairs `captureMessage` had **no preview guard at all**. SOK-860 / #3908 gated the check-failure `captureException` next to it on `VERCEL_ENV`, but the empty-pair page kept firing. A preview cron reaches that branch on every run: it holds a deliberately non-admin `PAYMENT_API_KEY`, so zero ready pairs is the expected result there, not an incident. That is CORE-39.

## Why `VERCEL_ENV` alone is not the fix

CORE-37 kept paging from `sokosumi-core-mainnet-*.preview.sokosumi.com` on a release that already carried the SOK-860 gate.

That observation is **REPORTED** from the Sentry issue behind #3956. I did not reproduce it, so the host fallback is written to be safe whether or not it is needed: `preview.sokosumi.com` is this team's Vercel [Preview Deployment Suffix](https://vercel.com/docs/deployments/preview-deployment-suffix) (`apps/core/AGENTS.md`, mirrored by the `https://*.preview.sokosumi.com` trustedOrigins entry in `lib/auth.ts`), so production Core never answers there and matching it cannot silence a real alert.

## What changed

One predicate, `isX402ReadinessPreviewDeploy()`, now serves all three Sentry sites in the file instead of three spellings of the same rule. It parses the URL rather than substring-matching the raw env value, so neither a path nor a subdomain-shaped tail reads as the suffix, and an unparsable host fails **toward** paging.

Warn logs and the cache write are untouched, so fail-closed listing and pay behavior are unchanged on preview.

## Note on #4040

#4040 deletes the uncapped-key block, which is one of the three call sites converted here. Whichever lands first, the other is a one-line rebase: if this lands first #4040 deletes a hunk that happens to call the predicate; if #4040 lands first that one edit simply drops out.

## Verification

- `pnpm --filter @sokosumi/core exec vitest run src/services/agent-sync.x402-readiness.test.ts`: `39 passed` (31 before, 8 new)
- `pnpm check` clean on 3678 files, `pnpm typecheck` 19/19

Mutation tested:

| Mutation | Test(s) that failed |
| --- | --- |
| drop the guard on the empty-pairs page | `does not page for zero ready pairs on a Vercel preview`, `... on a preview HOST that claims production` |
| drop the guard on the uncapped-key page | `does not page for an uncapped key on a Vercel preview` |
| drop the `VERCEL_URL` host check | `... on a preview HOST that claims production` |
| drop the `VERCEL_BRANCH_URL` host check | `matches the branch alias` |
| make the predicate always return `true` | 8 tests, incl. `still pages for zero ready pairs on a real production host` |