### PR TITLE
feat(core): hide silenced notifications from the feed

### DIFF
--- a/apps/core/src/helpers/notification-feed.test.ts
+++ b/apps/core/src/helpers/notification-feed.test.ts
@@ -12,7 +12,7 @@ import {
   findStaleCoworkerAccessNotificationReferenceIds,
   findStaleVendorGrantNotificationReferenceIds,
   mergeAccessNotificationExclusions,
-  notificationFeedKindWhere,
+  notificationFeedWhere,
   VENDOR_GRANT_PENDING_MESSAGE_KEY,
 } from "./notification-feed";
 
@@ -35,45 +35,60 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-describe("notificationFeedKindWhere", () => {
+describe("notificationFeedWhere", () => {
   it("excludes CHAT from the default in-app feed", () => {
-    expect(notificationFeedKindWhere()).toEqual({
-      notIn: [NotificationKind.CHAT],
+    expect(notificationFeedWhere()).toEqual({
+      kind: { notIn: [NotificationKind.CHAT] },
+      inApp: true,
     });
   });
 
   it("drops CHAT when an explicit kind filter includes it", () => {
     expect(
-      notificationFeedKindWhere([
+      notificationFeedWhere([
         NotificationKind.JOB,
         NotificationKind.CHAT,
         NotificationKind.TASK,
       ]),
     ).toEqual({
-      in: [NotificationKind.JOB, NotificationKind.TASK],
+      kind: { in: [NotificationKind.JOB, NotificationKind.TASK] },
+      inApp: true,
     });
   });
 
   it("matches nothing when the only requested kind is browser-only", () => {
-    expect(notificationFeedKindWhere([NotificationKind.CHAT])).toEqual({
-      notIn: [
-        NotificationKind.JOB,
-        NotificationKind.TASK,
-        NotificationKind.BILLING,
-        NotificationKind.SYSTEM,
-        NotificationKind.CHAT,
-      ],
+    expect(notificationFeedWhere([NotificationKind.CHAT])).toEqual({
+      kind: {
+        notIn: [
+          NotificationKind.JOB,
+          NotificationKind.TASK,
+          NotificationKind.BILLING,
+          NotificationKind.SYSTEM,
+          NotificationKind.CHAT,
+        ],
+      },
+      inApp: true,
     });
   });
 
   it("keeps non-chat kinds as an explicit in filter", () => {
     expect(
-      notificationFeedKindWhere([
-        NotificationKind.JOB,
-        NotificationKind.SYSTEM,
-      ]),
+      notificationFeedWhere([NotificationKind.JOB, NotificationKind.SYSTEM]),
     ).toEqual({
-      in: [NotificationKind.JOB, NotificationKind.SYSTEM],
+      kind: { in: [NotificationKind.JOB, NotificationKind.SYSTEM] },
+      inApp: true,
+    });
+  });
+
+  /**
+   * A notification the reader silenced in the app is written but never shown,
+   * so every feed read has to exclude it. Asserted on its own, because it is
+   * the one clause a new call site is most likely to leave out.
+   */
+  it("hides a notification the reader silenced in the app, whatever the kinds", () => {
+    expect(notificationFeedWhere()).toMatchObject({ inApp: true });
+    expect(notificationFeedWhere([NotificationKind.JOB])).toMatchObject({
+      inApp: true,
     });
   });
 });

--- a/apps/core/src/helpers/notification-feed.ts
+++ b/apps/core/src/helpers/notification-feed.ts
@@ -27,11 +27,7 @@ export const VENDOR_GRANT_PENDING_MESSAGE_KEY =
 export const COWORKER_ACCESS_PENDING_MESSAGE_KEY =
   "notifications.coworkerAccess.pending";
 
-/**
- * Prisma `kind` filter for the in-app notification feed (list, unread count,
- * mark-all-read). Always excludes browser-only kinds such as CHAT.
- */
-export function notificationFeedKindWhere(
+function notificationFeedKindWhere(
   requestedKinds?: readonly NotificationKind[],
 ): Prisma.EnumNotificationKindFilter {
   if (requestedKinds && requestedKinds.length > 0) {
@@ -49,6 +45,23 @@ export function notificationFeedKindWhere(
 
   return {
     notIn: BROWSER_ONLY_KIND_FILTER,
+  };
+}
+
+/**
+ * Prisma filter for the in-app notification feed (list, unread count,
+ * mark-all-read).
+ *
+ * Two reasons a stored notification never reaches the feed, returned together
+ * so a call site cannot apply one and forget the other: its kind is
+ * browser-only, such as CHAT, or the reader silenced its category in the app.
+ */
+export function notificationFeedWhere(
+  requestedKinds?: readonly NotificationKind[],
+): Prisma.NotificationWhereInput {
+  return {
+    kind: notificationFeedKindWhere(requestedKinds),
+    inApp: true,
   };
 }
 

--- a/apps/core/src/routes/v1/notifications/get.test.ts
+++ b/apps/core/src/routes/v1/notifications/get.test.ts
@@ -123,6 +123,7 @@ describe("GET /notifications", () => {
       where: {
         userId: "user_123",
         kind: { notIn: [NotificationKind.CHAT] },
+        inApp: true,
       },
       take: LIMITS.DEFAULT_PAGINATION_LIMIT + 1,
       skip: undefined,
@@ -133,6 +134,7 @@ describe("GET /notifications", () => {
       where: {
         userId: "user_123",
         kind: { notIn: [NotificationKind.CHAT] },
+        inApp: true,
       },
     });
 
@@ -162,6 +164,7 @@ describe("GET /notifications", () => {
         where: {
           userId: "user_123",
           kind: { in: [NotificationKind.JOB, NotificationKind.TASK] },
+          inApp: true,
           isRead: false,
         },
       }),
@@ -180,6 +183,7 @@ describe("GET /notifications", () => {
         where: {
           userId: "user_123",
           kind: { in: [NotificationKind.JOB] },
+          inApp: true,
           isRead: false,
         },
       }),
@@ -201,6 +205,7 @@ describe("GET /notifications", () => {
           {
             userId: "user_123",
             kind: { in: [NotificationKind.JOB] },
+            inApp: true,
             isRead: false,
           },
           { id: "notif_cursor" },
@@ -267,6 +272,7 @@ describe("GET /notifications", () => {
         where: {
           userId: "user_123",
           kind: { notIn: [NotificationKind.CHAT] },
+          inApp: true,
           NOT: {
             AND: [
               { messageKey: "notifications.vendorGrant.pending" },
@@ -280,6 +286,7 @@ describe("GET /notifications", () => {
       where: {
         userId: "user_123",
         kind: { notIn: [NotificationKind.CHAT] },
+        inApp: true,
         NOT: {
           AND: [
             { messageKey: "notifications.vendorGrant.pending" },
@@ -312,6 +319,7 @@ describe("GET /notifications", () => {
         where: {
           userId: "user_123",
           kind: { notIn: [NotificationKind.CHAT] },
+          inApp: true,
           NOT: {
             AND: [
               { messageKey: "notifications.coworkerAccess.pending" },

--- a/apps/core/src/routes/v1/notifications/get.ts
+++ b/apps/core/src/routes/v1/notifications/get.ts
@@ -8,7 +8,7 @@ import {
   findStaleCoworkerAccessNotificationReferenceIds,
   findStaleVendorGrantNotificationReferenceIds,
   mergeAccessNotificationExclusions,
-  notificationFeedKindWhere,
+  notificationFeedWhere,
 } from "@/helpers/notification-feed";
 import {
   jsonErrorResponse,
@@ -167,7 +167,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     const where: Prisma.NotificationWhereInput = {
       userId: userContext.userId,
-      kind: notificationFeedKindWhere(queryParams.kind),
+      ...notificationFeedWhere(queryParams.kind),
       ...mergeAccessNotificationExclusions(
         excludeResolvedVendorGrantNotificationsWhere(
           staleVendorGrantReferenceIds,

--- a/apps/core/src/routes/v1/notifications/mutations.test.ts
+++ b/apps/core/src/routes/v1/notifications/mutations.test.ts
@@ -195,6 +195,7 @@ describe("PATCH /notifications/read-all", () => {
         userId: "user_123",
         isRead: false,
         kind: { notIn: [NotificationKind.CHAT] },
+        inApp: true,
       },
       data: {
         isRead: true,
@@ -226,6 +227,7 @@ describe("GET /notifications/unread-count", () => {
         userId: "user_123",
         isRead: false,
         kind: { notIn: [NotificationKind.CHAT] },
+        inApp: true,
       },
     });
 
@@ -251,6 +253,7 @@ describe("GET /notifications/unread-count", () => {
         userId: "user_123",
         isRead: false,
         kind: { notIn: [NotificationKind.CHAT] },
+        inApp: true,
         NOT: {
           AND: [
             { messageKey: "notifications.vendorGrant.pending" },
@@ -278,6 +281,7 @@ describe("GET /notifications/unread-count", () => {
         userId: "user_123",
         isRead: false,
         kind: { notIn: [NotificationKind.CHAT] },
+        inApp: true,
         NOT: {
           AND: [
             { messageKey: "notifications.coworkerAccess.pending" },

--- a/apps/core/src/routes/v1/notifications/read-all/patch.ts
+++ b/apps/core/src/routes/v1/notifications/read-all/patch.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
-import { notificationFeedKindWhere } from "@/helpers/notification-feed";
+import { notificationFeedWhere } from "@/helpers/notification-feed";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -52,7 +52,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       where: {
         userId: userContext.userId,
         isRead: false,
-        kind: notificationFeedKindWhere(),
+        ...notificationFeedWhere(),
       },
       data: {
         isRead: true,

--- a/apps/core/src/routes/v1/notifications/unread-count/get.ts
+++ b/apps/core/src/routes/v1/notifications/unread-count/get.ts
@@ -6,7 +6,7 @@ import {
   findStaleCoworkerAccessNotificationReferenceIds,
   findStaleVendorGrantNotificationReferenceIds,
   mergeAccessNotificationExclusions,
-  notificationFeedKindWhere,
+  notificationFeedWhere,
 } from "@/helpers/notification-feed";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -53,7 +53,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       where: {
         userId: userContext.userId,
         isRead: false,
-        kind: notificationFeedKindWhere(),
+        ...notificationFeedWhere(),
         ...mergeAccessNotificationExclusions(
           excludeResolvedVendorGrantNotificationsWhere(
             staleVendorGrantReferenceIds,

--- a/apps/web/src/app/(app)/components/notification-toast-listener.test.tsx
+++ b/apps/web/src/app/(app)/components/notification-toast-listener.test.tsx
@@ -104,6 +104,8 @@ const NOTIFICATION: NotificationEventData = {
   isRead: false,
   readAt: null,
   createdAt: "2026-01-01T00:00:00.000Z",
+  inApp: true,
+  osBanner: true,
 };
 
 function emitOnUnfocusedTab() {
@@ -139,6 +141,21 @@ describe("NotificationToastListener OS banner", () => {
         expect.objectContaining({ body: "message", target: TARGET }),
       );
     });
+  });
+
+  /**
+   * An open tab renders its own banner rather than waiting for the push, so the
+   * reader's banner choice has to be read here too. Reading it only on the push
+   * would leave the banner running for anyone with a tab open.
+   */
+  it("renders no banner when the reader silenced the category's banner", async () => {
+    render(<NotificationToastListener userId="user-1" markRead={markRead} />);
+    onNotificationRef.current?.({ ...NOTIFICATION, osBanner: false });
+
+    await vi.waitFor(() => {
+      expect(getNotificationServiceWorker).toHaveBeenCalled();
+    });
+    expect(showNotification).not.toHaveBeenCalled();
   });
 
   it("installs the worker on mount so the first banner does not wait", () => {

--- a/apps/web/src/app/(app)/components/notification-toast-listener.tsx
+++ b/apps/web/src/app/(app)/components/notification-toast-listener.tsx
@@ -155,13 +155,19 @@ export function NotificationToastListener({
       const isDocumentFocused =
         typeof document !== "undefined" ? document.hasFocus() : true;
       const permission = getBrowserNotificationPermission();
-      const showBrowser = shouldShowBrowserNotification({
-        permission,
-        isDocumentFocused,
-        isRead: notification.isRead,
-      });
+      // `osBanner` is the reader's own choice for this category. An open tab
+      // renders its banner from this event rather than from the push, so the
+      // choice has to be read here as well as at publish time.
+      const showBrowser =
+        notification.osBanner &&
+        shouldShowBrowserNotification({
+          permission,
+          isDocumentFocused,
+          isRead: notification.isRead,
+        });
       const showPendingAccessToast =
         isDocumentFocused &&
+        notification.inApp &&
         !notification.isRead &&
         (isPendingVendorGrantNotification(notification) ||
           isPendingCoworkerAccessNotification(notification));

--- a/apps/web/src/contexts/notification-provider.island.test.tsx
+++ b/apps/web/src/contexts/notification-provider.island.test.tsx
@@ -124,6 +124,63 @@ describe("NotificationProvider island", () => {
     });
   });
 
+  /** Emits one realtime event through the bridge's own callback. */
+  async function emit(notification: Record<string, unknown>) {
+    render(
+      <NotificationProvider userId="user-1">
+        <NotificationConsumer />
+      </NotificationProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const onNotification = useNotificationRealtimeMock.mock.calls
+      .map(
+        (call) =>
+          (call[0] as { onNotification?: (event: unknown) => void })
+            .onNotification,
+      )
+      .find(Boolean);
+
+    await act(async () => {
+      onNotification?.(notification);
+    });
+  }
+
+  const REALTIME_EVENT = {
+    id: "notification-1",
+    userId: "user-1",
+    kind: "JOB",
+    referenceId: "job-1",
+    eventId: "event-1",
+    messageKey: "Notifications.Job.completed",
+    messageParams: {},
+    metadata: null,
+    isRead: false,
+    readAt: null,
+    createdAt: "2026-06-18T09:00:00.000Z",
+    inApp: true,
+    osBanner: true,
+  };
+
+  it("counts a delivered notification the moment it arrives", async () => {
+    await emit(REALTIME_EVENT);
+
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("1");
+  });
+
+  /**
+   * The event still arrives, because the OS banner rides it. The bell is what
+   * the reader silenced, so it must not move.
+   */
+  it("leaves the bell alone for a notification silenced in the app", async () => {
+    await emit({ ...REALTIME_EVENT, inApp: false });
+
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("0");
+  });
+
   it("surfaces fetch errors on the immediate path without Ably", async () => {
     lazyAblyProviderMock.mockImplementation((): ReactNode => null);
     getNotificationsMock.mockRejectedValue(new Error("network down"));

--- a/apps/web/src/contexts/notification-provider.tsx
+++ b/apps/web/src/contexts/notification-provider.tsx
@@ -425,6 +425,12 @@ export function NotificationProvider({
 
   const handleNotificationEvent = useCallback(
     (notification: NotificationEventData) => {
+      // Silenced in the app by the reader's preference matrix. It still arrives,
+      // because an OS banner rides the same event.
+      if (!notification.inApp) {
+        return;
+      }
+
       dispatch({
         type: "realtime",
         notification: {

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -35,6 +35,13 @@ export const notificationEventDataSchema = z.object({
   isRead: z.boolean(),
   readAt: z.string().nullable(),
   createdAt: z.string(),
+  /**
+   * Where the reader's preference matrix said this goes. Both default to true
+   * for an event published by a Core that predates the matrix: it was delivered
+   * on both channels, so that is what the reader saw.
+   */
+  inApp: z.boolean().default(true),
+  osBanner: z.boolean().default(true),
 });
 
 export type NotificationEventData = z.infer<typeof notificationEventDataSchema>;


### PR DESCRIPTION
Part 5 of 7 for [SOK-877](https://linear.app/sokosumi/issue/SOK-877). Core and web halves of one thing: the feed reflects the matrix.

## Core

The Notification Center, the unread count, and mark-all-read each built their own where clause around one shared kind filter. A notification the reader silenced in the app has to disappear from all three, and a fourth reader of the feed would have had to remember the new clause.

`notificationFeedWhere` returns both reasons a stored notification never reaches the feed: a browser-only kind such as CHAT, and the reader's own choice. The old `notificationFeedKindWhere` is now private to it, since its name no longer describes what a feed query needs.

## Web

Core publishes a notification the reader silenced in the app whenever the OS banner still applies, because push rides that publish. The bell counted it anyway, and an open tab rendered its own banner from the same event without reading the reader's banner choice at all.

The event now carries both answers, so the app reads the same decision the push was gated on: the Notification Center skips what is silenced in the app, and the tab renders a banner only where the reader kept one. Both fields default to true when absent, so an event published by a Core that predates the matrix behaves as it does today. That matters during the deploy window, when an old Core and a new web app overlap.

## Verification

- `pnpm --filter @sokosumi/core test src/routes/v1/notifications src/helpers/notification-feed.test.ts` → `33 passed`
- `pnpm --filter web test` → `4210 passed | 1 skipped`
