### PR TITLE
fix(soko-bot): say what failed in a lab result instead of showing the haystack

### DIFF
--- a/apps/core/src/helpers/loaded-relation-summaries.ts
+++ b/apps/core/src/helpers/loaded-relation-summaries.ts
@@ -96,6 +96,7 @@ interface OrchestratorLoadedRelation {
   id: string;
   name: string | null;
   avatarSeed: string | null;
+  avatarImageUrl: string | null;
   userId: string;
   user: UserSummaryFields | null;
 }
@@ -104,6 +105,7 @@ export interface OrchestratorSummaryFields {
   id: string;
   name: string | null;
   avatarSeed: string | null;
+  avatarImageUrl: string | null;
   owner: UserSummaryFields;
 }
 
@@ -130,6 +132,9 @@ export function orchestratorSummaryFromLoadedRelation(
     id: orchestrator.id,
     name: orchestrator.name,
     avatarSeed: orchestrator.avatarSeed,
+    // Claiming a mascot writes both this and the coworker's image, which is
+    // why one showed in chat and not here: only chat read the coworker.
+    avatarImageUrl: orchestrator.avatarImageUrl,
     owner: userSummaryFromLoadedRelation(
       `${context} orchestrator owner`,
       orchestrator.userId,

--- a/apps/core/src/schemas/orchestrator.schema.ts
+++ b/apps/core/src/schemas/orchestrator.schema.ts
@@ -11,6 +11,10 @@ export const orchestratorSummarySchema = z
     avatarSeed: z.string().nullable().openapi({
       example: "orb:jewel-sky:user_123",
     }),
+    /** A claimed mascot. When set it is the bot's face; the orb is the fallback. */
+    avatarImageUrl: z.string().nullable().openapi({
+      example: "https://blob.example/mascot.png",
+    }),
     owner: userSummarySchema,
   })
   .openapi("OrchestratorSummary");

--- a/apps/core/src/types/task.ts
+++ b/apps/core/src/types/task.ts
@@ -17,6 +17,7 @@ export const taskEventApiInclude = {
       id: true,
       name: true,
       avatarSeed: true,
+      avatarImageUrl: true,
       userId: true,
       user: { select: { id: true, name: true, image: true } },
     },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4339,7 +4339,8 @@
           "noBotDescription": "Läufe nutzen deinen eigenen Assistenten.",
           "noBotLink": "Hier erstellen.",
           "runsAgainst": "Jeder Lauf ist ein echter Durchlauf von {bot}, dem Assistenten von {account}.",
-          "unnamedBot": "deinem Assistenten"
+          "unnamedBot": "deinem Assistenten",
+          "failedChecks": "Fehlgeschlagen: {labels}"
         },
         "KillSwitch": {
           "title": "Funktionsschalter",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4370,7 +4370,8 @@
           "noBotDescription": "Runs use your own assistant.",
           "noBotLink": "Create it here.",
           "runsAgainst": "Every run is a real turn on {bot}, the assistant belonging to {account}.",
-          "unnamedBot": "your assistant"
+          "unnamedBot": "your assistant",
+          "failedChecks": "Failed: {labels}"
         },
         "KillSwitch": {
           "title": "Feature switch",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4339,7 +4339,8 @@
           "noBotDescription": "Las ejecuciones usan tu propio asistente.",
           "noBotLink": "Créalo aquí.",
           "runsAgainst": "Cada ejecución es un turno real de {bot}, el asistente de {account}.",
-          "unnamedBot": "tu asistente"
+          "unnamedBot": "tu asistente",
+          "failedChecks": "Fallaron: {labels}"
         },
         "KillSwitch": {
           "title": "Interruptor de la función",

--- a/apps/web/src/app/(app)/tasks/components/task-activity.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.test.tsx
@@ -706,6 +706,7 @@ describe("TaskActivitySection", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          avatarImageUrl: null,
           owner: {
             id: "user-1",
             name: "Ada Lovelace",
@@ -742,6 +743,7 @@ describe("TaskActivitySection", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: null,
+          avatarImageUrl: null,
           owner: {
             id: "user-1",
             name: "Ada Lovelace",
@@ -779,6 +781,7 @@ describe("TaskActivitySection", () => {
             id: "orch-1",
             name: "Hermes",
             avatarSeed: "orb:jewel-sky:user_123",
+            avatarImageUrl: null,
             owner: {
               id: "user-1",
               name: "Ada Lovelace",
@@ -799,6 +802,7 @@ describe("TaskActivitySection", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          avatarImageUrl: null,
           owner: {
             id: "user-1",
             name: "Ada Lovelace",

--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -492,7 +492,11 @@ export function TaskActivitySection({
                   })
                 : (actorInfo?.name ?? actorLabel);
             const actorImage = actorInfo?.image ?? null;
-            const showAssistantOrb = actorKind === "orchestrator";
+            // Only when the bot has no mascot of its own: a claimed image is
+            // its face in chat and the sidebar, and an orb here made the same
+            // assistant look like two different ones.
+            const showAssistantOrb =
+              actorKind === "orchestrator" && !actorInfo?.image;
             const ChannelIcon = CHANNEL_ICON_MAP[event.channel];
             const channelAppName = t(
               `channelApp.${CHANNEL_APP_NAME_KEY_MAP[event.channel]}`,

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
@@ -140,6 +140,7 @@ describe("TaskMetadata", () => {
               id: "01960001-0001-7001-8001-000000000099",
               name: "Hermes",
               avatarSeed: null,
+              avatarImageUrl: null,
               owner: {
                 id: "user_2",
                 name: "Ada Lovelace",
@@ -212,6 +213,7 @@ describe("TaskMetadata", () => {
               id: "01960001-0001-7001-8001-000000000099",
               name: "Ada Lovelace's personal assistant",
               avatarSeed: null,
+              avatarImageUrl: null,
               owner: { id: "user_2", name: "Ada Lovelace", image: null },
             },
           },

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
@@ -169,6 +169,38 @@ describe("TaskMetadata", () => {
     );
   });
 
+  it("shows the mascot the bot claimed, not a generated orb", () => {
+    // Claiming writes the coworker's image too, so the picture appeared in
+    // chat and the sidebar while a Task showed a blank disc for the same bot.
+    render(
+      <TaskMetadata
+        task={createTask({
+          creator: {
+            type: "orchestrator",
+            id: "01960001-0001-7001-8001-000000000099",
+            orchestrator: {
+              id: "01960001-0001-7001-8001-000000000099",
+              name: "Joseph",
+              avatarSeed: null,
+              avatarImageUrl: "https://blob.example/cat.png",
+              owner: { id: "user_2", name: "Ada Lovelace", image: null },
+            },
+          },
+        })}
+        project={null}
+        createdAtLabel="Jul 16, 10:28 AM"
+        updatedAtLabel="Jul 16, 10:29 AM"
+        labels={baseLabels}
+      />,
+    );
+
+    // Radix only swaps in the <img> once it loads, which never happens in
+    // jsdom, so the regression itself is the assertion: no orb stands in for
+    // a bot that has a face of its own.
+    expect(screen.queryByTestId("assistant-orb")).not.toBeInTheDocument();
+    expect(screen.getByText("Joseph")).toBeInTheDocument();
+  });
+
   it("does not print the role twice when the bot is named after it", () => {
     render(
       <TaskMetadata

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -90,17 +90,24 @@ function resolveTaskCreatorDisplay(
       // assistant did it, or on whose behalf.
       const assistantName = orchestrator.name ?? "Assistant";
       const role = formatOrchestratorRole({ owner: orchestrator.owner.name });
+      // A claimed mascot is the bot's face everywhere else, so the orb is the
+      // fallback, not the rule. Claiming writes the coworker's image too,
+      // which is why chat showed the picture and this showed a blank disc.
+      const claimed = orchestrator.avatarImageUrl
+        ? resolveIpfsOrHttpUrl(orchestrator.avatarImageUrl)
+        : null;
       return {
         name: assistantName,
         // A bot named "Ada's personal assistant" would otherwise print the
         // same sentence twice.
         role: role.toLowerCase() === assistantName.toLowerCase() ? null : role,
-        image: null,
+        image: claimed,
         // Same fallback the sidebar and the Soko Bots page use. `avatarSeed`
         // is null for every bot, and passing that through rendered a different
         // face here than the one the owner sees everywhere else.
-        avatarSeed:
-          orchestrator.avatarSeed ?? defaultOrbSeed(orchestrator.owner.id),
+        avatarSeed: claimed
+          ? null
+          : (orchestrator.avatarSeed ?? defaultOrbSeed(orchestrator.owner.id)),
       };
     }
     default: {
@@ -285,7 +292,7 @@ function MetadataAvatarValue({
     <div className="flex items-center justify-between gap-4">
       <span className="text-muted-foreground text-sm">{label}</span>
       <div className="flex min-w-0 items-center gap-2">
-        {avatarSeed !== undefined ? (
+        {avatarSeed ? (
           <AssistantOrb
             seed={avatarSeed}
             // Resting eyes so the creator chip reads as the assistant's

--- a/apps/web/src/app/(app)/tasks/utils/task-activity-actors.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-activity-actors.test.ts
@@ -20,6 +20,7 @@ describe("resolveTaskEventActorKind", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          avatarImageUrl: null,
         },
       },
       userId: "user-1",
@@ -88,6 +89,7 @@ describe("getEventActorInfo", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          avatarImageUrl: null,
           owner: {
             id: "user-1",
             name: "Ada Lovelace",
@@ -128,6 +130,7 @@ describe("buildTaskActivityActors", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          avatarImageUrl: null,
           owner: {
             id: "user-1",
             name: "Ada Lovelace",
@@ -214,6 +217,7 @@ describe("buildTaskActivityActors", () => {
               id: "orch-2",
               name: "Athena",
               avatarSeed: null,
+              avatarImageUrl: null,
               owner: {
                 id: "user-3",
                 name: "Grace Hopper",
@@ -230,6 +234,7 @@ describe("buildTaskActivityActors", () => {
             id: "orch-2",
             name: "Athena",
             avatarSeed: null,
+            avatarImageUrl: null,
             owner: {
               id: "user-3",
               name: "Grace Hopper",

--- a/apps/web/src/app/(app)/tasks/utils/task-activity-actors.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-activity-actors.ts
@@ -31,6 +31,7 @@ type OrchestratorActorSummary = {
   id: string;
   name: string | null;
   avatarSeed?: string | null;
+  avatarImageUrl?: string | null;
   owner: {
     id: string;
     name: string;
@@ -218,12 +219,17 @@ function orchestratorActorInfo(
 ): TaskActivityActorInfo {
   return {
     name: orchestrator.name ?? "Assistant",
-    image: null,
+    // A claimed mascot is the bot's face everywhere else; the orb is only the
+    // fallback for a bot that has not picked one.
+    image: orchestrator.avatarImageUrl
+      ? resolveIpfsOrHttpUrl(orchestrator.avatarImageUrl)
+      : null,
     // Same fallback the sidebar and the Soko Bots page use. `avatarSeed` is
     // null for every bot, and passing that through rendered a different face
     // here than the one the owner sees everywhere else.
-    avatarSeed:
-      orchestrator.avatarSeed ?? defaultOrbSeed(orchestrator.owner.id),
+    avatarSeed: orchestrator.avatarImageUrl
+      ? null
+      : (orchestrator.avatarSeed ?? defaultOrbSeed(orchestrator.owner.id)),
     ownerName: orchestrator.owner.name,
   };
 }

--- a/apps/web/src/components/admin/soko-bots/scenario-lab.client.tsx
+++ b/apps/web/src/components/admin/soko-bots/scenario-lab.client.tsx
@@ -524,32 +524,46 @@ function ScenarioRow({
                   ) : null}
                 </div>
               ) : null}
+              {/* Failures first. Nine rows of mostly ticks buries the two that
+                  matter, and the reader should not have to hunt for them. */}
+              {latest.checks.some((check) => !check.pass) ? (
+                <p className="text-semantic-destructive text-xs font-medium">
+                  {t("failedChecks", {
+                    labels: latest.checks
+                      .filter((check) => !check.pass)
+                      .map((check) => check.label)
+                      .join(", "),
+                  })}
+                </p>
+              ) : null}
               <ul className="space-y-1">
-                {latest.checks.map((check) => (
-                  <li
-                    key={check.label}
-                    className="flex items-start gap-2 text-xs"
-                  >
-                    {check.pass ? (
-                      <Check
-                        aria-hidden
-                        className="text-semantic-success mt-0.5 size-3.5 shrink-0"
-                      />
-                    ) : (
-                      <X
-                        aria-hidden
-                        className="text-semantic-destructive mt-0.5 size-3.5 shrink-0"
-                      />
-                    )}
-                    <span className="min-w-0">
-                      <span className="font-medium">{check.label}</span>
-                      <span className="text-muted-foreground">
-                        {" — "}
-                        {check.actual}
+                {[...latest.checks]
+                  .sort((a, b) => Number(a.pass) - Number(b.pass))
+                  .map((check) => (
+                    <li
+                      key={check.label}
+                      className="flex items-start gap-2 text-xs"
+                    >
+                      {check.pass ? (
+                        <Check
+                          aria-hidden
+                          className="text-semantic-success mt-0.5 size-3.5 shrink-0"
+                        />
+                      ) : (
+                        <X
+                          aria-hidden
+                          className="text-semantic-destructive mt-0.5 size-3.5 shrink-0"
+                        />
+                      )}
+                      <span className="min-w-0">
+                        <span className="font-medium">{check.label}</span>
+                        <span className="text-muted-foreground">
+                          {" — "}
+                          {check.actual}
+                        </span>
                       </span>
-                    </span>
-                  </li>
-                ))}
+                    </li>
+                  ))}
               </ul>
             </div>
           ) : (

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -4702,6 +4702,13 @@ export const OrchestratorSummarySchema = {
             ],
             example: 'orb:jewel-sky:user_123'
         },
+        avatarImageUrl: {
+            type: [
+                'string',
+                'null'
+            ],
+            example: 'https://blob.example/mascot.png'
+        },
         owner: {
             $ref: '#/components/schemas/UserSummary'
         }
@@ -4710,6 +4717,7 @@ export const OrchestratorSummarySchema = {
         'id',
         'name',
         'avatarSeed',
+        'avatarImageUrl',
         'owner'
     ]
 } as const;
@@ -4854,6 +4862,13 @@ export const TaskEventSchema = {
                     ],
                     example: 'orb:jewel-sky:user_123'
                 },
+                avatarImageUrl: {
+                    type: [
+                        'string',
+                        'null'
+                    ],
+                    example: 'https://blob.example/mascot.png'
+                },
                 owner: {
                     $ref: '#/components/schemas/UserSummary'
                 }
@@ -4862,6 +4877,7 @@ export const TaskEventSchema = {
                 'id',
                 'name',
                 'avatarSeed',
+                'avatarImageUrl',
                 'owner'
             ],
             deprecated: true,

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1135,6 +1135,7 @@ export type OrchestratorSummary = {
     id: string;
     name: string | null;
     avatarSeed: string | null;
+    avatarImageUrl: string | null;
     owner: UserSummary;
 };
 
@@ -1192,6 +1193,7 @@ export type TaskEvent = {
         id: string;
         name: string | null;
         avatarSeed: string | null;
+        avatarImageUrl: string | null;
         owner: UserSummary;
     } | null;
     transactionId?: string | null;

--- a/packages/soko-bot/src/__tests__/scenarios.test.ts
+++ b/packages/soko-bot/src/__tests__/scenarios.test.ts
@@ -232,6 +232,26 @@ describe("evaluateScenario", () => {
     expect(check?.actual).toBe("schedule points somewhere else");
   });
 
+  it("does not accept an id that merely sits inside a longer one", () => {
+    // "task-1" appearing within "task-10" is a different task, and reporting
+    // that schedule as correct is the failure this check exists to catch.
+    const result = evaluateScenario(
+      byId("delegate-with-daily-checkin"),
+      turn({
+        toolCalls: [
+          call("create_task"),
+          call("update_schedule", scheduleFor("task-10")),
+        ],
+        delegations: [{ id: "d1", taskId: "task-1", jobId: null }],
+      }),
+    );
+
+    const check = result.checks.find(
+      (c) => c.label === "Schedule names a task from this turn",
+    );
+    expect(check?.pass).toBe(false);
+  });
+
   it("fails a bare promise to follow up without a schedule", () => {
     const result = evaluateScenario(
       byId("delegate-with-daily-checkin"),

--- a/packages/soko-bot/src/__tests__/scenarios.test.ts
+++ b/packages/soko-bot/src/__tests__/scenarios.test.ts
@@ -20,8 +20,16 @@ function turn(overrides: Partial<SokoBotLabTurn>): SokoBotLabTurn {
   };
 }
 
-function call(capability: string): SokoBotLabTurn["toolCalls"][number] {
-  return { capability, status: "COMPLETED", result: null };
+function call(
+  capability: string,
+  result: unknown = null,
+): SokoBotLabTurn["toolCalls"][number] {
+  return { capability, status: "COMPLETED", result };
+}
+
+/** A schedule row as the tool returns it, naming the Task it watches. */
+function scheduleFor(taskId: string) {
+  return { id: "sch-1", prompt: `Check on task ${taskId} and nudge me.` };
 }
 
 const byId = (id: string): SokoBotScenario => {
@@ -120,7 +128,7 @@ describe("evaluateScenario", () => {
         toolCalls: [
           call("find_coworkers"),
           call("create_task"),
-          call("create_schedule"),
+          call("create_schedule", scheduleFor("task-1")),
         ],
         finalAnswer: "Created it and I'll check every weekday at 9.",
         delegations: [{ id: "d1", taskId: "task-1", jobId: null }],
@@ -164,7 +172,10 @@ describe("evaluateScenario", () => {
     const result = evaluateScenario(
       byId("delegate-with-daily-checkin"),
       turn({
-        toolCalls: [call("create_task"), call("update_schedule")],
+        toolCalls: [
+          call("create_task"),
+          call("update_schedule", scheduleFor("task-1")),
+        ],
         finalAnswer: "Created the brief and pointed your daily check at it.",
         delegations: [{ id: "d1", taskId: "task-1", jobId: null }],
       }),
@@ -199,6 +210,28 @@ describe("evaluateScenario", () => {
     expect(check?.actual).toBe("never called — used get_task_status");
   });
 
+  it("fails a schedule left pointing at some other task", () => {
+    // "Called a schedule tool" is not the same as following up on the brief:
+    // reusing yesterday's check-in without repointing it watches the wrong
+    // work and reads, from the outside, exactly like success.
+    const result = evaluateScenario(
+      byId("delegate-with-daily-checkin"),
+      turn({
+        toolCalls: [
+          call("create_task"),
+          call("update_schedule", scheduleFor("some-older-task")),
+        ],
+        delegations: [{ id: "d1", taskId: "task-1", jobId: null }],
+      }),
+    );
+
+    const check = result.checks.find(
+      (c) => c.label === "Schedule names a task from this turn",
+    );
+    expect(check?.pass).toBe(false);
+    expect(check?.actual).toBe("schedule points somewhere else");
+  });
+
   it("fails a bare promise to follow up without a schedule", () => {
     const result = evaluateScenario(
       byId("delegate-with-daily-checkin"),
@@ -211,6 +244,7 @@ describe("evaluateScenario", () => {
     const failed = result.checks.filter((c) => !c.pass).map((c) => c.label);
     expect(failed).toEqual([
       "Calls one of create_schedule, update_schedule",
+      "Schedule names a task from this turn",
       "No follow-up promise without a schedule",
     ]);
   });

--- a/packages/soko-bot/src/__tests__/scenarios.test.ts
+++ b/packages/soko-bot/src/__tests__/scenarios.test.ts
@@ -158,6 +158,47 @@ describe("evaluateScenario", () => {
     expect(result.passed).toBe(result.total);
   });
 
+  it("accepts an existing daily schedule pointed at the new task", () => {
+    // Reusing the schedule the owner already has is a real follow-up, and a
+    // tidier one than a second daily check-in beside it.
+    const result = evaluateScenario(
+      byId("delegate-with-daily-checkin"),
+      turn({
+        toolCalls: [call("create_task"), call("update_schedule")],
+        finalAnswer: "Created the brief and pointed your daily check at it.",
+        delegations: [{ id: "d1", taskId: "task-1", jobId: null }],
+      }),
+    );
+
+    expect(result.checks.filter((c) => !c.pass)).toEqual([]);
+  });
+
+  it("names the tool that failed rather than only listing it", () => {
+    // "No failed tool calls — assign_task" reads as an answer to the label.
+    const result = evaluateScenario(
+      byId("delegate-with-daily-checkin"),
+      turn({
+        toolCalls: [
+          call("create_task"),
+          { ...call("assign_task"), status: "FAILED" },
+        ],
+      }),
+    );
+
+    const check = result.checks.find((c) => c.label === "No failed tool calls");
+    expect(check?.actual).toBe("assign_task failed");
+  });
+
+  it("says a tool was never called instead of printing the haystack", () => {
+    const result = evaluateScenario(
+      byId("delegate-with-daily-checkin"),
+      turn({ toolCalls: [call("get_task_status")] }),
+    );
+
+    const check = result.checks.find((c) => c.label === "Calls create_task");
+    expect(check?.actual).toBe("never called — used get_task_status");
+  });
+
   it("fails a bare promise to follow up without a schedule", () => {
     const result = evaluateScenario(
       byId("delegate-with-daily-checkin"),
@@ -169,7 +210,7 @@ describe("evaluateScenario", () => {
     );
     const failed = result.checks.filter((c) => !c.pass).map((c) => c.label);
     expect(failed).toEqual([
-      "Calls create_schedule",
+      "Calls one of create_schedule, update_schedule",
       "No follow-up promise without a schedule",
     ]);
   });

--- a/packages/soko-bot/src/scenarios.ts
+++ b/packages/soko-bot/src/scenarios.ts
@@ -101,7 +101,12 @@ export const SOKO_BOT_SCENARIOS: SokoBotScenario[] = [
       "Create a task for a one-page research brief on the top 5 EU AI-agent marketplaces (pricing, positioning, funding), due end of next week, and assign it to whoever on the team handles research (leave it unassigned and tell me if nobody fits). Then check on it every weekday at 9:00 Europe/Berlin and nudge me if it is not moving.",
     expect: {
       routes: ["DELEGATE_TASK", "MIXED"],
-      tools: ["create_task", "create_schedule"],
+      tools: ["create_task"],
+      // The intent is a real follow-up rather than a promise of one. Pointing
+      // an existing daily schedule at the new Task does that as well as
+      // creating a second one does — better, in fact — so demanding
+      // `create_schedule` marked the bot down for the tidier answer.
+      anyTools: ["create_schedule", "update_schedule"],
       forbiddenTools: ["hire_agent"],
       minDelegations: 1,
       noEmptyPromise: true,
@@ -539,28 +544,37 @@ export function evaluateScenario(
   checks.push({
     label: "No failed tool calls",
     pass: failedTools.length === 0,
+    // A bare tool name under a "no failed calls" label reads as the answer to
+    // the label rather than as the thing that broke. Say which verb applies.
     actual:
       failedTools.length === 0
         ? "clean"
-        : failedTools.map((c) => c.capability).join(", "),
+        : `${list(failedTools.map((c) => c.capability))} failed`,
   });
   checks.push({
     label: `Route ∈ ${expect.routes.join(" | ")}`,
     pass: turn.route !== null && expect.routes.includes(turn.route),
     actual: turn.route ?? "UNCLASSIFIED",
   });
+  // A failing "Calls X" used to print the whole tool list and leave the reader
+  // to notice X was absent from it. Lead with the verdict; the list is the
+  // evidence behind it, not the finding.
   for (const tool of expect.tools ?? []) {
     checks.push({
       label: `Calls ${tool}`,
       pass: tools.has(tool),
-      actual: list(tools),
+      actual: tools.has(tool) ? "called" : `never called — used ${list(tools)}`,
     });
   }
   if (expect.anyTools?.length) {
+    const used = expect.anyTools.filter((tool) => tools.has(tool));
     checks.push({
       label: `Calls one of ${expect.anyTools.join(", ")}`,
-      pass: expect.anyTools.some((tool) => tools.has(tool)),
-      actual: list(tools),
+      pass: used.length > 0,
+      actual:
+        used.length > 0
+          ? `called ${list(used)}`
+          : `none called — used ${list(tools)}`,
     });
   }
   if (expect.forbiddenTools?.length) {

--- a/packages/soko-bot/src/scenarios.ts
+++ b/packages/soko-bot/src/scenarios.ts
@@ -72,6 +72,12 @@ export interface SokoBotScenario {
     asksQuestion?: boolean;
     /** The answer must not promise a later check without a schedule. */
     noEmptyPromise?: boolean;
+    /**
+     * A schedule the turn created or updated must name a Task the same turn
+     * touched. Without it "called a schedule tool" passes a bot that pointed
+     * the owner's daily check at whatever it happened to be watching before.
+     */
+    scheduleTargetsTouchedTask?: boolean;
     /** Every UUID in the answer must appear in a tool result or delegation. */
     noInventedIds?: boolean;
     /** Must answer the Coworker (reply_to_task) or ask the owner one question. */
@@ -107,6 +113,10 @@ export const SOKO_BOT_SCENARIOS: SokoBotScenario[] = [
       // creating a second one does — better, in fact — so demanding
       // `create_schedule` marked the bot down for the tidier answer.
       anyTools: ["create_schedule", "update_schedule"],
+      // Either tool is fine, but the schedule has to point at the Task this
+      // turn made — reusing one that still watches something else is not a
+      // follow-up on the brief.
+      scheduleTargetsTouchedTask: true,
       forbiddenTools: ["hire_agent"],
       minDelegations: 1,
       noEmptyPromise: true,
@@ -585,13 +595,38 @@ export function evaluateScenario(
       actual: violated.length > 0 ? `called ${list(violated)}` : "clean",
     });
   }
-  if (expect.minDelegations !== undefined) {
-    // A READY task becomes an approval instead of a delegation; both count
-    // as work the turn set in motion.
-    const touched = new Set([
+  // A READY task becomes an approval instead of a delegation; both count as
+  // work the turn set in motion.
+  const touchedIds = new Set(
+    [
       ...turn.delegations.map((d) => d.taskId ?? d.jobId ?? d.id),
       ...turn.decisions.map((d) => d.resultingEntityId ?? d.id),
-    ]).size;
+    ].filter((id): id is string => Boolean(id)),
+  );
+  if (expect.scheduleTargetsTouchedTask) {
+    const scheduleResults = turn.toolCalls
+      .filter(
+        (call) =>
+          call.capability === "create_schedule" ||
+          call.capability === "update_schedule",
+      )
+      .map((call) => JSON.stringify(call.result ?? ""));
+    const hit = scheduleResults.find((text) =>
+      Array.from(touchedIds).some((id) => text.includes(id)),
+    );
+    checks.push({
+      label: "Schedule names a task from this turn",
+      pass: Boolean(hit),
+      actual:
+        scheduleResults.length === 0
+          ? "no schedule touched"
+          : hit
+            ? "names it"
+            : "schedule points somewhere else",
+    });
+  }
+  if (expect.minDelegations !== undefined) {
+    const touched = touchedIds.size;
     checks.push({
       label: `≥ ${expect.minDelegations} tasks/jobs touched`,
       pass: touched >= expect.minDelegations,
@@ -672,7 +707,10 @@ export function evaluateScenario(
   }
   if (expect.noEmptyPromise) {
     const promised = EMPTY_PROMISE.test(answer);
-    const scheduled = tools.has("create_schedule");
+    // Updating an existing schedule keeps the promise as well as creating one
+    // does; counting only creation failed the bot for the tidier answer.
+    const scheduled =
+      tools.has("create_schedule") || tools.has("update_schedule");
     checks.push({
       label: "No follow-up promise without a schedule",
       pass: !promised || scheduled,

--- a/packages/soko-bot/src/scenarios.ts
+++ b/packages/soko-bot/src/scenarios.ts
@@ -611,8 +611,16 @@ export function evaluateScenario(
           call.capability === "update_schedule",
       )
       .map((call) => JSON.stringify(call.result ?? ""));
+    // Bounded rather than a substring test: an id that merely appears inside
+    // a longer one is a different task, and matching it would report the
+    // wrong schedule as correct.
+    const namesTouchedTask = (text: string, id: string) =>
+      new RegExp(
+        `(^|[^0-9a-z-])${id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([^0-9a-z-]|$)`,
+        "i",
+      ).test(text);
     const hit = scheduleResults.find((text) =>
-      Array.from(touchedIds).some((id) => text.includes(id)),
+      Array.from(touchedIds).some((id) => namesTouchedTask(text, id)),
     );
     checks.push({
       label: "Schedule names a task from this turn",


### PR DESCRIPTION
Reading a failed scenario meant deducing the finding from raw data.

## Before

> ✗ **No failed tool calls** — assign_task
> ✗ **Calls create_schedule** — get_task_status, list_schedules, assign_task, create_task, update_schedule

The first reads as an *answer* to the label. The second is a list you have to scan for something that is not in it.

## After

> ✗ **No failed tool calls** — assign_task failed
> ✗ **Calls one of create_schedule, update_schedule** — none called — used …

Failures state the verdict and keep the data behind it as evidence. The card also names the failed checks in a line above the list and sorts them to the top — nine rows of mostly ticks bury the two that matter.

## One of those failures was the check, not the bot

`delegate-with-daily-checkin` demanded `create_schedule`. Its stated intent is *"sets up a real daily follow-up schedule instead of promising one."* The bot pointed the owner's **existing** daily schedule at the new Task, which does that — arguably better than adding a second daily check-in beside the first.

The judge agreed and scored the turn a pass, calling out that *"the daily schedule was updated (not created fresh, but reused and corrected), pointing to the new task ID."* The deterministic check disagreed with the judge, and the check was wrong. `anyTools: ["create_schedule", "update_schedule"]` now.

The other failure is real signal and stays: `assign_task` genuinely failed on that turn, and the bot did not say so in its answer.

## Verification

Run without pnpm — `main` pinned `packageManager` to pnpm 12.1.0 and my local version manager cannot install it (it ships a native binary the npm tarball only stubs). Binaries invoked directly instead:

- `biome check .` — 3695 files, clean
- `tsc --noEmit` — core and web, clean
- `vitest` — 15 in `packages/soko-bot` (3 new: an updated schedule passing, the named failed tool, the never-called wording), 20 in the lab components

CI is the authority on the full suite here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt6But7wNmMpRx4C7ykdnV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orchestrator avatars now appear in task activity and metadata when available, with the assistant orb as a fallback.
  * Scenario Lab results prioritize failed checks and summarize failure labels.
  * Daily check-in validation supports schedule creation and updates tied to recently handled tasks.

* **Bug Fixes**
  * Improved avatar handling for image URLs across task views.
  * Enhanced schedule validation and diagnostics for missing or incorrectly assigned schedules.

* **Localization**
  * Added failed-check messages in English, German, and Spanish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->