### PR TITLE
feat(core): add the notification delivery decision

### DIFF
--- a/apps/core/src/helpers/chat-direct-message-notifications.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/node";
 import { NotificationKind } from "@sokosumi/database";
 
+import { CHAT_DIRECT_MESSAGE_MESSAGE_KEY } from "@/helpers/notification-delivery";
 import { createNotification } from "@/helpers/notifications";
 import prisma from "@/lib/db/prisma";
 
@@ -84,7 +85,7 @@ export async function emitChatDirectMessageNotifications(
         kind: NotificationKind.CHAT,
         referenceId: params.roomId,
         eventId: params.messageId,
-        messageKey: "Notifications.Chat.directMessage",
+        messageKey: CHAT_DIRECT_MESSAGE_MESSAGE_KEY,
         messageParams: {
           authorName: params.authorName,
           roomName: params.roomName,

--- a/apps/core/src/helpers/chat-mention-notifications.ts
+++ b/apps/core/src/helpers/chat-mention-notifications.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/node";
 import { NotificationKind } from "@sokosumi/database";
 
+import { CHAT_MENTION_MESSAGE_KEY } from "@/helpers/notification-delivery";
 import { createNotification } from "@/helpers/notifications";
 import prisma from "@/lib/db/prisma";
 
@@ -65,7 +66,7 @@ export async function emitChatMentionNotifications(
         kind: NotificationKind.CHAT,
         referenceId: params.roomId,
         eventId: params.messageId,
-        messageKey: "Notifications.Chat.mentioned",
+        messageKey: CHAT_MENTION_MESSAGE_KEY,
         messageParams: {
           authorName: params.authorName,
           roomName: params.roomName,

--- a/apps/core/src/helpers/notification-delivery.test.ts
+++ b/apps/core/src/helpers/notification-delivery.test.ts
@@ -1,0 +1,161 @@
+import { NotificationKind } from "@sokosumi/database";
+import type { NotificationCategory } from "@sokosumi/utils";
+import { describe, expect, it } from "vitest";
+
+import {
+  CHAT_DIRECT_MESSAGE_MESSAGE_KEY,
+  CHAT_MENTION_MESSAGE_KEY,
+  resolveNotificationDelivery,
+  type StoredNotificationPreference,
+  toNotificationCategory,
+} from "./notification-delivery";
+
+describe("toNotificationCategory", () => {
+  it("maps a job notification to the job category", () => {
+    expect(
+      toNotificationCategory(NotificationKind.JOB, "Notifications.Job.failed"),
+    ).toBe("JOB");
+  });
+
+  it("maps a task notification to the task category", () => {
+    expect(
+      toNotificationCategory(
+        NotificationKind.TASK,
+        "Notifications.Task.completed",
+      ),
+    ).toBe("TASK");
+  });
+
+  it("maps a system notification to the system category", () => {
+    expect(
+      toNotificationCategory(
+        NotificationKind.SYSTEM,
+        "notifications.vendorGrant.pending",
+      ),
+    ).toBe("SYSTEM");
+  });
+
+  it("splits chat by message key, because the reader chooses between them", () => {
+    expect(
+      toNotificationCategory(NotificationKind.CHAT, CHAT_MENTION_MESSAGE_KEY),
+    ).toBe("CHAT_MENTION");
+    expect(
+      toNotificationCategory(
+        NotificationKind.CHAT,
+        CHAT_DIRECT_MESSAGE_MESSAGE_KEY,
+      ),
+    ).toBe("CHAT_DIRECT_MESSAGE");
+  });
+
+  it("has no category for a chat key it does not know", () => {
+    expect(
+      toNotificationCategory(NotificationKind.CHAT, "Notifications.Chat.wat"),
+    ).toBeNull();
+  });
+
+  it("has no category for billing, which nothing emits yet", () => {
+    expect(
+      toNotificationCategory(NotificationKind.BILLING, "whatever"),
+    ).toBeNull();
+  });
+
+  /**
+   * A kind added later fails to compile here, so someone decides which row it
+   * belongs to rather than letting it fall through to the defaults unnoticed.
+   */
+  it("has an answer for every kind Core can store", () => {
+    const EXPECTED: Record<NotificationKind, NotificationCategory | null> = {
+      JOB: "JOB",
+      TASK: "TASK",
+      SYSTEM: "SYSTEM",
+      // Read with the mention key, so chat answers with one of its two rows.
+      CHAT: "CHAT_MENTION",
+      BILLING: null,
+    };
+
+    for (const kind of Object.values(NotificationKind)) {
+      expect(toNotificationCategory(kind, CHAT_MENTION_MESSAGE_KEY)).toBe(
+        EXPECTED[kind],
+      );
+    }
+  });
+});
+
+describe("resolveNotificationDelivery", () => {
+  const NO_PREFERENCES: StoredNotificationPreference[] = [];
+
+  it("delivers on both channels for a reader who set nothing", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: "JOB",
+        preferences: NO_PREFERENCES,
+        pushOptIn: true,
+      }),
+    ).toEqual({ inApp: true, osBanner: true });
+  });
+
+  it("withholds the banner without account-wide push consent", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: "JOB",
+        preferences: NO_PREFERENCES,
+        pushOptIn: false,
+      }),
+    ).toEqual({ inApp: true, osBanner: false });
+  });
+
+  it("stops delivering in-app when the reader turned that cell off", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: "TASK",
+        preferences: [{ category: "TASK", channel: "IN_APP", enabled: false }],
+        pushOptIn: true,
+      }),
+    ).toEqual({ inApp: false, osBanner: true });
+  });
+
+  it("stops interrupting when the reader turned that banner cell off", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: "CHAT_MENTION",
+        preferences: [
+          { category: "CHAT_MENTION", channel: "OS_BANNER", enabled: false },
+        ],
+        pushOptIn: true,
+      }),
+    ).toEqual({ inApp: true, osBanner: false });
+  });
+
+  it("keeps one category's choice out of another's", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: "CHAT_DIRECT_MESSAGE",
+        preferences: [
+          { category: "CHAT_MENTION", channel: "IN_APP", enabled: false },
+          { category: "CHAT_MENTION", channel: "OS_BANNER", enabled: false },
+        ],
+        pushOptIn: true,
+      }),
+    ).toEqual({ inApp: true, osBanner: true });
+  });
+
+  it("falls back to the defaults for a notification with no category", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: null,
+        preferences: [{ category: "JOB", channel: "IN_APP", enabled: false }],
+        pushOptIn: true,
+      }),
+    ).toEqual({ inApp: true, osBanner: true });
+  });
+
+  it("ignores a stored channel it does not recognise", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: "SYSTEM",
+        preferences: [{ category: "SYSTEM", channel: "EMAIL", enabled: false }],
+        pushOptIn: true,
+      }),
+    ).toEqual({ inApp: true, osBanner: true });
+  });
+});

--- a/apps/core/src/helpers/notification-delivery.ts
+++ b/apps/core/src/helpers/notification-delivery.ts
@@ -1,0 +1,105 @@
+import type { NotificationKind } from "@sokosumi/database";
+import {
+  NOTIFICATION_CHANNEL_DEFAULT,
+  type NotificationCategory,
+  type NotificationChannel,
+} from "@sokosumi/utils";
+
+/** The message key an @mention carries. Read by the category mapping below. */
+export const CHAT_MENTION_MESSAGE_KEY = "Notifications.Chat.mentioned";
+
+/** The message key a direct message carries. */
+export const CHAT_DIRECT_MESSAGE_MESSAGE_KEY =
+  "Notifications.Chat.directMessage";
+
+/**
+ * One stored choice, as the database holds it: strings rather than the unions,
+ * because a row written by an older build can name a category or a channel this
+ * build no longer knows.
+ */
+export interface StoredNotificationPreference {
+  category: string;
+  channel: string;
+  enabled: boolean;
+}
+
+export interface NotificationDeliveryInput {
+  category: NotificationCategory | null;
+  preferences: readonly StoredNotificationPreference[];
+  /** The account-wide push consent. Off means no banner, whatever the row says. */
+  pushOptIn: boolean;
+}
+
+/** Where one Notification goes. */
+export interface NotificationDelivery {
+  /** The Notification Center for a feed kind, the in-app toast for a chat one. */
+  inApp: boolean;
+  osBanner: boolean;
+}
+
+/**
+ * The matrix row a Notification belongs to, or null when it belongs to none.
+ *
+ * Chat splits by message key, because a reader chooses between an @mention and
+ * a direct message rather than between two kinds. Every other kind is its own
+ * row.
+ *
+ * Null means the defaults apply and nothing is stored against it: a chat key
+ * added later that nobody mapped, and BILLING, which no producer emits yet. A
+ * row would be a switch that controls nothing, so there is none.
+ */
+export function toNotificationCategory(
+  kind: NotificationKind,
+  messageKey: string,
+): NotificationCategory | null {
+  switch (kind) {
+    case "JOB":
+      return "JOB";
+    case "TASK":
+      return "TASK";
+    case "SYSTEM":
+      return "SYSTEM";
+    case "CHAT":
+      if (messageKey === CHAT_MENTION_MESSAGE_KEY) {
+        return "CHAT_MENTION";
+      }
+      if (messageKey === CHAT_DIRECT_MESSAGE_MESSAGE_KEY) {
+        return "CHAT_DIRECT_MESSAGE";
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+function isEnabled(
+  category: NotificationCategory | null,
+  channel: NotificationChannel,
+  preferences: readonly StoredNotificationPreference[],
+): boolean {
+  const stored = preferences.find(
+    (preference) =>
+      preference.category === category && preference.channel === channel,
+  );
+
+  return stored?.enabled ?? NOTIFICATION_CHANNEL_DEFAULT[channel];
+}
+
+/**
+ * The one place that decides where a Notification is delivered.
+ *
+ * Both answers are returned together rather than asked separately, so a caller
+ * cannot read one gate and forget the other. Neither answer stops the
+ * Notification being written: `inApp` false hides it from the feed and the
+ * toast, and leaves the row that keeps a duplicate emit idempotent.
+ */
+export function resolveNotificationDelivery({
+  category,
+  preferences,
+  pushOptIn,
+}: NotificationDeliveryInput): NotificationDelivery {
+  return {
+    inApp: isEnabled(category, "IN_APP", preferences),
+    osBanner: pushOptIn && isEnabled(category, "OS_BANNER", preferences),
+  };
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -236,6 +236,13 @@ export {
   isBrowserOnlyNotificationKind,
 } from "./notification-feed-kinds.js";
 export {
+  NOTIFICATION_CATEGORIES,
+  NOTIFICATION_CHANNEL_DEFAULT,
+  NOTIFICATION_CHANNELS,
+  type NotificationCategory,
+  type NotificationChannel,
+} from "./notification-preferences.js";
+export {
   type BuildOAuthClientScopeParamOptions,
   buildOAuthClientGrantTypes,
   buildOAuthClientScopeParam,

--- a/packages/utils/src/notification-preferences.ts
+++ b/packages/utils/src/notification-preferences.ts
@@ -1,0 +1,50 @@
+/**
+ * The vocabulary of the notification preference matrix (SOK-877).
+ *
+ * A category is a row and a channel is a column. Both are stored as plain
+ * strings rather than database enums, so adding either is data plus UI rather
+ * than a schema migration. Core validates an incoming value against these
+ * lists.
+ *
+ * Web reads the same vocabulary from the generated Core client, not from here:
+ * the Core DTO boundary keeps domain values out of web's direct imports.
+ */
+export const NOTIFICATION_CATEGORIES = [
+  "JOB",
+  "TASK",
+  "CHAT_MENTION",
+  "CHAT_DIRECT_MESSAGE",
+  "SYSTEM",
+] as const;
+
+export type NotificationCategory = (typeof NOTIFICATION_CATEGORIES)[number];
+
+/**
+ * Where a Notification is delivered.
+ *
+ * `IN_APP` is one column with two faces, because the product already has two.
+ * A feed kind lands in the Notification Center. A browser-only kind lands in
+ * the in-app toast and never in the feed at all
+ * (`BROWSER_ONLY_NOTIFICATION_KINDS`). Splitting them into separate channels
+ * would give every row a cell that controls nothing.
+ */
+export const NOTIFICATION_CHANNELS = ["IN_APP", "OS_BANNER"] as const;
+
+export type NotificationChannel = (typeof NOTIFICATION_CHANNELS)[number];
+
+/**
+ * What a missing row means.
+ *
+ * Both on, so a reader who never opens the matrix keeps exactly what they get
+ * today. That is safe for the OS banner column too: the account-wide push
+ * opt-in still gates every banner, and it is off until the reader turns it on.
+ * A default of off there would instead silence a reader who did opt in and
+ * never touched the matrix.
+ */
+export const NOTIFICATION_CHANNEL_DEFAULT: Record<
+  NotificationChannel,
+  boolean
+> = {
+  IN_APP: true,
+  OS_BANNER: true,
+};


### PR DESCRIPTION
Part 3 of 7 for [SOK-877](https://linear.app/sokosumi/issue/SOK-877). A pure decision, with no caller yet: the layer above wires it into the publish path.

## What changes

One place answers "where does this notification go".

`toNotificationCategory` maps a notification to its matrix row. Chat splits by message key, because a reader chooses between an @mention and a direct message rather than between two kinds. BILLING maps to nothing: no producer emits it, so a row would be a switch that controls nothing.

`resolveNotificationDelivery` reads the stored rows and returns both channels together, so a caller cannot read one gate and forget the other. A missing row means the default.

The shared vocabulary (categories, channels, and what a missing row means) lives in `@sokosumi/utils` because Core validates it and the settings page renders it. `IN_APP` is one column with two faces: the Notification Center for a feed kind, the in-app toast for a browser-only one, which never reaches the feed at all.

The two chat producers now read their message keys from the same constants the mapping does, so the key and its category cannot drift.

## Verification

- `pnpm --filter @sokosumi/core test src/helpers/notification-delivery.test.ts` → `17 passed`, including a table that fails to compile when a `NotificationKind` is added without a decision
- Full core and web suites green on the top of the stack
