### PR TITLE
fix(web): put Agents under Search in sidebar nav

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/menu-items.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/menu-items.test.tsx
@@ -158,4 +158,26 @@ describe("MenuItems search action", () => {
       "/calendar",
     );
   });
+
+  it("orders primary destinations Search, Agents, Projects, Tasks, Schedules, History", () => {
+    const { container } = renderMenu(true, true);
+    const menuLabels = Array.from(container.querySelectorAll("button, a")).map(
+      (element) => element.textContent ?? "",
+    );
+
+    const primaryOrder = [
+      "search",
+      "exploreAgents",
+      "projects",
+      "taskManager",
+      "calendar",
+      "history",
+    ];
+    const positions = primaryOrder.map((label) =>
+      menuLabels.findIndex((text) => text.includes(label)),
+    );
+
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+  });
 });

--- a/apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
@@ -82,16 +82,22 @@ export default function MenuItems({ calendarMenuEnabled }: MenuItemsProps) {
       ariaKeyshortcuts: historySearch ? "Meta+K Control+K" : undefined,
     },
     {
-      key: "task-manager",
-      href: "/tasks",
-      label: t("taskManager"),
-      Icon: ListTodo,
+      key: "explore-agents",
+      href: "/agents",
+      label: t("exploreAgents"),
+      Icon: Bot,
     },
     {
       key: "projects",
       href: "/projects",
       label: t("projects"),
       Icon: FolderKanban,
+    },
+    {
+      key: "task-manager",
+      href: "/tasks",
+      label: t("taskManager"),
+      Icon: ListTodo,
     },
     ...(calendarMenuEnabled
       ? [
@@ -103,12 +109,6 @@ export default function MenuItems({ calendarMenuEnabled }: MenuItemsProps) {
           },
         ]
       : []),
-    {
-      key: "explore-agents",
-      href: "/agents",
-      label: t("exploreAgents"),
-      Icon: Bot,
-    },
     {
       key: "history",
       href: "/history",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders the main app sidebar destinations so Agents sits under Search:

`Search → Agents → Projects → Tasks → Schedules → History`

Matches product agreement that Agents should not sit near the bottom of the nav.

## Changes

- Reorder items in `menu-items.tsx`
- Add unit test that locks primary destination order (including Schedules/Calendar when enabled)

## Verification

- `pnpm --filter web exec vitest run src/app/(app)/components/sidebar/components/menu-items.test.tsx` (8 passed)
- Pre-commit: `pnpm check` + `pnpm typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0419bde1-f82e-437b-9300-903d09140a47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0419bde1-f82e-437b-9300-903d09140a47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reordered the sidebar navigation for a more intuitive flow: Search, Agents, Projects, Tasks, Calendar, and History.
  * Calendar remains available in its optional position when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->