### PR TITLE
feat(core): deliver notifications through the preference matrix

### DIFF
--- a/apps/core/src/helpers/notifications.test.ts
+++ b/apps/core/src/helpers/notifications.test.ts
@@ -115,6 +115,7 @@ describe("createNotification", () => {
         messageKey: notificationInput.messageKey,
         messageParams: JSON.stringify(notificationInput.messageParams),
         metadata: JSON.stringify(notificationInput.metadata),
+        inApp: true,
       },
     });
     expect(publishNotificationEventMock).toHaveBeenCalledWith({
@@ -132,6 +133,8 @@ describe("createNotification", () => {
         isRead: notification.isRead,
         readAt: null,
         createdAt: notification.createdAt.toISOString(),
+        inApp: true,
+        osBanner: false,
       },
     });
     expect(prismaMock.notification.findUnique).not.toHaveBeenCalled();
@@ -205,6 +208,7 @@ describe("createNotification", () => {
         messageKey: "Notifications.Job.paymentFailed",
         messageParams: JSON.stringify(notificationInput.messageParams),
         metadata: JSON.stringify(notificationInput.metadata),
+        inApp: true,
       },
     });
     expect(publishNotificationEventMock).toHaveBeenCalled();
@@ -246,6 +250,24 @@ describe("createNotification push gating", () => {
     publishNotificationEventMock.mockResolvedValue(undefined);
   });
 
+  /** The reader's account row, as the delivery read selects it. */
+  function mockReader({
+    pushOptIn = true,
+    preferences = [],
+  }: {
+    pushOptIn?: boolean;
+    preferences?: {
+      category: string;
+      channel: string;
+      enabled: boolean;
+    }[];
+  } = {}) {
+    userFindUniqueMock.mockResolvedValue({
+      pushOptIn,
+      notificationPreferences: preferences,
+    });
+  }
+
   const chatInput: CreateNotificationInput = {
     ...notificationInput,
     kind: NotificationKind.CHAT,
@@ -270,23 +292,31 @@ describe("createNotification push gating", () => {
   it("pushes a chat notification when the user opted in", async () => {
     const prismaMock = createPrismaMock();
     prismaMock.notification.create.mockResolvedValue(createChatRecord());
-    userFindUniqueMock.mockResolvedValue({ pushOptIn: true });
+    mockReader({ pushOptIn: true });
 
     await createNotification(chatInput, prismaMock as unknown as typeof prisma);
 
     expect(publishNotificationEventMock).toHaveBeenCalledWith(
-      expect.objectContaining({ push: true }),
+      expect.objectContaining({
+        push: true,
+        notification: expect.objectContaining({ osBanner: true }),
+      }),
     );
     expect(userFindUniqueMock).toHaveBeenCalledWith({
       where: { id: chatInput.userId },
-      select: { pushOptIn: true },
+      select: {
+        pushOptIn: true,
+        notificationPreferences: {
+          select: { category: true, channel: true, enabled: true },
+        },
+      },
     });
   });
 
   it("does not push a chat notification when the user did not opt in", async () => {
     const prismaMock = createPrismaMock();
     prismaMock.notification.create.mockResolvedValue(createChatRecord());
-    userFindUniqueMock.mockResolvedValue({ pushOptIn: false });
+    mockReader({ pushOptIn: false });
 
     await createNotification(chatInput, prismaMock as unknown as typeof prisma);
 
@@ -311,7 +341,7 @@ describe("createNotification push gating", () => {
       prismaMock.notification.create.mockResolvedValue(
         createNotificationRecord({ kind }),
       );
-      userFindUniqueMock.mockResolvedValue({ pushOptIn: true });
+      mockReader({ pushOptIn: true });
 
       await createNotification(
         { ...notificationInput, kind },
@@ -328,7 +358,7 @@ describe("createNotification push gating", () => {
       prismaMock.notification.create.mockResolvedValue(
         createNotificationRecord({ kind }),
       );
-      userFindUniqueMock.mockResolvedValue({ pushOptIn: false });
+      mockReader({ pushOptIn: false });
 
       await createNotification(
         { ...notificationInput, kind },
@@ -363,7 +393,7 @@ describe("createNotification push gating", () => {
         findUnique: vi.fn(),
       },
     };
-    userFindUniqueMock.mockResolvedValue({ pushOptIn: true });
+    mockReader({ pushOptIn: true });
 
     const result = await createNotification(
       chatInput,
@@ -382,11 +412,112 @@ describe("createNotification push gating", () => {
     const notification = createChatRecord();
     const prismaMock = createPrismaMock();
     prismaMock.notification.create.mockResolvedValue(notification);
-    userFindUniqueMock.mockResolvedValue({ pushOptIn: true });
+    mockReader({ pushOptIn: true });
 
     await expect(
       createNotification(chatInput, prismaMock as unknown as typeof prisma),
     ).resolves.toEqual({ notification, created: true });
+  });
+
+  it("stores the notification unseen when the reader silenced the category in the app", async () => {
+    const prismaMock = createPrismaMock();
+    prismaMock.notification.create.mockResolvedValue(
+      createNotificationRecord({ inApp: false }),
+    );
+    mockReader({
+      preferences: [{ category: "JOB", channel: "IN_APP", enabled: false }],
+    });
+
+    await createNotification(
+      notificationInput,
+      prismaMock as unknown as typeof prisma,
+    );
+
+    // Still written, so a later duplicate emit stays a no-op and the row can
+    // still be deleted by reference. Hidden, not dropped.
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ inApp: false }),
+      }),
+    );
+    // The banner survives the in-app choice: they are separate columns.
+    expect(publishNotificationEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ push: true }),
+    );
+  });
+
+  it("keeps a notification in the app when the reader silenced only its banner", async () => {
+    const prismaMock = createPrismaMock();
+    prismaMock.notification.create.mockResolvedValue(
+      createNotificationRecord(),
+    );
+    mockReader({
+      preferences: [{ category: "JOB", channel: "OS_BANNER", enabled: false }],
+    });
+
+    await createNotification(
+      notificationInput,
+      prismaMock as unknown as typeof prisma,
+    );
+
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ inApp: true }),
+      }),
+    );
+    // An open tab renders its own banner from this event, so the answer has to
+    // ride the payload and not only the push extras.
+    expect(publishNotificationEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        push: false,
+        notification: expect.objectContaining({ osBanner: false }),
+      }),
+    );
+  });
+
+  it("splits the two chat rows, so muting mentions leaves direct messages alone", async () => {
+    const prismaMock = createPrismaMock();
+    prismaMock.notification.create.mockResolvedValue(createChatRecord());
+    mockReader({
+      preferences: [
+        { category: "CHAT_MENTION", channel: "IN_APP", enabled: false },
+        { category: "CHAT_MENTION", channel: "OS_BANNER", enabled: false },
+      ],
+    });
+
+    await createNotification(
+      {
+        ...chatInput,
+        messageKey: "Notifications.Chat.directMessage",
+      },
+      prismaMock as unknown as typeof prisma,
+    );
+
+    expect(publishNotificationEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ push: true }),
+    );
+  });
+
+  it("does not publish a notification the reader silenced on both channels", async () => {
+    const prismaMock = createPrismaMock();
+    prismaMock.notification.create.mockResolvedValue(
+      createNotificationRecord({ inApp: false }),
+    );
+    mockReader({
+      preferences: [
+        { category: "JOB", channel: "IN_APP", enabled: false },
+        { category: "JOB", channel: "OS_BANNER", enabled: false },
+      ],
+    });
+
+    await createNotification(
+      notificationInput,
+      prismaMock as unknown as typeof prisma,
+    );
+
+    // Nothing to render and nothing to interrupt with, so the publish would be
+    // an Ably message no client acts on.
+    expect(publishNotificationEventMock).not.toHaveBeenCalled();
   });
 
   it("still publishes in-app, with push off, when the opt-in read fails", async () => {

--- a/apps/core/src/helpers/notifications.ts
+++ b/apps/core/src/helpers/notifications.ts
@@ -5,6 +5,11 @@ import {
   type Prisma,
 } from "@sokosumi/database";
 
+import type { NotificationDelivery } from "@/helpers/notification-delivery";
+import {
+  resolveNotificationDelivery,
+  toNotificationCategory,
+} from "@/helpers/notification-delivery";
 import {
   COWORKER_ACCESS_PENDING_MESSAGE_KEY,
   VENDOR_GRANT_PENDING_MESSAGE_KEY,
@@ -29,50 +34,66 @@ export interface CreateNotificationResult {
 }
 
 /**
- * Whether this notification also goes out as a closed-app OS banner.
+ * Where this notification goes: the app, the OS banner, both, or neither.
  *
- * Push rides the notification publish over Ably (ADR-0022), gated on explicit
- * user consent and on nothing else: every kind pushes. That costs one consent
- * read per notification on the bulk job and task paths too, where the chat-only
- * gate used to return before reading. A room mention still costs one read per
- * recipient.
+ * Read once, before the row is written, because the in-app answer is stored on
+ * the row itself. That costs one read per notification on the bulk job and task
+ * paths too, and one read per recipient of a room mention.
  *
  * Never throws, and never reads through the caller's transaction client. A
- * consent read that fails must degrade push alone: it must not abort a caller's
- * transaction, and it must not stop the in-app realtime publish.
+ * failed read must degrade delivery alone: it must not abort a caller's
+ * transaction, and it must not cost the reader the notification. So it falls
+ * back to the in-app notification without the banner, which is the quieter of
+ * the two and the one that leaves a record the reader can still find.
  */
-async function shouldPushNotification(
-  notification: Notification,
-): Promise<boolean> {
+async function resolveDelivery(
+  input: CreateNotificationInput,
+): Promise<NotificationDelivery> {
   try {
     const user = await prisma.user.findUnique({
-      where: { id: notification.userId },
-      select: { pushOptIn: true },
-    });
-
-    return user?.pushOptIn === true;
-  } catch (error) {
-    console.error("Failed to read the push opt-in; skipping push:", error);
-    Sentry.captureException(error, {
-      extra: {
-        notificationId: notification.id,
-        userId: notification.userId,
-        errorType: "push-opt-in-read",
+      where: { id: input.userId },
+      select: {
+        pushOptIn: true,
+        notificationPreferences: {
+          select: { category: true, channel: true, enabled: true },
+        },
       },
     });
 
-    return false;
+    if (!user) {
+      return { inApp: true, osBanner: false };
+    }
+
+    return resolveNotificationDelivery({
+      category: toNotificationCategory(input.kind, input.messageKey),
+      preferences: user.notificationPreferences,
+      pushOptIn: user.pushOptIn,
+    });
+  } catch (error) {
+    console.error(
+      "Failed to read the notification preferences; skipping push:",
+      error,
+    );
+    Sentry.captureException(error, {
+      extra: {
+        userId: input.userId,
+        kind: input.kind,
+        messageKey: input.messageKey,
+        errorType: "notification-delivery-read",
+      },
+    });
+
+    return { inApp: true, osBanner: false };
   }
 }
 
 async function publishNotificationCreated(
   notification: Notification,
+  delivery: NotificationDelivery,
 ): Promise<void> {
   try {
-    const push = await shouldPushNotification(notification);
-
     await publishNotificationEvent({
-      push,
+      push: delivery.osBanner,
       userId: notification.userId,
       notification: {
         id: notification.id,
@@ -88,6 +109,8 @@ async function publishNotificationCreated(
         isRead: notification.isRead,
         readAt: notification.readAt?.toISOString() ?? null,
         createdAt: notification.createdAt.toISOString(),
+        inApp: notification.inApp,
+        osBanner: delivery.osBanner,
       },
     });
   } catch (error) {
@@ -129,6 +152,8 @@ export async function createNotification(
     messageKey: input.messageKey,
   };
 
+  const delivery = await resolveDelivery(input);
+
   try {
     const notification = await prisma.notification.create({
       data: {
@@ -138,10 +163,15 @@ export async function createNotification(
           input.metadata === undefined || input.metadata === null
             ? null
             : JSON.stringify(input.metadata),
+        inApp: delivery.inApp,
       },
     });
 
-    await publishNotificationCreated(notification);
+    // Nothing to render and nothing to interrupt with: the publish would be an
+    // Ably message no client acts on.
+    if (delivery.inApp || delivery.osBanner) {
+      await publishNotificationCreated(notification, delivery);
+    }
 
     return { notification, created: true };
   } catch (error) {

--- a/apps/core/src/helpers/task-notifications.test.ts
+++ b/apps/core/src/helpers/task-notifications.test.ts
@@ -43,7 +43,6 @@ describe("dispatchTaskNotification", () => {
         project: null,
         projectId: null,
         workspaceId: null,
-        owner: { notificationsOptIn: true },
       },
       "event_1",
       "COMPLETED",

--- a/apps/core/src/helpers/task-notifications.ts
+++ b/apps/core/src/helpers/task-notifications.ts
@@ -53,15 +53,10 @@ export async function dispatchTaskNotification(
     project: { name: string } | null;
     projectId: string | null;
     workspaceId: string | null;
-    owner: { notificationsOptIn: boolean };
   },
   eventId: string,
   status: string,
 ): Promise<void> {
-  if (!task.owner.notificationsOptIn) {
-    return;
-  }
-
   try {
     let messageKey: string;
     switch (status) {
@@ -152,11 +147,6 @@ export async function notifyTaskStatusEvent(
         project: {
           select: {
             name: true,
-          },
-        },
-        owner: {
-          select: {
-            notificationsOptIn: true,
           },
         },
       },

--- a/apps/core/src/lib/ably/publish.test.ts
+++ b/apps/core/src/lib/ably/publish.test.ts
@@ -77,6 +77,8 @@ describe("publishNotificationEvent", () => {
     isRead: false,
     readAt: null,
     createdAt: "2026-06-17T12:00:00.000Z",
+    inApp: true,
+    osBanner: false,
   };
 
   beforeEach(() => {

--- a/apps/core/src/lib/ably/publish.ts
+++ b/apps/core/src/lib/ably/publish.ts
@@ -52,6 +52,19 @@ interface NotificationEventData {
   isRead: boolean;
   readAt: string | null;
   createdAt: string;
+  /**
+   * Whether the app shows this at all: the Notification Center for a feed
+   * kind, the in-app toast for a browser-only one. False when the reader
+   * silenced its category in the app but still wants the OS banner, which is
+   * why the event is published at all in that case.
+   */
+  inApp: boolean;
+  /**
+   * Whether this may interrupt with an OS banner. An open tab renders its own
+   * banner from this event rather than waiting for the push, so it has to read
+   * the same answer the push extras were gated on.
+   */
+  osBanner: boolean;
 }
 
 interface PublishNotificationEventInput {

--- a/apps/core/src/services/job-sync-state.service.ts
+++ b/apps/core/src/services/job-sync-state.service.ts
@@ -115,11 +115,13 @@ async function dispatchFinalStatusNotification(
   jobStatus: SokosumiJobStatus,
   enqueueEmail: (input: SendEmailInput) => void,
 ): Promise<void> {
+  await dispatchJobInAppNotification(job, jobStatus);
+
+  // The account-wide opt-in is the email gate now. The notification answers to
+  // the preference matrix instead, one row per category and channel.
   if (!job.owner.notificationsOptIn) {
     return;
   }
-
-  await dispatchJobInAppNotification(job, jobStatus);
 
   try {
     const agentName = getAgentName(job.agent);
@@ -153,11 +155,11 @@ async function dispatchInputRequiredNotification(
   job: JobWithSokosumiStatus,
   enqueueEmail: (input: SendEmailInput) => void,
 ): Promise<void> {
+  await dispatchJobInAppNotification(job, SokosumiJobStatus.INPUT_REQUIRED);
+
   if (!job.owner.notificationsOptIn) {
     return;
   }
-
-  await dispatchJobInAppNotification(job, SokosumiJobStatus.INPUT_REQUIRED);
 
   try {
     const agentName = getAgentName(job.agent);
@@ -271,10 +273,6 @@ async function dispatchJobNotification(
   jobStatus: SokosumiJobStatus,
   eventId: string,
 ): Promise<void> {
-  if (!job.owner.notificationsOptIn) {
-    return;
-  }
-
   try {
     const agentName = getAgentName(job.agent);
     const jobName = job.name ?? "Untitled job";

--- a/apps/core/src/services/job-sync.service.test.ts
+++ b/apps/core/src/services/job-sync.service.test.ts
@@ -1746,6 +1746,56 @@ describe("jobSyncService.syncUnfinishedJobs", () => {
     });
   });
 
+  it("still notifies an owner who turned the account-wide emails off", async () => {
+    const owner = {
+      id: "user_1",
+      email: "user@example.com",
+      name: "Ada",
+      notificationsOptIn: false,
+    };
+    const initialJob = createJob({ owner });
+    const completedJob = createJob({
+      owner,
+      status: SokosumiJobStatus.COMPLETED,
+      jobStatusSettled: true,
+      completedAt: new Date("2026-03-18T10:05:00.000Z"),
+      events: [
+        createJobEvent({
+          id: "event_2",
+          status: AgentJobStatus.COMPLETED,
+          result: "done",
+          statusHash: "new-hash",
+        }),
+      ],
+    });
+
+    mockInitialJobQueries({ agent: [initialJob] });
+    fetchAgentJobStatusMock.mockReturnValue(
+      ok({
+        status: "completed",
+        result: "done",
+        input_schema: null,
+        statusHash: "new-hash",
+      }),
+    );
+    getJobByIdMock.mockResolvedValueOnce(completedJob);
+
+    await jobSyncService.syncUnfinishedJobs(createExecutionOptions());
+
+    // The opt-in is the email gate now. The notification answers to the
+    // preference matrix, which `createNotification` reads for itself.
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_1",
+        kind: NotificationKind.JOB,
+        messageKey: "Notifications.Job.completed",
+      }),
+    );
+    expect(renderJobFinalStatusEmailMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
   it("emits failure notifications for terminal payment failures", async () => {
     const updatedFailedJob = createJob({
       status: SokosumiJobStatus.PAYMENT_FAILED,

--- a/apps/core/src/services/task-schedule-quarantine.service.ts
+++ b/apps/core/src/services/task-schedule-quarantine.service.ts
@@ -232,11 +232,9 @@ async function notifyQuarantineAction(
           ],
         },
       },
-      select: {
-        owner: { select: { notificationsOptIn: true } },
-      },
+      select: { id: true },
     });
-    if (!accessibleTask?.owner.notificationsOptIn) {
+    if (!accessibleTask) {
       return;
     }
 

--- a/packages/database/prisma/migrations/20260901170000_backfill_notification_opt_out/migration.sql
+++ b/packages/database/prisma/migrations/20260901170000_backfill_notification_opt_out/migration.sql
@@ -1,0 +1,35 @@
+-- Carries the account-wide notification opt-out into the preference matrix.
+--
+-- `user.notificationsOptIn = false` used to stop the job and task notifications
+-- from being created at all. It is the email gate alone now, so without these
+-- rows every reader who turned it off would start receiving what they silenced.
+--
+-- Job and task only: chat and system notifications were never gated by it.
+-- Both channels, because the old gate stopped the feed row and the OS banner
+-- together.
+--
+-- Idempotent: a reader who already chose something for a cell keeps their
+-- choice.
+
+INSERT INTO "notification_preference" (
+  "id",
+  "userId",
+  "category",
+  "channel",
+  "enabled",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  gen_random_uuid()::text,
+  "user"."id",
+  category,
+  channel,
+  false,
+  now(),
+  now()
+FROM "user"
+CROSS JOIN (VALUES ('JOB'), ('TASK')) AS categories(category)
+CROSS JOIN (VALUES ('IN_APP'), ('OS_BANNER')) AS channels(channel)
+WHERE "user"."notificationsOptIn" = false
+ON CONFLICT ("userId", "category", "channel") DO NOTHING;


### PR DESCRIPTION
Part 4 of 7 for [SOK-877](https://linear.app/sokosumi/issue/SOK-877). This is the layer that changes behaviour for existing readers.

## What changes for a reader

The publish path read one flag, `pushOptIn`, and the producers read another, `notificationsOptIn`. Neither could express "tell me about mentions but not about jobs".

`createNotification` now resolves the delivery once, before it writes the row: the reader's matrix decides the in-app answer, which is stored on the notification, and the OS banner, which still needs the account-wide push consent on top. A notification silenced on both channels is written but not published, because no client would act on the event.

The job and task producers stop gating creation on `notificationsOptIn`. It keeps its other job: the job status emails still answer to it, and that is now the only thing it gates. The quarantine notification kept its accessibility check, which the same query had conflated with the opt-in.

## Migration

`20260901170000_backfill_notification_opt_out` carries the old opt-out into the matrix: a reader with `notificationsOptIn = false` gets `JOB` and `TASK` off on both channels, so nothing they silenced starts arriving. Chat and system notifications were never gated by that flag, so they are left alone.

Proved on a local database inside a transaction that was rolled back: an opted-out user got four rows, an opted-in user got none, and a row the reader had already chosen was left untouched (`INSERT 0 3`, existing `JOB / IN_APP` still `true`).

## Verification

- `pnpm --filter @sokosumi/core test` → `4646 passed | 6 skipped`
- The new job-sync case was mutation-checked: restoring the old gate fails it, removing it passes.
