### PR TITLE
feat(database): add the notification preference model

### DIFF
--- a/apps/core/src/helpers/notifications.test.ts
+++ b/apps/core/src/helpers/notifications.test.ts
@@ -70,6 +70,7 @@ function createNotificationRecord(
     isRead: false,
     readAt: null,
     createdAt: CREATED_AT,
+    inApp: true,
     ...overrides,
   };
 }

--- a/packages/database/prisma/migrations/20260901125553_notification_preference/migration.sql
+++ b/packages/database/prisma/migrations/20260901125553_notification_preference/migration.sql
@@ -1,0 +1,25 @@
+-- SOK-877: per-user Notification delivery preference.
+-- Prisma's diff also wanted to drop eight hand-written partial unique indexes
+-- it cannot express in schema.prisma (chat_room slugs and direct keys, the
+-- guest invitation, the live orchestrator, the planned occurrence). Those
+-- drops are removed: they enforce live constraints and are unrelated to this
+-- change.
+
+-- CreateTable
+CREATE TABLE "notification_preference" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notification_preference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "notification_preference_userId_category_channel_key" ON "notification_preference"("userId", "category", "channel");
+
+-- AddForeignKey
+ALTER TABLE "notification_preference" ADD CONSTRAINT "notification_preference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260901160000_notification_in_app/migration.sql
+++ b/packages/database/prisma/migrations/20260901160000_notification_in_app/migration.sql
@@ -1,0 +1,9 @@
+-- Records the in-app delivery decision on the notification itself, so the feed
+-- and the unread count can filter on it without re-reading the preference
+-- matrix for every row.
+--
+-- Defaults to true, so every notification written before the matrix existed
+-- stays visible.
+
+-- AlterTable
+ALTER TABLE "notification" ADD COLUMN "inApp" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -445,6 +445,13 @@ model Notification {
   readAt        DateTime?
   createdAt     DateTime         @default(now())
 
+  /// Whether this notification is shown in the app at all: the Notification
+  /// Center for a feed kind, the in-app toast for a browser-only one. Decided
+  /// once, when the notification is created, from the reader's preference
+  /// matrix. A reader who turns a category back on does not get back the
+  /// notifications they silenced while it was off.
+  inApp Boolean @default(true)
+
   @@unique([userId, kind, referenceId, eventId, messageKey])
   @@index([userId, createdAt(sort: Desc), id(sort: Desc)])
   @@index([userId, isRead])
@@ -456,8 +463,9 @@ model Notification {
 /// One user's choice for one Notification category on one delivery channel.
 ///
 /// A missing row means the default rather than "off", so a new user needs no
-/// rows written and a new category needs no backfill. Only a choice that
-/// differs from the default is stored.
+/// rows written and a new category needs no backfill. A row is written the
+/// first time the reader touches a cell, whether or not the value they land on
+/// matches the default.
 ///
 /// `category` and `channel` are strings, not enums, so adding a category or a
 /// delivery channel is data plus UI rather than a schema migration. The Core

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -58,6 +58,8 @@ model User {
   notificationsOptIn Boolean @default(true) // Whether the user wants to receive notifications
   pushOptIn          Boolean @default(false) // Whether the user wants OS banners while Sokosumi is closed
 
+  notificationPreferences NotificationPreference[]
+
   // UTM Attribution
   utmAttribution UTMAttribution?
 
@@ -449,6 +451,30 @@ model Notification {
   @@index([eventId])
   @@index([kind, eventId])
   @@map("notification")
+}
+
+/// One user's choice for one Notification category on one delivery channel.
+///
+/// A missing row means the default rather than "off", so a new user needs no
+/// rows written and a new category needs no backfill. Only a choice that
+/// differs from the default is stored.
+///
+/// `category` and `channel` are strings, not enums, so adding a category or a
+/// delivery channel is data plus UI rather than a schema migration. The Core
+/// schemas validate them against the known set on the way in.
+model NotificationPreference {
+  id        String   @id @default(uuid(7))
+  userId    String
+  category  String
+  channel   String
+  enabled   Boolean
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, category, channel])
+  @@map("notification_preference")
 }
 
 model Project {


### PR DESCRIPTION
Part 2 of 7 for [SOK-877](https://linear.app/sokosumi/issue/SOK-877). Schema only: nothing reads these columns until the layer above.

## What changes

Two schema changes for the notification preference matrix.

`NotificationPreference` stores one reader's choice for one category on one delivery channel. A missing row means the default, so a new user needs no rows written and a new category needs no backfill. `category` and `channel` are strings rather than database enums, so adding either is data plus UI rather than a migration; Core validates them against the shared vocabulary on the way in.

`Notification.inApp` records the in-app delivery decision on the notification itself. The feed and the unread count can then filter on it instead of re-reading the matrix per row. It defaults to true, so every existing row stays visible and no backfill is needed. The cost is that turning a category back on does not restore what it silenced, which is what the account-wide opt-in already did: those notifications were never written at all.

## Migrations

- `20260901125553_notification_preference` — creates the table, the `(userId, category, channel)` unique index, and the cascade to `user`.
- `20260901160000_notification_in_app` — adds `notification.inApp` with `DEFAULT true`.

Both applied to a local database with `prisma migrate deploy`, followed by `prisma migrate status` → `Database schema is up to date!`.

Note on the first file: `prisma migrate dev` also wanted to drop eight hand-written partial unique indexes it cannot express in `schema.prisma` (chat room slugs and direct keys, the guest invitation, the live orchestrator, the planned occurrence). Those drops were removed from the migration and the indexes were confirmed present afterwards. The drift is older than this branch.

## Verification

- `pnpm --filter @sokosumi/database test` → `347 passed | 3 skipped`
- `prisma validate` → schema is valid
