### PR TITLE
fix(web): show the owner's own mascot in the Soko Bots hero

### DIFF
--- a/apps/web/src/app/(app)/soko-bots/components/soko-bots-hero.tsx
+++ b/apps/web/src/app/(app)/soko-bots/components/soko-bots-hero.tsx
@@ -17,11 +17,14 @@ type Member = SokoBotTeam["members"][number];
 function AvatarStack({
   avatars,
   seeds,
+  ownImage,
 }: {
   avatars: SokoBotAvatar[];
   seeds: string[];
+  /** The owner's own bot, when it has picked a face rather than an orb. */
+  ownImage: string | null;
 }) {
-  const hasFaces = avatars.length > 0 || seeds.length > 0;
+  const hasFaces = avatars.length > 0 || seeds.length > 0 || ownImage !== null;
   if (!hasFaces) return null;
   return (
     <span className="flex shrink-0 -space-x-4" aria-hidden>
@@ -42,6 +45,13 @@ function AvatarStack({
           className="size-14 sm:size-16"
         />
       ))}
+      {ownImage ? (
+        <img
+          src={ownImage}
+          alt=""
+          className="size-14 rounded-full object-cover sm:size-16"
+        />
+      ) : null}
     </span>
   );
 }
@@ -60,8 +70,12 @@ export async function SokoBotsHero({
   const t = await getTranslations("App.SokoBots");
   const bot = me?.bot ?? null;
 
-  // Your own bot leads the stack when you have one; mascots fill the rest.
-  const seeds = bot && me ? [bot.avatarSeed ?? defaultOrbSeed(me.userId)] : [];
+  // Your own bot closes the stack when you have one; mascots fill the rest.
+  // A bot that claimed a mascot wears it here too — rendering the orb
+  // regardless put a blank disc beside four faces and read as a stranger.
+  const ownImage = bot?.avatarImageUrl ?? null;
+  const seeds =
+    bot && me && !ownImage ? [bot.avatarSeed ?? defaultOrbSeed(me.userId)] : [];
   const faces = avatars.slice(0, bot ? 4 : 5);
 
   return (
@@ -79,6 +93,7 @@ export async function SokoBotsHero({
         <AvatarStack
           avatars={bot ? faces : avatars.slice(0, 5)}
           seeds={seeds}
+          ownImage={ownImage}
         />
 
         {bot && me ? (


### PR DESCRIPTION
That "random Soko Bot without a picture" in the hero row is **your bot** — Joseph — drawn as an orb instead of the cat he claimed.

## Cause

```ts
const seeds = bot && me ? [bot.avatarSeed ?? defaultOrbSeed(me.userId)] : [];
```

The hero resolved a seed and never looked at `avatarImageUrl`, so it always drew an orb. Next to four mascots that reads as a fifth, faceless stranger rather than as you.

## Everywhere else was already right

The team chart directly below it, the sidebar stack, the create-assistant card, and both Task surfaces (since this morning's `2b56d14a2`) all do `image ?? orb`. The hero was a single omission, not a pattern — so this is the fix, not a refactor toward a shared helper.

## Change

The claimed image renders in the stack when there is one, and the orb stays the fallback for a bot that has not picked a face.

## Verification

- `biome check .` — 3725 files, clean
- `tsc --noEmit` — web, clean
- `vitest` — 4059 web tests pass

**No test added, deliberately.** This page has none, its components are async server components with no harness in the repo, and the four sites that already express this rule express it inline too. Adding a bespoke seam for one of them would be less consistent than matching them. The check here is visual — worth a glance at the hero once this deploys.

Run without pnpm: `main` pins pnpm 12.1.0 and my local version manager cannot install it, so binaries were invoked directly. CI is the authority on the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt6But7wNmMpRx4C7ykdnV