### PR TITLE
feat(core): restore PA orchestrator HTTP auth

### DIFF
--- a/apps/core/src/lib/api-key-hash.ts
+++ b/apps/core/src/lib/api-key-hash.ts
@@ -1,0 +1,13 @@
+import { base64Url } from "@better-auth/utils/base64";
+import { createHash } from "@better-auth/utils/hash";
+
+/**
+ * Hashes an API key token (SHA-256 + base64url, no padding).
+ * Shared by coworker and orchestrator key mint/verify paths.
+ */
+export async function hashApiKey(token: string): Promise<string> {
+  const hash = await createHash("SHA-256").digest(
+    new TextEncoder().encode(token),
+  );
+  return base64Url.encode(new Uint8Array(hash), { padding: false });
+}

--- a/apps/core/src/lib/coworker-api-key.ts
+++ b/apps/core/src/lib/coworker-api-key.ts
@@ -1,8 +1,5 @@
 import { randomBytes } from "node:crypto";
 
-import { base64Url } from "@better-auth/utils/base64";
-import { createHash } from "@better-auth/utils/hash";
-
 /** Prefix for dedicated coworker API key tokens. Must match in CLI and auth. */
 export const COWORKER_API_KEY_PREFIX = "coworker_";
 
@@ -16,15 +13,4 @@ export function generateCoworkerApiKeyToken(): string {
   return `${COWORKER_API_KEY_PREFIX}${randomBytes(
     COWORKER_API_KEY_RANDOM_BYTES,
   ).toString("base64url")}`;
-}
-
-/**
- * Hashes a coworker API key token (SHA-256 + base64url, no padding).
- * Single source of truth for key creation and verification.
- */
-export async function hashApiKey(token: string): Promise<string> {
-  const hash = await createHash("SHA-256").digest(
-    new TextEncoder().encode(token),
-  );
-  return base64Url.encode(new Uint8Array(hash), { padding: false });
 }

--- a/apps/core/src/lib/orchestrator-api-key.test.ts
+++ b/apps/core/src/lib/orchestrator-api-key.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  generateOrchestratorApiKeyToken,
+  ORCHESTRATOR_API_KEY_PREFIX,
+  ORCHESTRATOR_API_KEY_START_LENGTH,
+} from "./orchestrator-api-key";
+
+describe("orchestrator-api-key", () => {
+  it("mints tokens with the orchestrator_ prefix, not orch_", () => {
+    const token = generateOrchestratorApiKeyToken();
+    expect(token.startsWith(ORCHESTRATOR_API_KEY_PREFIX)).toBe(true);
+    expect(token.startsWith("orch_")).toBe(false);
+    expect(token.slice(0, ORCHESTRATOR_API_KEY_START_LENGTH).length).toBe(
+      ORCHESTRATOR_API_KEY_START_LENGTH,
+    );
+  });
+});

--- a/apps/core/src/lib/orchestrator-api-key.ts
+++ b/apps/core/src/lib/orchestrator-api-key.ts
@@ -1,0 +1,17 @@
+import { randomBytes } from "node:crypto";
+
+/** Prefix for first-party Soko Bot / PA orchestrator API keys. Never `orch_`. */
+export const ORCHESTRATOR_API_KEY_PREFIX = "orchestrator_";
+
+/** Length of the key start stored for display (prefix + 8 chars). */
+export const ORCHESTRATOR_API_KEY_START_LENGTH =
+  ORCHESTRATOR_API_KEY_PREFIX.length + 8;
+
+const ORCHESTRATOR_API_KEY_RANDOM_BYTES = 32;
+
+/** Generates a dedicated orchestrator API key token bound to a Soko Bot. */
+export function generateOrchestratorApiKeyToken(): string {
+  return `${ORCHESTRATOR_API_KEY_PREFIX}${randomBytes(
+    ORCHESTRATOR_API_KEY_RANDOM_BYTES,
+  ).toString("base64url")}`;
+}

--- a/apps/core/src/middleware/auth.test.ts
+++ b/apps/core/src/middleware/auth.test.ts
@@ -15,6 +15,7 @@ const {
   verifyApiKeyMock,
   getSessionMock,
   coworkerApiKeyFindUniqueMock,
+  orchestratorApiKeyFindUniqueMock,
   prismaTransactionMock,
   oauthAccessTokenFindUniqueMock,
   oauthConsentFindFirstMock,
@@ -23,6 +24,7 @@ const {
   verifyApiKeyMock: vi.fn(),
   getSessionMock: vi.fn(),
   coworkerApiKeyFindUniqueMock: vi.fn(),
+  orchestratorApiKeyFindUniqueMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
   oauthAccessTokenFindUniqueMock: vi.fn(),
   oauthConsentFindFirstMock: vi.fn(),
@@ -42,6 +44,9 @@ vi.mock("@/lib/db/prisma", () => ({
   default: {
     coworkerApiKey: {
       findUnique: coworkerApiKeyFindUniqueMock,
+    },
+    orchestratorApiKey: {
+      findUnique: orchestratorApiKeyFindUniqueMock,
     },
     user: {
       findUnique: userFindUniqueMock,
@@ -68,6 +73,7 @@ describe("authMiddleware", () => {
     vi.clearAllMocks();
 
     coworkerApiKeyFindUniqueMock.mockResolvedValue(null);
+    orchestratorApiKeyFindUniqueMock.mockResolvedValue(null);
 
     verifyApiKeyMock.mockResolvedValue({
       valid: false,
@@ -88,6 +94,175 @@ describe("authMiddleware", () => {
         },
       });
     });
+  });
+
+  it("authenticates from dedicated orchestrator API key bound to a Soko Bot", async () => {
+    orchestratorApiKeyFindUniqueMock.mockResolvedValue({
+      sokoBotId: "01960001-0001-7001-8001-000000000099",
+      revokedAt: null,
+      expiresAt: null,
+      sokoBot: {
+        archivedAt: null,
+        deletedAt: null,
+        userId: "user_pa_owner",
+        workspaceId: "01960001-0001-7001-8001-000000000010",
+      },
+    });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer orchestrator_validtoken",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      actor: "orchestrator",
+      sokoBotId: "01960001-0001-7001-8001-000000000099",
+      userId: "user_pa_owner",
+      workspaceId: "01960001-0001-7001-8001-000000000010",
+    });
+    expect(orchestratorApiKeyFindUniqueMock).toHaveBeenCalledWith({
+      where: {
+        keyHash: expect.any(String),
+      },
+      select: {
+        sokoBotId: true,
+        revokedAt: true,
+        expiresAt: true,
+        sokoBot: {
+          select: {
+            archivedAt: true,
+            deletedAt: true,
+            userId: true,
+            workspaceId: true,
+          },
+        },
+      },
+    });
+    expect(coworkerApiKeyFindUniqueMock).not.toHaveBeenCalled();
+    expect(verifyApiKeyMock).not.toHaveBeenCalled();
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not authenticate a coworker API key as the orchestrator actor", async () => {
+    coworkerApiKeyFindUniqueMock.mockResolvedValue({
+      coworkerId: "cow_shadow_pa",
+      revokedAt: null,
+      expiresAt: null,
+      coworker: {
+        archivedAt: null,
+        vendorId: "01960001-0001-7001-8001-000000000001",
+        sokoBotId: "01960001-0001-7001-8001-000000000099",
+      },
+    });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer coworker_shadow_pa_token",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      actor: "coworker",
+      coworkerId: "cow_shadow_pa",
+      vendorId: "01960001-0001-7001-8001-000000000001",
+    });
+    expect(orchestratorApiKeyFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for revoked orchestrator API key", async () => {
+    orchestratorApiKeyFindUniqueMock.mockResolvedValue({
+      sokoBotId: "01960001-0001-7001-8001-000000000099",
+      revokedAt: new Date(),
+      expiresAt: null,
+      sokoBot: {
+        archivedAt: null,
+        deletedAt: null,
+        userId: "user_pa_owner",
+        workspaceId: "01960001-0001-7001-8001-000000000010",
+      },
+    });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer orchestrator_revoked",
+      },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 for expired orchestrator API key", async () => {
+    orchestratorApiKeyFindUniqueMock.mockResolvedValue({
+      sokoBotId: "01960001-0001-7001-8001-000000000099",
+      revokedAt: null,
+      expiresAt: new Date(Date.now() - 60_000),
+      sokoBot: {
+        archivedAt: null,
+        deletedAt: null,
+        userId: "user_pa_owner",
+        workspaceId: "01960001-0001-7001-8001-000000000010",
+      },
+    });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer orchestrator_expired",
+      },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 for orchestrator API key tied to an archived Soko Bot", async () => {
+    orchestratorApiKeyFindUniqueMock.mockResolvedValue({
+      sokoBotId: "01960001-0001-7001-8001-000000000099",
+      revokedAt: null,
+      expiresAt: null,
+      sokoBot: {
+        archivedAt: new Date(),
+        deletedAt: null,
+        userId: "user_pa_owner",
+        workspaceId: "01960001-0001-7001-8001-000000000010",
+      },
+    });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer orchestrator_archived_bot",
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(verifyApiKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to user auth for invalid orchestrator-prefixed token", async () => {
+    verifyApiKeyMock.mockResolvedValue({
+      valid: true,
+      key: {
+        referenceId: "user_api_key",
+        metadata: {},
+      },
+    });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer orchestrator_invalid",
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(verifyApiKeyMock).not.toHaveBeenCalled();
+    expect(oauthAccessTokenFindUniqueMock).not.toHaveBeenCalled();
   });
 
   it("authenticates from dedicated coworker API key bearer token", async () => {

--- a/apps/core/src/middleware/auth.ts
+++ b/apps/core/src/middleware/auth.ts
@@ -5,10 +5,12 @@ import { bearerAuth } from "hono/bearer-auth";
 import { createMiddleware } from "hono/factory";
 
 import { forbidden, unauthorized } from "@/helpers/error";
+import { hashApiKey } from "@/lib/api-key-hash";
 import { auth } from "@/lib/auth";
-import { COWORKER_API_KEY_PREFIX, hashApiKey } from "@/lib/coworker-api-key";
+import { COWORKER_API_KEY_PREFIX } from "@/lib/coworker-api-key";
 import prisma from "@/lib/db/prisma";
 import { attachAuthToLogger } from "@/lib/evlog";
+import { ORCHESTRATOR_API_KEY_PREFIX } from "@/lib/orchestrator-api-key";
 
 const DEFAULT_USER_ROLE = "user";
 
@@ -37,9 +39,18 @@ export interface CoworkerAuthenticationContext {
   context?: WorkspaceActorRequestContext;
 }
 
+/** Personal assistant (Soko Bot) authenticating with a first-party orchestrator key. */
+export interface OrchestratorAuthenticationContext {
+  actor: "orchestrator";
+  sokoBotId: string;
+  userId: string;
+  workspaceId: string;
+}
+
 export type AuthenticationContext =
   | UserAuthenticationContext
-  | CoworkerAuthenticationContext;
+  | CoworkerAuthenticationContext
+  | OrchestratorAuthenticationContext;
 
 export type AuthVariables = {
   isAuthenticated: boolean;
@@ -62,6 +73,14 @@ function syncSentryUser(context: AuthVariables) {
     scope.setUser({
       id: context.authContext.userId,
       organizationId: context.authContext.organizationId || undefined,
+    });
+    return;
+  }
+
+  if (context.authContext.actor === "orchestrator") {
+    scope.setUser({
+      id: `orchestrator:${context.authContext.sokoBotId}`,
+      orchestratorId: context.authContext.sokoBotId,
     });
     return;
   }
@@ -106,6 +125,15 @@ function syncRequestLogger(context: AuthVariables) {
     return;
   }
 
+  if (isOrchestratorAuthContext(authContext)) {
+    attachAuthToLogger({
+      actor: "orchestrator",
+      orchestratorId: authContext.sokoBotId,
+      userId: authContext.userId,
+    });
+    return;
+  }
+
   const _exhaustive: never = authContext;
   void _exhaustive;
 }
@@ -127,6 +155,12 @@ export function isCoworkerAuthContext(
   authContext: AuthenticationContext,
 ): authContext is CoworkerAuthenticationContext {
   return authContext.actor === "coworker";
+}
+
+export function isOrchestratorAuthContext(
+  authContext: AuthenticationContext,
+): authContext is OrchestratorAuthenticationContext {
+  return authContext.actor === "orchestrator";
 }
 
 /**
@@ -397,6 +431,74 @@ async function verifyCoworkerApiKey(
   return true;
 }
 
+/**
+ * Verifies a first-party orchestrator API key bound to a Soko Bot / PA.
+ *
+ * Expected token format: orchestrator_<secret>
+ * Legacy `orch_` keys are intentionally not accepted.
+ */
+async function verifyOrchestratorApiKey(
+  token: string,
+  c: Context<AuthEnv>,
+): Promise<boolean> {
+  if (!token.startsWith(ORCHESTRATOR_API_KEY_PREFIX)) {
+    return false;
+  }
+
+  const keyHash = await hashApiKey(token);
+  const orchestratorApiKey = await prisma.orchestratorApiKey.findUnique({
+    where: {
+      keyHash,
+    },
+    select: {
+      sokoBotId: true,
+      revokedAt: true,
+      expiresAt: true,
+      sokoBot: {
+        select: {
+          archivedAt: true,
+          deletedAt: true,
+          userId: true,
+          workspaceId: true,
+        },
+      },
+    },
+  });
+
+  if (!orchestratorApiKey) {
+    return false;
+  }
+
+  if (orchestratorApiKey.revokedAt) {
+    return false;
+  }
+
+  if (
+    orchestratorApiKey.expiresAt &&
+    orchestratorApiKey.expiresAt <= new Date()
+  ) {
+    return false;
+  }
+
+  if (
+    orchestratorApiKey.sokoBot.archivedAt ||
+    orchestratorApiKey.sokoBot.deletedAt
+  ) {
+    return false;
+  }
+
+  setAuthContext(c, {
+    isAuthenticated: true,
+    authContext: {
+      actor: "orchestrator",
+      sokoBotId: orchestratorApiKey.sokoBotId,
+      userId: orchestratorApiKey.sokoBot.userId,
+      workspaceId: orchestratorApiKey.sokoBot.workspaceId,
+    },
+  });
+  return true;
+}
+
 const hashAccessToken = async (value: string) => {
   const tokenWithoutPrefix = value.replace(/^soko_access_token_/, "");
   return await hashApiKey(tokenWithoutPrefix);
@@ -518,13 +620,25 @@ const bearerMiddleware: MiddlewareHandler<AuthEnv> = bearerAuth({
       throw unauthorized("Invalid or expired coworker token");
     }
 
-    // Check 2: Better Auth API key
+    // Check 2: First-party orchestrator API key (PA / Soko Bot).
+    // Orchestrator-prefixed tokens must not fall back to user auth schemes.
+    // Legacy `orch_` tokens are not handled here and fall through to 401.
+    if (token.startsWith(ORCHESTRATOR_API_KEY_PREFIX)) {
+      const orchestratorApiKeyValid = await verifyOrchestratorApiKey(token, c);
+      if (orchestratorApiKeyValid) {
+        return true;
+      }
+
+      throw unauthorized("Invalid or expired orchestrator token");
+    }
+
+    // Check 3: Better Auth API key
     const apiKeyValid = await verifyApiKey(token, c);
     if (apiKeyValid) {
       return true;
     }
 
-    // Check 3: OAuth Access Token
+    // Check 4: OAuth Access Token
     const oauthTokenValid = await verifyOAuthToken(token, c);
     if (oauthTokenValid) {
       return true;

--- a/apps/core/src/routes/v1/coworkers/[id]/api-keys/post.ts
+++ b/apps/core/src/routes/v1/coworkers/[id]/api-keys/post.ts
@@ -3,10 +3,10 @@ import { createRoute } from "@hono/zod-openapi";
 import { notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { created } from "@/helpers/response";
+import { hashApiKey } from "@/lib/api-key-hash";
 import {
   COWORKER_API_KEY_START_LENGTH,
   generateCoworkerApiKeyToken,
-  hashApiKey,
 } from "@/lib/coworker-api-key";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";

--- a/apps/core/src/routes/v1/index.test.ts
+++ b/apps/core/src/routes/v1/index.test.ts
@@ -97,8 +97,19 @@ describe("v1 router", () => {
     const body = (await response.json()) as {
       paths?: Record<string, { get?: { security?: [] } }>;
       servers: Array<{ url: string }>;
+      components?: {
+        securitySchemes?: {
+          bearerAuth?: { description?: string };
+        };
+      };
     };
     expect(body.servers).toEqual([{ url: "/v1" }]);
     expect(body.paths?.["/share/{token}"]?.get?.security).toEqual([]);
+    expect(body.components?.securitySchemes?.bearerAuth?.description).toContain(
+      "orchestrator_",
+    );
+    expect(body.components?.securitySchemes?.bearerAuth?.description).toContain(
+      "coworker_",
+    );
   });
 });

--- a/apps/core/src/routes/v1/index.ts
+++ b/apps/core/src/routes/v1/index.ts
@@ -42,7 +42,7 @@ app.openAPIRegistry.registerComponent("securitySchemes", "bearerAuth", {
   scheme: "bearer",
   bearerFormat: "JWT",
   description:
-    "Authentication required for all endpoints. Supports Better Auth user credentials and dedicated coworker bearer API keys (`coworker_`). Soko Bot runtime routes use their documented Vercel OIDC plus scoped turn-grant authentication.",
+    "Authentication required for all endpoints. Supports Better Auth user credentials, dedicated coworker bearer API keys (`coworker_`), and first-party personal-assistant orchestrator bearer API keys (`orchestrator_`). Legacy Hermes `orch_` keys are rejected. Soko Bot runtime routes use their documented Vercel OIDC plus scoped turn-grant authentication.",
 });
 
 app.openAPIRegistry.registerComponent("parameters", "OrganizationSlug", {

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -54,6 +54,7 @@ import {
   type AuthenticationContext,
   isCoworkerAgentContext,
   isCoworkerAuthContext,
+  isOrchestratorAuthContext,
   isUserAuthContext,
   requireUserContext,
 } from "@/middleware/auth";
@@ -83,6 +84,14 @@ function getStatusEventActorData(authContext: AuthenticationContext) {
     };
   }
 
+  if (isOrchestratorAuthContext(authContext)) {
+    return {
+      userId: null,
+      coworkerId: null,
+      orchestratorId: authContext.sokoBotId,
+    };
+  }
+
   // Status transitions from a delegated coworker are attributed to the acting
   // coworker only. Context userId is workspace context, not a second actor FK.
   return {
@@ -98,6 +107,14 @@ function getCommentEventActorData(authContext: AuthenticationContext) {
       userId: authContext.userId,
       coworkerId: null,
       orchestratorId: null,
+    };
+  }
+
+  if (isOrchestratorAuthContext(authContext)) {
+    return {
+      userId: null,
+      coworkerId: null,
+      orchestratorId: authContext.sokoBotId,
     };
   }
 

--- a/apps/core/src/routes/v1/workspaces/calendar/get.test.ts
+++ b/apps/core/src/routes/v1/workspaces/calendar/get.test.ts
@@ -103,7 +103,9 @@ function createApp(authContext: AuthenticationContext = USER_AUTH_CONTEXT) {
       organizationId:
         authContext.actor === "coworker"
           ? (authContext.context?.organizationId ?? null)
-          : authContext.organizationId,
+          : authContext.actor === "user"
+            ? authContext.organizationId
+            : null,
     });
     return await next();
   });

--- a/apps/core/src/types/task-link.ts
+++ b/apps/core/src/types/task-link.ts
@@ -78,6 +78,13 @@ function buildVisiblePeerTaskWhere(
         ownerId: authContext.userId,
       };
     }
+    case "orchestrator": {
+      return {
+        workspaceId: workspaceId ?? authContext.workspaceId,
+        archivedAt: null,
+        ownerId: authContext.userId,
+      };
+    }
     default: {
       const exhaustive: never = authContext;
       return exhaustive;

--- a/packages/database/prisma/migrations/20260901140000_soko_bot_orchestrator_api_key/migration.sql
+++ b/packages/database/prisma/migrations/20260901140000_soko_bot_orchestrator_api_key/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "orchestrator_api_key" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT,
+    "keyHash" TEXT NOT NULL,
+    "keyStart" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "sokoBotId" UUID NOT NULL,
+
+    CONSTRAINT "orchestrator_api_key_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "orchestrator_api_key_keyHash_key" ON "orchestrator_api_key"("keyHash");
+
+-- CreateIndex
+CREATE INDEX "orchestrator_api_key_sokoBotId_idx" ON "orchestrator_api_key"("sokoBotId");
+
+-- CreateIndex
+CREATE INDEX "orchestrator_api_key_revokedAt_expiresAt_idx" ON "orchestrator_api_key"("revokedAt", "expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "orchestrator_api_key" ADD CONSTRAINT "orchestrator_api_key_sokoBotId_fkey" FOREIGN KEY ("sokoBotId") REFERENCES "orchestrator"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1847,6 +1847,7 @@ model SokoBot {
   legacyMessages     SokoBotLegacyMessage[]
   pendingDecisions   SokoBotPendingDecision[]
   schedules          SokoBotSchedule[]
+  apiKeys            OrchestratorApiKey[]
 
   @@index([archivedAt])
   @@index([lastPolledAt])
@@ -1857,6 +1858,29 @@ model SokoBot {
   @@index([userId, workspaceId])
   @@index([workspaceId])
   @@map("orchestrator")
+}
+
+/// First-party API keys for a personal assistant (Soko Bot) authenticating as
+/// the `orchestrator` HTTP actor. Distinct from coworker keys and from the
+/// retired Hermes `orch_` token shape.
+model OrchestratorApiKey {
+  id        String   @id @default(uuid(7)) @db.Uuid
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  name     String?
+  keyHash  String  @unique
+  keyStart String
+
+  expiresAt DateTime?
+  revokedAt DateTime?
+
+  sokoBotId String  @db.Uuid
+  sokoBot   SokoBot @relation(fields: [sokoBotId], references: [id], onDelete: Cascade)
+
+  @@index([sokoBotId])
+  @@index([revokedAt, expiresAt])
+  @@map("orchestrator_api_key")
 }
 
 /// Immutable copy of external Hermes chat history made during first-party


### PR DESCRIPTION
## Summary
- Restore first-party PA orchestrator HTTP auth: `orchestrator_` bearer keys authenticate as `actor: "orchestrator"` bound to a Soko Bot
- Add `OrchestratorApiKey` storage + migration; document the prefix in OpenAPI
- Keep `coworker_` as coworker; legacy `orch_` / Hermes shapes still 401

Layer 1 of 5 on [SOK-933](https://linear.app/masumi/issue/SOK-933). Does not mint keys yet (verify path only).

Refs [SOK-941](https://linear.app/masumi/issue/SOK-941)

## Test plan
- [x] `pnpm --filter @sokosumi/core test src/middleware/auth.test.ts`
- [x] Core full vitest suite
- [x] Pre-commit typecheck / biome
- [ ] Apply migration locally / agent DB and verify schema
- [ ] Optional live: insert hashed key, call authenticated GET as orchestrator