### PR TITLE
fix(dev): install Cloud Agent pnpm 12 via corepack

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "Sokosumi Monorepo",
   "agentCanUpdateSnapshot": true,
-  "install": "pnpm install && node scripts/cloud-agent-db/provision.mjs",
-  "start": "node scripts/cloud-agent-db/with-db.mjs -- pnpm dev"
+  "install": "bash scripts/cloud-agent-install.sh",
+  "start": "node scripts/cloud-agent-db/with-db.mjs -- corepack pnpm dev"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,7 +393,7 @@ Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily). Se
 
 ## Cursor Cloud specific instructions
 
-These notes cover non-obvious, durable facts about running this repo in the Cursor Cloud VM. The update script runs `pnpm install` then provisions an ephemeral Neon agent database when secrets are present (see below). Node, tooling, and non-DB `.env` values may still come from the VM snapshot.
+These notes cover non-obvious, durable facts about running this repo in the Cursor Cloud VM. The update script runs `bash scripts/cloud-agent-install.sh` (Corepack-activated `pnpm install`, then provision) when secrets are present (see below). Node, tooling, and non-DB `.env` values may still come from the VM snapshot. Do not invoke a snapshot `~/.local/share/pnpm/.tools/pnpm/12.x` shim directly — pnpm 12 leaves a shebang-less placeholder there (`Syntax error: ")" unexpected`); use `corepack pnpm`.
 
 ### Runtime versions
 
@@ -403,8 +403,8 @@ These notes cover non-obvious, durable facts about running this repo in the Curs
 
 Cloud agents get a **disposable Neon branch** forked from production/`main`, not a shared mutable DB and not live production writes.
 
-- **Provision:** `.cursor/environment.json` `install` runs `node scripts/cloud-agent-db/provision.mjs` after `pnpm install` when `CURSOR_AGENT=1` and `NEON_API_KEY` + `NEON_PROJECT_ID` are set (Cursor Runtime Secrets). Branch name: `cloud-agent-<CURSOR_CONVERSATION_ID>`. Parent is always `NEON_PARENT_BRANCH` (default `main`). Resume reuses the same branch and refreshes the **72h** `expires_at` TTL. Pending migrations run via `pnpm prisma:migrate:deploy` (`DATABASE_URL_UNPOOLED`). After migrate, upserts guarded auth fixtures (`admin@sokosumi.test` / `alice@sokosumi.test` / `bob@sokosumi.test` / `zero@sokosumi.test` / `Password123!`) on agent branches only — **not** a full catalog seed.
-- **Use:** Prefer `node scripts/cloud-agent-db/with-db.mjs -- <command>` so ambient/stale `DATABASE_URL` cannot win. `start` already wraps `pnpm dev`. Login shells source `.cursor/cloud-agent-db.env` via bashrc/profile.
+- **Provision:** `.cursor/environment.json` `install` is `bash scripts/cloud-agent-install.sh` (Corepack `pnpm@` from `package.json`, then `corepack pnpm install`, then `node scripts/cloud-agent-db/provision.mjs`) when `CURSOR_AGENT=1` and `NEON_API_KEY` + `NEON_PROJECT_ID` are set (Cursor Runtime Secrets). Branch name: `cloud-agent-<CURSOR_CONVERSATION_ID>`. Parent is always `NEON_PARENT_BRANCH` (default `main`). Resume reuses the same branch and refreshes the **72h** `expires_at` TTL. Pending migrations run via `pnpm prisma:migrate:deploy` (`DATABASE_URL_UNPOOLED`). After migrate, upserts guarded auth fixtures (`admin@sokosumi.test` / `alice@sokosumi.test` / `bob@sokosumi.test` / `zero@sokosumi.test` / `Password123!`) on agent branches only — **not** a full catalog seed.
+- **Use:** Prefer `node scripts/cloud-agent-db/with-db.mjs -- <command>` so ambient/stale `DATABASE_URL` cannot win. `start` already wraps `corepack pnpm dev`. Login shells source `.cursor/cloud-agent-db.env` via bashrc/profile.
 - **Teardown:** deletes only `cloud-agent-*` branches — never production/`main`. Triggers: PR merged/closed (GitHub Action parses `bc-…` from PR body), agent completes with no PR (`pnpm cloud-agent-db:teardown`), agent archived (same when possible). Idle **72h** expiry is Neon `expires_at` only (no scheduled Action GC).
 - **Do not** put a static production `DATABASE_URL` in Cursor secrets. Full runbook: [`docs/agents/cloud-agent-database.md`](./docs/agents/cloud-agent-database.md).
 

--- a/docs/agents/cloud-agent-database.md
+++ b/docs/agents/cloud-agent-database.md
@@ -30,10 +30,12 @@ branch named `cloud-agent-<run-id>`.
 
 ## Provision (how agents get the URL)
 
-`.cursor/environment.json` runs provision after `pnpm install`:
+`.cursor/environment.json` runs `bash scripts/cloud-agent-install.sh`, which
+activates the repo-pinned pnpm via Corepack (pnpm 12's tools-cache shim is a
+shebang-less placeholder), then `corepack pnpm install` and provision:
 
 ```bash
-pnpm install && node scripts/cloud-agent-db/provision.mjs
+bash scripts/cloud-agent-install.sh
 ```
 
 When `CURSOR_AGENT=1` and Neon secrets are present, provision:

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Cloud Agent / environment-build install.
+#
+# pnpm 12 ships a native binary. The npm tarball's `pnpm` file is a shebang-less
+# placeholder that `install.js` replaces. Corepack skips lifecycle scripts, and
+# pnpm's tools cache at ~/.local/share/pnpm/.tools/pnpm/<ver> can keep that
+# placeholder. Executing it with /bin/sh fails:
+#   /home/ubuntu/.local/share/pnpm/.tools/pnpm/12.1.0/bin/pnpm: 4: Syntax error: ")" unexpected
+# Corepack's own entry downloads the native binary. Always install through it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PACKAGE_MANAGER="$(node -p "require('./package.json').packageManager")"
+if [[ ! "$PACKAGE_MANAGER" =~ ^pnpm@ ]]; then
+  echo "cloud-agent-install: expected packageManager pnpm@*, got ${PACKAGE_MANAGER}" >&2
+  exit 1
+fi
+
+corepack enable
+corepack prepare "$PACKAGE_MANAGER" --activate
+rm -rf "${HOME}/.local/share/pnpm/.tools/${PACKAGE_MANAGER/@/\/}"
+
+corepack pnpm install
+node scripts/cloud-agent-db/provision.mjs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud environment builds started failing after the repo pinned `packageManager` to `pnpm@12.1.0` (`#4049`).

Failed build [`bld-20260831-e172e841-1cee-4382-8a58-57c471289cae`](https://cursor.com/dashboard/cloud-agents/builds/bld-20260831-e172e841-1cee-4382-8a58-57c471289cae) died immediately on:

```
/home/ubuntu/.local/share/pnpm/.tools/pnpm/12.1.0/bin/pnpm: 4: Syntax error: ")" unexpected
```

pnpm 12 ships a native binary. The npm tarball’s `pnpm` file is a shebang-less placeholder that `install.js` is supposed to replace. The snapshot tools cache kept that placeholder; `/bin/sh` then parsed `e.g. allow-list` and exited 2. The last successful recurring build still used pnpm 11.24.0.

## Change

- Add `scripts/cloud-agent-install.sh`: enable Corepack, activate the repo-pinned `pnpm@` version, delete the broken tools-cache shim, then `corepack pnpm install` + provision.
- Point `.cursor/environment.json` `install` / `start` at that path.

The personal Cloud environment is still dashboard-managed. Saving the proposed environment config is required before new agents pick it up.

## Verification

1. Recreated the placeholder shim on the failed-build VM → same `Syntax error: ")" unexpected`, exit 2.
2. `bash scripts/cloud-agent-install.sh` → `pnpm -v` / `corepack pnpm -v` = `12.1.0`.
3. Draft build [`bld-20260831-1abd8c40-5633-4ee3-bcf1-669777ab9a88`](https://cursor.com/dashboard/cloud-agents/builds/bld-20260831-1abd8c40-5633-4ee3-bcf1-669777ab9a88) **SUCCEEDED**: `Done in 25.2s using pnpm v12.1.0`.
4. Fresh agent on that build: `pnpm -v` = 12.1.0, 11 workspace projects present, `@sokosumi/utils` typecheck passed.

## Action

Click **Save** on the Environment panel to apply the tested Corepack install to future agents.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38ccff81-8641-4a06-b063-d27a2e135ba0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38ccff81-8641-4a06-b063-d27a2e135ba0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

