### PR TITLE
feat(core): push OS banners for every notification kind

### DIFF
--- a/apps/core/src/helpers/notifications.test.ts
+++ b/apps/core/src/helpers/notifications.test.ts
@@ -294,23 +294,51 @@ describe("createNotification push gating", () => {
     );
   });
 
-  it("does not push non-chat kinds, and skips the opt-in read entirely", async () => {
-    const prismaMock = createPrismaMock();
-    prismaMock.notification.create.mockResolvedValue(
-      createNotificationRecord(),
-    );
-    userFindUniqueMock.mockResolvedValue({ pushOptIn: true });
+  // Every kind pushes now, not chat alone, so the gate is the opt-in and
+  // nothing else. Listed rather than derived from the enum: a kind added later
+  // should fail this list and make someone decide whether it pushes.
+  const NON_CHAT_KINDS = [
+    NotificationKind.JOB,
+    NotificationKind.TASK,
+    NotificationKind.SYSTEM,
+    NotificationKind.BILLING,
+  ] as const;
 
-    await createNotification(
-      notificationInput,
-      prismaMock as unknown as typeof prisma,
-    );
+  for (const kind of NON_CHAT_KINDS) {
+    it(`pushes a ${kind} notification when the user opted in`, async () => {
+      const prismaMock = createPrismaMock();
+      prismaMock.notification.create.mockResolvedValue(
+        createNotificationRecord({ kind }),
+      );
+      userFindUniqueMock.mockResolvedValue({ pushOptIn: true });
 
-    expect(publishNotificationEventMock).toHaveBeenCalledWith(
-      expect.objectContaining({ push: false }),
-    );
-    expect(userFindUniqueMock).not.toHaveBeenCalled();
-  });
+      await createNotification(
+        { ...notificationInput, kind },
+        prismaMock as unknown as typeof prisma,
+      );
+
+      expect(publishNotificationEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({ push: true }),
+      );
+    });
+
+    it(`does not push a ${kind} notification when the user did not opt in`, async () => {
+      const prismaMock = createPrismaMock();
+      prismaMock.notification.create.mockResolvedValue(
+        createNotificationRecord({ kind }),
+      );
+      userFindUniqueMock.mockResolvedValue({ pushOptIn: false });
+
+      await createNotification(
+        { ...notificationInput, kind },
+        prismaMock as unknown as typeof prisma,
+      );
+
+      expect(publishNotificationEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({ push: false }),
+      );
+    });
+  }
 
   it("does not push when the user row is missing", async () => {
     const prismaMock = createPrismaMock();

--- a/apps/core/src/helpers/notifications.ts
+++ b/apps/core/src/helpers/notifications.ts
@@ -32,10 +32,10 @@ export interface CreateNotificationResult {
  * Whether this notification also goes out as a closed-app OS banner.
  *
  * Push rides the notification publish over Ably (ADR-0022), gated on explicit
- * user consent. This slice pushes chat only; widening the kinds is a change to
- * this gate alone (SOK-877). Non-chat kinds skip the user read entirely, so the
- * bulk job and task paths keep their current query count. Chat pays one read
- * per notification, so a room mention costs one per recipient.
+ * user consent and on nothing else: every kind pushes. That costs one consent
+ * read per notification on the bulk job and task paths too, where the chat-only
+ * gate used to return before reading. A room mention still costs one read per
+ * recipient.
  *
  * Never throws, and never reads through the caller's transaction client. A
  * consent read that fails must degrade push alone: it must not abort a caller's
@@ -44,10 +44,6 @@ export interface CreateNotificationResult {
 async function shouldPushNotification(
   notification: Notification,
 ): Promise<boolean> {
-  if (notification.kind !== NotificationKind.CHAT) {
-    return false;
-  }
-
   try {
     const user = await prisma.user.findUnique({
       where: { id: notification.userId },

--- a/apps/web/public/ably-push-sw.js
+++ b/apps/web/public/ably-push-sw.js
@@ -42,26 +42,113 @@ const FALLBACK_LOCALE = "en";
 const LOCALE_COOKIE_NAME = "sokosumi.locale";
 
 /**
- * Copy of `Library.Notifications.Chat.*` from apps/web/messages/<locale>.json.
+ * Copy of every notification string from apps/web/messages/<locale>.json.
  *
- * A service worker cannot reach next-intl, so this worker duplicates the two
- * chat strings. SOK-876 replaces this with the shared renderer. Change a
- * string here only together with the message files.
+ * A service worker cannot reach next-intl, so this worker duplicates them.
+ * Two shapes, because Core stores two: Job, Task and Chat come from
+ * `Library.Notifications.<Group>` and are keyed `Notifications.<Group>.<key>`;
+ * the system keys sit at the catalog root and Core stores them verbatim.
+ *
+ * Generated from the catalogs rather than typed by hand, and guarded by
+ * `push-service-worker-messages.test.ts`, which fails when a catalog string
+ * changes without this copy changing with it. SOK-876 replaces the whole copy
+ * with the shared renderer.
  */
 const MESSAGES = {
   en: {
+    "Notifications.Job.completed": "{agentName} completed {jobName}",
+    "Notifications.Job.failed": "{agentName} failed to complete {jobName}",
+    "Notifications.Job.paymentFailed": "Payment failed for {jobName}",
+    "Notifications.Job.inputRequired":
+      "{agentName} needs your input for {jobName}",
+    "Notifications.Job.refundResolved": "{jobName} was refunded",
+    "Notifications.Job.disputeResolved": "Dispute resolved for {jobName}",
+    "Notifications.Task.inputRequired":
+      "{coworkerName} needs your input for {taskName}",
+    "Notifications.Task.approvalRequired":
+      "{coworkerName} needs your approval for {taskName}",
+    "Notifications.Task.authenticationRequired":
+      "{coworkerName} needs authentication for {taskName}",
+    "Notifications.Task.outOfCredits":
+      "{coworkerName} ran out of credits for {taskName}",
+    "Notifications.Task.completed": "{coworkerName} completed {taskName}",
+    "Notifications.Task.failed": "{coworkerName} failed to complete {taskName}",
+    "Notifications.Task.canceled": "{taskName} was canceled",
+    "Notifications.Task.scheduleRepaired":
+      "The schedule for {taskName} was repaired",
+    "Notifications.Task.scheduleRemovedByOperator":
+      "The schedule for {taskName} was removed after review",
     "Notifications.Chat.mentioned": "{authorName} mentioned you in {roomName}",
     "Notifications.Chat.directMessage": "{authorName} sent you a message",
+    "notifications.vendorGrant.pending":
+      "{vendorName} requested vendor access to your workspace",
+    "notifications.coworkerAccess.pending":
+      "{coworkerName} requested coworker early access to your workspace",
   },
   de: {
+    "Notifications.Job.completed": "{agentName} hat {jobName} abgeschlossen",
+    "Notifications.Job.failed":
+      "{agentName} konnte {jobName} nicht abschließen",
+    "Notifications.Job.paymentFailed": "Zahlung für {jobName} fehlgeschlagen",
+    "Notifications.Job.inputRequired":
+      "{agentName} benötigt deinen Input für {jobName}",
+    "Notifications.Job.refundResolved": "{jobName} wurde erstattet",
+    "Notifications.Job.disputeResolved": "Einspruch für {jobName} gelöst",
+    "Notifications.Task.inputRequired":
+      "{coworkerName} benötigt deinen Input für {taskName}",
+    "Notifications.Task.approvalRequired":
+      "{coworkerName} benötigt deine Freigabe für {taskName}",
+    "Notifications.Task.authenticationRequired":
+      "{coworkerName} benötigt eine Authentifizierung für {taskName}",
+    "Notifications.Task.outOfCredits":
+      "{coworkerName} hat keine Credits mehr für {taskName}",
+    "Notifications.Task.completed":
+      "{coworkerName} hat {taskName} abgeschlossen",
+    "Notifications.Task.failed":
+      "{coworkerName} konnte {taskName} nicht abschließen",
+    "Notifications.Task.canceled": "{taskName} wurde abgebrochen",
+    "Notifications.Task.scheduleRepaired":
+      "Der Zeitplan für {taskName} wurde repariert",
+    "Notifications.Task.scheduleRemovedByOperator":
+      "Der Zeitplan für {taskName} wurde nach der Prüfung entfernt",
     "Notifications.Chat.mentioned":
       "{authorName} hat dich in {roomName} erwähnt",
     "Notifications.Chat.directMessage":
       "{authorName} hat dir eine Nachricht gesendet",
+    "notifications.vendorGrant.pending":
+      "{vendorName} hat Vendor-Zugriff auf den Organisations-Workspace angefordert",
+    "notifications.coworkerAccess.pending":
+      "{coworkerName} hat Coworker-Early-Access für deinen Workspace angefordert",
   },
   es: {
+    "Notifications.Job.completed": "{agentName} completó {jobName}",
+    "Notifications.Job.failed": "{agentName} no pudo completar {jobName}",
+    "Notifications.Job.paymentFailed": "Error de pago para {jobName}",
+    "Notifications.Job.inputRequired":
+      "{agentName} necesita tu input para {jobName}",
+    "Notifications.Job.refundResolved": "{jobName} fue reembolsado",
+    "Notifications.Job.disputeResolved": "Disputa resuelta para {jobName}",
+    "Notifications.Task.inputRequired":
+      "{coworkerName} necesita tu input para {taskName}",
+    "Notifications.Task.approvalRequired":
+      "{coworkerName} necesita tu aprobación para {taskName}",
+    "Notifications.Task.authenticationRequired":
+      "{coworkerName} necesita autenticación para {taskName}",
+    "Notifications.Task.outOfCredits":
+      "{coworkerName} se quedó sin créditos para {taskName}",
+    "Notifications.Task.completed": "{coworkerName} completó {taskName}",
+    "Notifications.Task.failed": "{coworkerName} no pudo completar {taskName}",
+    "Notifications.Task.canceled": "{taskName} fue cancelado",
+    "Notifications.Task.scheduleRepaired":
+      "Se reparó la programación de {taskName}",
+    "Notifications.Task.scheduleRemovedByOperator":
+      "Se eliminó la programación de {taskName} después de revisarla",
     "Notifications.Chat.mentioned": "{authorName} te mencionó en {roomName}",
     "Notifications.Chat.directMessage": "{authorName} te envió un mensaje",
+    "notifications.vendorGrant.pending":
+      "{vendorName} solicitó acceso de proveedor al workspace de la organización",
+    "notifications.coworkerAccess.pending":
+      "{coworkerName} solicitó acceso anticipado de coworker a tu espacio de trabajo",
   },
 };
 

--- a/apps/web/public/ably-push-sw.js
+++ b/apps/web/public/ably-push-sw.js
@@ -63,6 +63,7 @@ const MESSAGES = {
       "{agentName} needs your input for {jobName}",
     "Notifications.Job.refundResolved": "{jobName} was refunded",
     "Notifications.Job.disputeResolved": "Dispute resolved for {jobName}",
+    "Notifications.Task.assigned": "You were assigned {taskName}",
     "Notifications.Task.inputRequired":
       "{coworkerName} needs your input for {taskName}",
     "Notifications.Task.approvalRequired":
@@ -94,6 +95,7 @@ const MESSAGES = {
       "{agentName} benötigt deinen Input für {jobName}",
     "Notifications.Job.refundResolved": "{jobName} wurde erstattet",
     "Notifications.Job.disputeResolved": "Einspruch für {jobName} gelöst",
+    "Notifications.Task.assigned": "Dir wurde {taskName} zugewiesen",
     "Notifications.Task.inputRequired":
       "{coworkerName} benötigt deinen Input für {taskName}",
     "Notifications.Task.approvalRequired":
@@ -128,6 +130,7 @@ const MESSAGES = {
       "{agentName} necesita tu input para {jobName}",
     "Notifications.Job.refundResolved": "{jobName} fue reembolsado",
     "Notifications.Job.disputeResolved": "Disputa resuelta para {jobName}",
+    "Notifications.Task.assigned": "Se te asignó {taskName}",
     "Notifications.Task.inputRequired":
       "{coworkerName} necesita tu input para {taskName}",
     "Notifications.Task.approvalRequired":

--- a/apps/web/src/lib/utils/__tests__/push-service-worker-messages.test.ts
+++ b/apps/web/src/lib/utils/__tests__/push-service-worker-messages.test.ts
@@ -34,13 +34,43 @@ const CATALOGS = {
   es: esMessages,
 } as const;
 
+type Catalog = (typeof CATALOGS)[keyof typeof CATALOGS];
+
 /**
- * Read from the catalog rather than a fixed list, so a chat key added later is
- * guarded without anyone remembering to extend this test.
+ * Every message key Core can store, read from the catalog rather than a fixed
+ * list, so a key added later is guarded without anyone remembering to extend
+ * this test.
+ *
+ * Two shapes, because Core stores two. Job, Task and Chat sit under
+ * `Library.Notifications.<Group>` and Core stores them as
+ * `Notifications.<Group>.<key>`. The system keys sit at the catalog root and
+ * Core stores them verbatim, lowercase `notifications.` and all.
  */
-const CHAT_MESSAGE_KEYS = Object.keys(
-  enMessages.Library.Notifications.Chat,
-) as (keyof typeof enMessages.Library.Notifications.Chat)[];
+function messageEntries(catalog: Catalog): { key: string; text: string }[] {
+  const entries: { key: string; text: string }[] = [];
+
+  const groups: Record<string, Record<string, string>> = catalog.Library
+    .Notifications;
+  for (const [group, strings] of Object.entries(groups)) {
+    for (const [name, text] of Object.entries(strings)) {
+      entries.push({ key: `Notifications.${group}.${name}`, text });
+    }
+  }
+
+  const systemAreas: Record<
+    string,
+    Record<string, string>
+  > = catalog.notifications;
+  for (const [area, strings] of Object.entries(systemAreas)) {
+    for (const [name, text] of Object.entries(strings)) {
+      entries.push({ key: `notifications.${area}.${name}`, text });
+    }
+  }
+
+  return entries;
+}
+
+const MESSAGE_KEYS = messageEntries(enMessages).map((entry) => entry.key);
 
 /**
  * The worker's strings for one locale. Read the block rather than the file, or
@@ -65,12 +95,10 @@ describe("ably-push-sw message map", () => {
   });
 
   for (const [locale, catalog] of Object.entries(CATALOGS)) {
-    for (const key of CHAT_MESSAGE_KEYS) {
-      it(`carries the current ${locale} string for Notifications.Chat.${key}`, () => {
-        const expected = catalog.Library.Notifications.Chat[key];
-
-        expect(expected).toBeTruthy();
-        expect(localeBlock(source, locale)).toContain(expected);
+    for (const { key, text } of messageEntries(catalog)) {
+      it(`carries the current ${locale} string for ${key}`, () => {
+        expect(text).toBeTruthy();
+        expect(localeBlock(source, locale)).toContain(text);
       });
     }
   }
@@ -102,10 +130,10 @@ describe("ably-push-sw message map", () => {
   });
 
   it("keys the map by the messageKey Core stores", () => {
-    expect(CHAT_MESSAGE_KEYS.length).toBeGreaterThan(0);
+    expect(MESSAGE_KEYS.length).toBeGreaterThan(0);
 
-    for (const key of CHAT_MESSAGE_KEYS) {
-      expect(source).toContain(`"Notifications.Chat.${key}"`);
+    for (const key of MESSAGE_KEYS) {
+      expect(source).toContain(`"${key}"`);
     }
   });
 });


### PR DESCRIPTION
Part 1 of 7 for [SOK-877](https://linear.app/sokosumi/issue/SOK-877). Layers above this one add the preference matrix; this layer widens the push gate alone.

## What changes for a reader

A job, task or system Notification never reached them with Sokosumi closed: the publish gate returned early for anything that was not CHAT. Consent is the only gate now. Every kind pushes when the reader opted in, and none does when they did not.

## How

The service worker renders the banner text itself, so it carries a copy of the app's strings. That copy grows from the two chat keys to all nineteen, generated from the message catalogs rather than typed by hand. Its parity guard grows with it and now covers both key shapes Core stores: the `Library.Notifications.<Group>` keys and the two root `notifications.` ones.

Cost worth naming: the consent read used to be skipped for every non-chat kind, so the bulk job and task paths now pay one read per Notification. A room mention still pays one per recipient.

## Verification

Run on the top of the stack, so CI is what proves this layer on its own.

- `pnpm --filter @sokosumi/core test` → `4646 passed | 6 skipped`
- `pnpm --filter web test` → `4210 passed | 1 skipped`
- `biome check .` → `Checked 3761 files. No fixes applied.`
- `turbo typecheck` for core, web, utils and database → 13 tasks successful
