### PR TITLE
feat(soko-bot): stop creating shadow coworker for personal assistants

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -6,6 +6,7 @@ import { buildCoworkerUsableInWorkspaceWhere } from "@/helpers/access-control";
 import {
   assertChatRoomPatchAuth,
   buildDirectCoworkerRoomKey,
+  buildDirectOrchestratorRoomKey,
   buildDirectParticipantRoomKey,
   buildDirectRoomKey,
   buildDirectRoomName,
@@ -363,6 +364,12 @@ describe("buildDirectRoomKey", () => {
   it("builds a namespaced key for coworker direct messages", () => {
     expect(buildDirectCoworkerRoomKey("user_a", "coworker_elena")).toBe(
       "coworker:user_a:coworker_elena",
+    );
+  });
+
+  it("builds a namespaced key for orchestrator direct messages", () => {
+    expect(buildDirectOrchestratorRoomKey("user_a", "bot_1")).toBe(
+      "orchestrator:user_a:bot_1",
     );
   });
 

--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -37,6 +37,8 @@ import {
   resolveMentionedCoworkerIds,
   resolveMentionedOrchestratorIds,
   resolveMentionedUserIds,
+  resolveOrchestratorDirectLookupOrganizationIds,
+  resolveOrchestratorDirectRoomOrganizationId,
   resolvePeerInActiveOrganization,
   resolveWorkspaceIdForChatRoom,
   usersShareExternalChannel,
@@ -1831,5 +1833,54 @@ describe("requireRoomMemberCanInviteGuests", () => {
       (error: unknown) =>
         error instanceof HTTPException && error.status === 404,
     );
+  });
+});
+
+describe("resolveOrchestratorDirectRoomOrganizationId", () => {
+  it("forces owner↔PA directs to personal scope", () => {
+    expect(
+      resolveOrchestratorDirectRoomOrganizationId({
+        isOwner: true,
+        activeOrganizationId: "org_1",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps colleague approach org-scoped", () => {
+    expect(
+      resolveOrchestratorDirectRoomOrganizationId({
+        isOwner: false,
+        activeOrganizationId: "org_1",
+      }),
+    ).toBe("org_1");
+  });
+});
+
+describe("resolveOrchestratorDirectLookupOrganizationIds", () => {
+  it("searches personal then active org for owners", () => {
+    expect(
+      resolveOrchestratorDirectLookupOrganizationIds({
+        isOwner: true,
+        activeOrganizationId: "org_1",
+      }),
+    ).toEqual([null, "org_1"]);
+  });
+
+  it("searches only personal when the owner has no active org", () => {
+    expect(
+      resolveOrchestratorDirectLookupOrganizationIds({
+        isOwner: true,
+        activeOrganizationId: null,
+      }),
+    ).toEqual([null]);
+  });
+
+  it("searches only the active org for colleagues", () => {
+    expect(
+      resolveOrchestratorDirectLookupOrganizationIds({
+        isOwner: false,
+        activeOrganizationId: "org_1",
+      }),
+    ).toEqual(["org_1"]);
   });
 });

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -2068,8 +2068,11 @@ export async function validateChatCoworkerIds(
 }
 
 /**
- * Owner may add their own live Soko Bot (PA) to a room. Must match workspace
- * and owner; archived/deleted bots are rejected.
+ * Validate Soko Bot ids for chat room membership.
+ * - Owner-scoped (`ownerUserId` set): personal DMs / owner channels — bots
+ *   must belong to that user in the workspace.
+ * - Workspace-scoped (no `ownerUserId`): org rooms — any live PA in the
+ *   workspace (colleague approach).
  */
 export async function validateChatOrchestratorIds(
   orchestratorIds: readonly string[],
@@ -2098,7 +2101,9 @@ export async function validateChatOrchestratorIds(
 
   if (missing.length > 0) {
     throw badRequest(
-      "Room personal assistants must be your live Soko Bot in this workspace",
+      opts.ownerUserId
+        ? "Room personal assistants must be your live Soko Bot in this workspace"
+        : "Room personal assistants must be a live Soko Bot in this workspace",
     );
   }
 
@@ -2471,6 +2476,35 @@ type DirectCreateShape =
       orchestratorIds: [string];
     };
 
+/**
+ * Owner↔PA directs are always personal (`organizationId` null) so Message bot
+ * under an active org reuses the legacy personal shadow DM. Colleague approach
+ * stays org-scoped and requires an active organization.
+ */
+export function resolveOrchestratorDirectRoomOrganizationId(params: {
+  isOwner: boolean;
+  activeOrganizationId: string | null;
+}): string | null {
+  return params.isOwner ? null : params.activeOrganizationId;
+}
+
+/**
+ * Lookup order when create-or-getting an orchestrator 1:1. Owner checks
+ * personal first, then the active org (reuse a previously forked org room
+ * instead of creating another). Colleague checks only the active org.
+ */
+export function resolveOrchestratorDirectLookupOrganizationIds(params: {
+  isOwner: boolean;
+  activeOrganizationId: string | null;
+}): Array<string | null> {
+  if (params.isOwner) {
+    return params.activeOrganizationId
+      ? [null, params.activeOrganizationId]
+      : [null];
+  }
+  return [params.activeOrganizationId];
+}
+
 export async function createOrGetDirectRoom(params: {
   organizationId: string | null;
   currentUserId: string;
@@ -2562,19 +2596,68 @@ export async function createOrGetDirectRoom(params: {
       }
 
       if (shape.kind === "orchestrator-1to1") {
-        const workspaceId = await resolveWorkspaceIdForChatRoom({
-          organizationId: activeOrganizationId,
-          personalUserId: currentUserId,
-          tx,
+        const requestedOrchestratorId = requestedOrchestratorIds[0];
+        // Peek ownership before choosing room org scope / workspace. Owner↔PA
+        // DMs stay personal even when an org is active so Message bot reuses
+        // the legacy personal shadow DM instead of forking an empty org room.
+        const botPeek = await tx.sokoBot.findFirst({
+          where: {
+            id: requestedOrchestratorId,
+            archivedAt: null,
+            deletedAt: null,
+          },
+          select: {
+            id: true,
+            userId: true,
+            workspaceId: true,
+            coworker: { select: { id: true } },
+          },
         });
-        // Personal DMs stay owner-scoped. Org DMs allow any live workspace PA
-        // so a bot can approach colleagues (and colleagues can be messaged)
-        // without a shadow coworker row.
+        if (!botPeek) {
+          throw badRequest(
+            "Room personal assistants must be a live Soko Bot in this workspace",
+          );
+        }
+
+        const isOwner = botPeek.userId === currentUserId;
+        if (!isOwner && !activeOrganizationId) {
+          throw badRequest(
+            "Switch to an organization to message a teammate's personal assistant.",
+          );
+        }
+
+        const roomOrganizationId = resolveOrchestratorDirectRoomOrganizationId({
+          isOwner,
+          activeOrganizationId,
+        });
+        const lookupOrganizationIds =
+          resolveOrchestratorDirectLookupOrganizationIds({
+            isOwner,
+            activeOrganizationId,
+          });
+
+        // Owner: validate against the bot's own workspace so a personal-
+        // workspace PA still opens when an org is selected. Colleague: org
+        // workspace only.
+        const workspaceId = isOwner
+          ? botPeek.workspaceId
+          : await resolveWorkspaceIdForChatRoom({
+              organizationId: activeOrganizationId,
+              personalUserId: currentUserId,
+              tx,
+            });
+
+        if (!isOwner && botPeek.workspaceId !== workspaceId) {
+          throw badRequest(
+            "Room personal assistants must be a live Soko Bot in this workspace",
+          );
+        }
+
         const orchestratorIds = await validateChatOrchestratorIds(
           requestedOrchestratorIds,
           {
             workspaceId,
-            ...(activeOrganizationId ? {} : { ownerUserId: currentUserId }),
+            ...(isOwner ? { ownerUserId: currentUserId } : {}),
           },
           tx,
         );
@@ -2585,46 +2668,41 @@ export async function createOrGetDirectRoom(params: {
           orchestratorIds,
         });
         directKeyRef.current = directKey;
-        createOrganizationIdRef.current = activeOrganizationId;
+        createOrganizationIdRef.current = roomOrganizationId;
 
-        const existing = await findOrRestoreDirectByKey(tx, {
-          organizationId: activeOrganizationId,
-          directKey,
-        });
-        if (existing) {
-          return { room: existing, created: false };
+        for (const organizationId of lookupOrganizationIds) {
+          const existing = await findOrRestoreDirectByKey(tx, {
+            organizationId,
+            directKey,
+          });
+          if (existing) {
+            return { room: existing, created: false };
+          }
         }
 
         // Prefer an existing shadow coworker DM for this PA until SOK-945
         // remaps memberships — avoids a second empty orchestrator room.
-        const bot = await tx.sokoBot.findFirst({
-          where: {
-            id: orchestratorIds[0],
-            workspaceId,
-            archivedAt: null,
-            deletedAt: null,
-          },
-          select: { coworker: { select: { id: true } } },
-        });
-        if (bot?.coworker) {
+        if (botPeek.coworker) {
           const legacyKey = buildDirectParticipantRoomKey({
             currentUserId,
             memberUserIds: [],
-            coworkerIds: [bot.coworker.id],
+            coworkerIds: [botPeek.coworker.id],
           });
-          const legacy = await findOrRestoreDirectByKey(tx, {
-            organizationId: activeOrganizationId,
-            directKey: legacyKey,
-          });
-          if (legacy) {
-            return { room: legacy, created: false };
+          for (const organizationId of lookupOrganizationIds) {
+            const legacy = await findOrRestoreDirectByKey(tx, {
+              organizationId,
+              directKey: legacyKey,
+            });
+            if (legacy) {
+              return { room: legacy, created: false };
+            }
           }
         }
 
         return createDirectRoomRecord({
           tx,
           currentUserId,
-          organizationId: activeOrganizationId,
+          organizationId: roomOrganizationId,
           directKey,
           memberUserIds: [],
           coworkerIds: [],

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -2073,7 +2073,7 @@ export async function validateChatCoworkerIds(
  */
 export async function validateChatOrchestratorIds(
   orchestratorIds: readonly string[],
-  opts: { workspaceId: string; ownerUserId: string },
+  opts: { workspaceId: string; ownerUserId?: string },
   tx: Prisma.TransactionClient,
 ): Promise<string[]> {
   const uniqueOrchestratorIds = normalizeUniqueStrings(orchestratorIds);
@@ -2085,7 +2085,7 @@ export async function validateChatOrchestratorIds(
     where: {
       id: { in: uniqueOrchestratorIds },
       workspaceId: opts.workspaceId,
-      userId: opts.ownerUserId,
+      ...(opts.ownerUserId ? { userId: opts.ownerUserId } : {}),
       archivedAt: null,
       deletedAt: null,
     },
@@ -2567,9 +2567,15 @@ export async function createOrGetDirectRoom(params: {
           personalUserId: currentUserId,
           tx,
         });
+        // Personal DMs stay owner-scoped. Org DMs allow any live workspace PA
+        // so a bot can approach colleagues (and colleagues can be messaged)
+        // without a shadow coworker row.
         const orchestratorIds = await validateChatOrchestratorIds(
           requestedOrchestratorIds,
-          { workspaceId, ownerUserId: currentUserId },
+          {
+            workspaceId,
+            ...(activeOrganizationId ? {} : { ownerUserId: currentUserId }),
+          },
           tx,
         );
         const directKey = buildDirectParticipantRoomKey({
@@ -2587,6 +2593,32 @@ export async function createOrGetDirectRoom(params: {
         });
         if (existing) {
           return { room: existing, created: false };
+        }
+
+        // Prefer an existing shadow coworker DM for this PA until SOK-945
+        // remaps memberships — avoids a second empty orchestrator room.
+        const bot = await tx.sokoBot.findFirst({
+          where: {
+            id: orchestratorIds[0],
+            workspaceId,
+            archivedAt: null,
+            deletedAt: null,
+          },
+          select: { coworker: { select: { id: true } } },
+        });
+        if (bot?.coworker) {
+          const legacyKey = buildDirectParticipantRoomKey({
+            currentUserId,
+            memberUserIds: [],
+            coworkerIds: [bot.coworker.id],
+          });
+          const legacy = await findOrRestoreDirectByKey(tx, {
+            organizationId: activeOrganizationId,
+            directKey: legacyKey,
+          });
+          if (legacy) {
+            return { room: legacy, created: false };
+          }
         }
 
         return createDirectRoomRecord({

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -1435,13 +1435,22 @@ export function buildDirectCoworkerRoomKey(
   return `coworker:${userId}:${coworkerId}`;
 }
 
+export function buildDirectOrchestratorRoomKey(
+  userId: string,
+  orchestratorId: string,
+): string {
+  return `orchestrator:${userId}:${orchestratorId}`;
+}
+
 export function buildDirectParticipantRoomKey(params: {
   currentUserId: string;
   memberUserIds: readonly string[];
   coworkerIds: readonly string[];
+  orchestratorIds?: readonly string[];
 }): string {
   const memberUserIds = normalizeUniqueStrings(params.memberUserIds);
   const coworkerIds = normalizeUniqueStrings(params.coworkerIds);
+  const orchestratorIds = normalizeUniqueStrings(params.orchestratorIds ?? []);
 
   if (memberUserIds.length === 1 && coworkerIds.length === 0) {
     return buildDirectRoomKey(params.currentUserId, memberUserIds[0]);
@@ -1451,11 +1460,21 @@ export function buildDirectParticipantRoomKey(params: {
     return buildDirectCoworkerRoomKey(params.currentUserId, coworkerIds[0]);
   }
 
+  if (memberUserIds.length === 0 && orchestratorIds.length === 1) {
+    return buildDirectOrchestratorRoomKey(
+      params.currentUserId,
+      orchestratorIds[0],
+    );
+  }
+
   const participantKeys = [
     ...normalizeUniqueStrings([params.currentUserId, ...memberUserIds]).map(
       (userId) => `user:${userId}`,
     ),
     ...coworkerIds.map((coworkerId) => `coworker:${coworkerId}`),
+    ...orchestratorIds.map(
+      (orchestratorId) => `orchestrator:${orchestratorId}`,
+    ),
   ].sort();
 
   return `direct:v2:${participantKeys.join(":")}`;
@@ -2345,31 +2364,55 @@ function parseDirectCreateShape(params: {
   currentUserId: string;
   memberUserIds: readonly string[];
   coworkerIds: readonly string[];
+  orchestratorIds: readonly string[];
 }): DirectCreateShape {
   const memberUserIds = normalizeUniqueStrings(params.memberUserIds);
   const coworkerIds = normalizeUniqueStrings(params.coworkerIds);
+  const orchestratorIds = normalizeUniqueStrings(params.orchestratorIds);
 
   if (memberUserIds.includes(params.currentUserId)) {
     throw badRequest("Choose another organization member");
   }
 
-  if (memberUserIds.length === 0 && coworkerIds.length === 0) {
+  if (
+    memberUserIds.length === 0 &&
+    coworkerIds.length === 0 &&
+    orchestratorIds.length === 0
+  ) {
     throw badRequest("Choose a direct message target");
   }
 
-  if (memberUserIds.length > 0 && coworkerIds.length > 0) {
-    throw badRequest("Group direct messages cannot include coworkers.");
+  if (
+    memberUserIds.length > 0 &&
+    (coworkerIds.length > 0 || orchestratorIds.length > 0)
+  ) {
+    throw badRequest(
+      "Group direct messages cannot include coworkers or personal assistants.",
+    );
+  }
+
+  if (coworkerIds.length > 0 && orchestratorIds.length > 0) {
+    throw badRequest("Choose one AI participant type.");
   }
 
   if (coworkerIds.length > 1) {
     throw badRequest("Direct messages support one coworker only.");
   }
 
-  if (memberUserIds.length >= 1 && coworkerIds.length === 0) {
+  if (orchestratorIds.length > 1) {
+    throw badRequest("Direct messages support one personal assistant only.");
+  }
+
+  if (
+    memberUserIds.length >= 1 &&
+    coworkerIds.length === 0 &&
+    orchestratorIds.length === 0
+  ) {
     return {
       kind: "human-direct",
       memberUserIds,
       coworkerIds: [],
+      orchestratorIds: [],
     };
   }
 
@@ -2378,6 +2421,16 @@ function parseDirectCreateShape(params: {
       kind: "coworker-1to1",
       memberUserIds: [],
       coworkerIds: [coworkerIds[0]],
+      orchestratorIds: [],
+    };
+  }
+
+  if (memberUserIds.length === 0 && orchestratorIds.length === 1) {
+    return {
+      kind: "orchestrator-1to1",
+      memberUserIds: [],
+      coworkerIds: [],
+      orchestratorIds: [orchestratorIds[0]],
     };
   }
 
@@ -2403,11 +2456,19 @@ type DirectCreateShape =
       kind: "human-direct";
       memberUserIds: string[];
       coworkerIds: [];
+      orchestratorIds: [];
     }
   | {
       kind: "coworker-1to1";
       memberUserIds: [];
       coworkerIds: [string];
+      orchestratorIds: [];
+    }
+  | {
+      kind: "orchestrator-1to1";
+      memberUserIds: [];
+      coworkerIds: [];
+      orchestratorIds: [string];
     };
 
 export async function createOrGetDirectRoom(params: {
@@ -2415,6 +2476,7 @@ export async function createOrGetDirectRoom(params: {
   currentUserId: string;
   memberUserIds: readonly string[];
   coworkerIds: readonly string[];
+  orchestratorIds?: readonly string[];
   /** Sidebar viewer. Null skips pin/mute/unread (coworker actor has none). */
   viewerUserId?: string | null;
 }): Promise<{ room: ChatRoom; created: boolean }> {
@@ -2425,9 +2487,11 @@ export async function createOrGetDirectRoom(params: {
     currentUserId,
     memberUserIds: params.memberUserIds,
     coworkerIds: params.coworkerIds,
+    orchestratorIds: params.orchestratorIds ?? [],
   });
   const requestedMemberUserIds = shape.memberUserIds;
   const requestedCoworkerIds = shape.coworkerIds;
+  const requestedOrchestratorIds = shape.orchestratorIds;
   const activeOrganizationId = params.organizationId;
 
   // Holds the key computed inside the transaction so a directKey race
@@ -2493,6 +2557,46 @@ export async function createOrGetDirectRoom(params: {
           directKey,
           memberUserIds: [],
           coworkerIds,
+          orchestratorIds: [],
+        });
+      }
+
+      if (shape.kind === "orchestrator-1to1") {
+        const workspaceId = await resolveWorkspaceIdForChatRoom({
+          organizationId: activeOrganizationId,
+          personalUserId: currentUserId,
+          tx,
+        });
+        const orchestratorIds = await validateChatOrchestratorIds(
+          requestedOrchestratorIds,
+          { workspaceId, ownerUserId: currentUserId },
+          tx,
+        );
+        const directKey = buildDirectParticipantRoomKey({
+          currentUserId,
+          memberUserIds: [],
+          coworkerIds: [],
+          orchestratorIds,
+        });
+        directKeyRef.current = directKey;
+        createOrganizationIdRef.current = activeOrganizationId;
+
+        const existing = await findOrRestoreDirectByKey(tx, {
+          organizationId: activeOrganizationId,
+          directKey,
+        });
+        if (existing) {
+          return { room: existing, created: false };
+        }
+
+        return createDirectRoomRecord({
+          tx,
+          currentUserId,
+          organizationId: activeOrganizationId,
+          directKey,
+          memberUserIds: [],
+          coworkerIds: [],
+          orchestratorIds,
         });
       }
 
@@ -2561,6 +2665,7 @@ export async function createOrGetDirectRoom(params: {
         directKey,
         memberUserIds,
         coworkerIds: [],
+        orchestratorIds: [],
       });
     });
 
@@ -2576,7 +2681,7 @@ export async function createOrGetDirectRoom(params: {
     // directKey race: another request won the create — return that room.
     if (isDirectKeyUniqueConstraintError(error) && directKeyRef.current) {
       const existing =
-        shape.kind === "coworker-1to1"
+        shape.kind === "coworker-1to1" || shape.kind === "orchestrator-1to1"
           ? await findOrRestoreDirectByKey(prisma, {
               organizationId: createOrganizationIdRef.current,
               directKey: directKeyRef.current,
@@ -2611,6 +2716,7 @@ async function createDirectRoomRecord(params: {
   directKey: string;
   memberUserIds: readonly string[];
   coworkerIds: readonly string[];
+  orchestratorIds: readonly string[];
 }) {
   const {
     tx,
@@ -2619,25 +2725,37 @@ async function createDirectRoomRecord(params: {
     directKey,
     memberUserIds,
     coworkerIds,
+    orchestratorIds,
   } = params;
 
-  const [targetUsers, targetCoworkers] = await Promise.all([
-    memberUserIds.length > 0
-      ? tx.user.findMany({
-          where: { id: { in: [...memberUserIds] } },
-          select: { id: true, name: true, email: true },
-        })
-      : Promise.resolve([]),
-    coworkerIds.length > 0
-      ? tx.coworker.findMany({
-          where: { id: { in: [...coworkerIds] } },
-          select: { id: true, name: true },
-        })
-      : Promise.resolve([]),
-  ]);
+  const [targetUsers, targetCoworkers, targetOrchestrators] = await Promise.all(
+    [
+      memberUserIds.length > 0
+        ? tx.user.findMany({
+            where: { id: { in: [...memberUserIds] } },
+            select: { id: true, name: true, email: true },
+          })
+        : Promise.resolve([]),
+      coworkerIds.length > 0
+        ? tx.coworker.findMany({
+            where: { id: { in: [...coworkerIds] } },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([]),
+      orchestratorIds.length > 0
+        ? tx.sokoBot.findMany({
+            where: { id: { in: [...orchestratorIds] } },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([]),
+    ],
+  );
   const usersById = new Map(targetUsers.map((user) => [user.id, user]));
   const coworkersById = new Map(
     targetCoworkers.map((coworker) => [coworker.id, coworker]),
+  );
+  const orchestratorsById = new Map(
+    targetOrchestrators.map((bot) => [bot.id, bot]),
   );
   const directName = buildDirectRoomName([
     ...memberUserIds.map((userId) => {
@@ -2646,6 +2764,9 @@ async function createDirectRoomRecord(params: {
     }),
     ...coworkerIds.map((coworkerId) => {
       return coworkersById.get(coworkerId)?.name || coworkerId;
+    }),
+    ...orchestratorIds.map((orchestratorId) => {
+      return orchestratorsById.get(orchestratorId)?.name?.trim() || "Soko Bot";
     }),
   ]);
   const room = await tx.chatRoom.create({
@@ -2670,6 +2791,9 @@ async function createDirectRoomRecord(params: {
       },
       coworkerMembers: {
         create: coworkerIds.map((coworkerId) => ({ coworkerId })),
+      },
+      orchestratorMembers: {
+        create: orchestratorIds.map((orchestratorId) => ({ orchestratorId })),
       },
     },
     include: chatRoomInclude,

--- a/apps/core/src/routes/v1/chats/rooms/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.test.ts
@@ -1363,7 +1363,7 @@ describe("POST /chats/rooms", () => {
 
     expect(response.status).toBe(400);
     expect(await response.text()).toBe(
-      "Group direct messages cannot include coworkers.",
+      "Group direct messages cannot include coworkers or personal assistants.",
     );
     expect(roomCreateMock).not.toHaveBeenCalled();
   });

--- a/apps/core/src/routes/v1/chats/rooms/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.ts
@@ -96,11 +96,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireUserAuthContext(authContext);
 
     if (body.kind === "direct") {
-      if ((body.orchestratorIds ?? []).length > 0) {
-        throw badRequest(
-          "Add personal assistants to a channel or via room settings",
-        );
-      }
       const direct = await createOrGetDirectRoom({
         // Both kinds respect activeOrganization when present.
         // Coworker 1:1 may be personal (null) with no active org.
@@ -110,6 +105,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         currentUserId: userContext.userId,
         memberUserIds: body.memberUserIds ?? [],
         coworkerIds: body.coworkerIds ?? [],
+        orchestratorIds: body.orchestratorIds ?? [],
       });
 
       return direct.created ? created(c, direct.room) : ok(c, direct.room);

--- a/apps/core/src/routes/v1/soko-bots/index.ts
+++ b/apps/core/src/routes/v1/soko-bots/index.ts
@@ -85,7 +85,6 @@ import {
 } from "@/services/soko-bot-avatar.service";
 import { SokoBotBillingAccessError } from "@/services/soko-bot-billing.service";
 import {
-  ensureSokoBotCoworker,
   introduceSokoBot,
   SokoBotIntroductionError,
 } from "@/services/soko-bot-chat.service";
@@ -182,7 +181,6 @@ function mapBot(
   return {
     ...bot,
     memory: bot.memoryRevisions[0] ?? null,
-    coworker: bot.coworker ?? null,
     memoryRevisions: undefined,
   };
 }
@@ -979,7 +977,6 @@ app.openapi(claimAvatarRoute, async (c) => {
   );
   if (!bot) throw notFound("Create a Soko Bot first");
   await claimAvatar(bot.id, c.req.valid("json").avatarId);
-  await ensureSokoBotCoworker(bot.id);
   const refreshed = await sokoBotControlPlane.getForUser(
     auth.userId,
     workspace.workspaceId,
@@ -1309,7 +1306,6 @@ const BOT_TEAM_SELECT = {
   avatarSeed: true,
   status: true,
   archivedAt: true,
-  coworker: { select: { id: true } },
 } as const;
 
 const teamRoute = createRoute({
@@ -1347,7 +1343,6 @@ app.openapi(teamRoute, async (c) => {
     avatarSeed: string | null;
     status: string;
     archivedAt: Date | null;
-    coworker: { id: string } | null;
   }) =>
     bot.archivedAt
       ? null
@@ -1357,7 +1352,6 @@ app.openapi(teamRoute, async (c) => {
           avatarImageUrl: bot.avatarImageUrl,
           avatarSeed: bot.avatarSeed,
           status: bot.status,
-          coworkerId: bot.coworker?.id ?? null,
         };
   if (workspace.organizationId) {
     const organization = await prisma.organization.findUnique({

--- a/apps/core/src/schemas/chat-room.schema.ts
+++ b/apps/core/src/schemas/chat-room.schema.ts
@@ -325,7 +325,7 @@ export const createChatRoomRequestSchema = z
       .object({
         kind: z.literal("direct").openapi({
           description:
-            "Creates or returns a direct room: one or more humans (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Human 1:1 is an Org Direct when both are Members of the active organization; otherwise a Personal Direct when they share an External channel. Multi-human groups and coworker DMs with an active org are org-scoped. Coworker DMs may be personal with no active org. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.",
+            "Creates or returns a direct room: one or more humans (1:1 or multi-human group), exactly one coworker, or exactly one personal assistant (orchestrator). Human, coworker, and orchestrator targets cannot be mixed. Human 1:1 is an Org Direct when both are Members of the active organization; otherwise a Personal Direct when they share an External channel. Multi-human groups and coworker DMs with an active org are org-scoped. Coworker and orchestrator DMs may be personal with no active org. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.",
         }),
         memberUserIds: roomMemberUserIdsSchema,
         coworkerIds: roomCoworkerIdsSchema,

--- a/apps/core/src/schemas/soko-bot.schema.ts
+++ b/apps/core/src/schemas/soko-bot.schema.ts
@@ -299,11 +299,6 @@ export const sokoBotSchema = z
     ingestTimezone: z.string().optional(),
     proactivePaused: z.boolean().optional(),
     proactiveDailyLimit: z.number().int().optional(),
-    /** Chat-facing coworker row; open a direct with it to chat with the bot. */
-    coworker: z
-      .object({ id: z.string(), slug: z.string() })
-      .nullable()
-      .optional(),
     createdAt: dateTimeSchema,
     updatedAt: dateTimeSchema,
   })
@@ -847,7 +842,6 @@ export const sokoBotTeamSchema = z
             avatarImageUrl: z.string().nullable(),
             avatarSeed: z.string().nullable(),
             status: sokoBotStatusSchema,
-            coworkerId: z.string().nullable(),
           })
           .nullable(),
       }),

--- a/apps/core/src/services/soko-bot-chat.service.test.ts
+++ b/apps/core/src/services/soko-bot-chat.service.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { selectSokoBotDirectDeliveryRoom } from "./soko-bot-chat.service";
+
+describe("selectSokoBotDirectDeliveryRoom", () => {
+  const older = new Date("2026-01-01T00:00:00.000Z");
+  const newer = new Date("2026-02-01T00:00:00.000Z");
+
+  it("prefers a personal legacy room with history over an empty org orchestrator room", () => {
+    const selected = selectSokoBotDirectDeliveryRoom([
+      {
+        id: "orch_org_empty",
+        organizationId: "org_1",
+        updatedAt: newer,
+        messageCount: 0,
+        isOrchestrator: true,
+      },
+      {
+        id: "legacy_personal",
+        organizationId: null,
+        updatedAt: older,
+        messageCount: 12,
+        isOrchestrator: false,
+      },
+    ]);
+    expect(selected?.id).toBe("legacy_personal");
+  });
+
+  it("prefers personal orchestrator over personal legacy when both have history", () => {
+    const selected = selectSokoBotDirectDeliveryRoom([
+      {
+        id: "legacy_personal",
+        organizationId: null,
+        updatedAt: newer,
+        messageCount: 3,
+        isOrchestrator: false,
+      },
+      {
+        id: "orch_personal",
+        organizationId: null,
+        updatedAt: older,
+        messageCount: 3,
+        isOrchestrator: true,
+      },
+    ]);
+    expect(selected?.id).toBe("orch_personal");
+  });
+
+  it("returns null for an empty candidate list", () => {
+    expect(selectSokoBotDirectDeliveryRoom([])).toBeNull();
+  });
+});

--- a/apps/core/src/services/soko-bot-chat.service.ts
+++ b/apps/core/src/services/soko-bot-chat.service.ts
@@ -282,29 +282,32 @@ export async function deliverSokoBotTurnToDirectRoom(
   const answer = turn.finalAnswer?.trim() ?? "";
   if (isSokoBotSilentAnswer(answer)) return;
   const legacyCoworkerId = turn.sokoBot.coworker?.id ?? null;
-  const room = await prisma.chatRoom.findFirst({
+  // Prefer the orchestrator DM when both exist so proactive delivery does not
+  // land nondeterministically in a stale shadow coworker room.
+  const orchestratorRoom = await prisma.chatRoom.findFirst({
     where: {
       kind: "direct",
       archivedAt: null,
       userMembers: { some: { userId: turn.userId } },
-      OR: [
-        { orchestratorMembers: { some: { orchestratorId: turn.sokoBotId } } },
-        ...(legacyCoworkerId
-          ? [{ coworkerMembers: { some: { coworkerId: legacyCoworkerId } } }]
-          : []),
-      ],
+      orchestratorMembers: { some: { orchestratorId: turn.sokoBotId } },
     },
-    select: {
-      id: true,
-      orchestratorMembers: {
-        where: { orchestratorId: turn.sokoBotId },
-        select: { orchestratorId: true },
-        take: 1,
-      },
-    },
+    select: { id: true },
   });
+  const legacyRoom =
+    orchestratorRoom || !legacyCoworkerId
+      ? null
+      : await prisma.chatRoom.findFirst({
+          where: {
+            kind: "direct",
+            archivedAt: null,
+            userMembers: { some: { userId: turn.userId } },
+            coworkerMembers: { some: { coworkerId: legacyCoworkerId } },
+          },
+          select: { id: true },
+        });
+  const room = orchestratorRoom ?? legacyRoom;
   if (!room) return;
-  const usesOrchestrator = room.orchestratorMembers.length > 0;
+  const usesOrchestrator = orchestratorRoom != null;
   const message = await prisma.$transaction(async (tx) => {
     const created = await tx.chatRoomMessage.create({
       data: {

--- a/apps/core/src/services/soko-bot-chat.service.ts
+++ b/apps/core/src/services/soko-bot-chat.service.ts
@@ -1,22 +1,18 @@
-import type { Prisma } from "@sokosumi/database";
 import {
   composeSokoBotIntroduction,
   isSokoBotSilentAnswer,
 } from "@sokosumi/soko-bot";
-import { personalAssistantCaption } from "@sokosumi/utils";
 
 import prisma from "@/lib/db/prisma";
 
 /**
- * Soko Bot in chat. The bot is represented by a first-party `Coworker` row
- * (`Coworker.sokoBotId`) so it rides every existing chat rail: room
- * membership, mentions, the sender FK, realtime, and the live-Thought
- * placeholder. Only dispatch differs: a mention starts a Soko Bot turn and
- * the turn's outcome is written back here.
+ * Soko Bot in chat. The bot is a first-class orchestrator participant
+ * (`ChatRoomOrchestratorMember` / `senderOrchestratorId`). Legacy bots may
+ * still have a shadow `Coworker` row; read paths fall back there until
+ * SOK-945 remaps them. Only dispatch differs: a mention starts a Soko Bot
+ * turn and the turn's outcome is written back here.
  */
 
-const SOKOSUMI_VENDOR_SLUG = "sokosumi";
-const SOKO_BOT_DEFAULT_NAME = "Soko Bot";
 const PROGRESS_PUBLISH_MIN_INTERVAL_MS = 250;
 
 /** Human labels for capability calls shown as live "thought" beats. */
@@ -40,59 +36,6 @@ const CAPABILITY_LABELS: Record<string, string> = {
 export function sokoBotCapabilityLabel(toolName: string | null): string {
   if (!toolName) return "Working";
   return CAPABILITY_LABELS[toolName] ?? toolName.replaceAll("_", " ");
-}
-
-export function sokoBotCoworkerSlug(sokoBotId: string): string {
-  return `soko-bot-${sokoBotId.replaceAll("-", "").slice(0, 12)}`;
-}
-
-/**
- * Create or refresh the chat-facing coworker row for a bot. Idempotent; call
- * on bot create, rename, reactivation, and archive.
- */
-export async function ensureSokoBotCoworker(
-  sokoBotId: string,
-  tx: Prisma.TransactionClient = prisma,
-): Promise<{ id: string; slug: string }> {
-  const bot = await tx.sokoBot.findUniqueOrThrow({
-    where: { id: sokoBotId },
-    select: {
-      id: true,
-      name: true,
-      archivedAt: true,
-      avatarImageUrl: true,
-      user: { select: { name: true } },
-    },
-  });
-  const vendor = await tx.vendor.upsert({
-    where: { slug: SOKOSUMI_VENDOR_SLUG },
-    create: { slug: SOKOSUMI_VENDOR_SLUG, name: "Sokosumi" },
-    update: {},
-    select: { id: true },
-  });
-  const data = {
-    name: bot.name?.trim() || SOKO_BOT_DEFAULT_NAME,
-    // Teammates can talk to it, so the roster says whose assistant it is.
-    caption: personalAssistantCaption(bot.user.name),
-    image: bot.avatarImageUrl,
-    description:
-      "Your personal project manager: delegates Tasks to Coworkers and hires Agents.",
-    baseURL: `soko-bot://${bot.id}`,
-    capabilities: ["chat", "tasks"],
-    isWhitelisted: false,
-    archivedAt: bot.archivedAt,
-  };
-  return tx.coworker.upsert({
-    where: { sokoBotId: bot.id },
-    create: {
-      ...data,
-      slug: sokoBotCoworkerSlug(bot.id),
-      sokoBotId: bot.id,
-      vendorId: vendor.id,
-    },
-    update: data,
-    select: { id: true, slug: true },
-  });
 }
 
 interface ChatLinkedTurn {
@@ -249,25 +192,41 @@ export async function introduceSokoBot(input: {
       archivedAt: null,
     },
     select: {
+      id: true,
       name: true,
       user: { select: { name: true } },
       coworker: { select: { id: true } },
     },
   });
-  if (!bot?.coworker) throw new SokoBotIntroductionError("Soko Bot not found");
-  const coworkerId = bot.coworker.id;
+  if (!bot) throw new SokoBotIntroductionError("Soko Bot not found");
   const room = await prisma.chatRoom.findFirst({
     where: {
       id: input.roomId,
       kind: "direct",
-      coworkerMembers: { some: { coworkerId } },
       userMembers: { some: { userId: input.userId } },
+      OR: [
+        { orchestratorMembers: { some: { orchestratorId: bot.id } } },
+        ...(bot.coworker
+          ? [{ coworkerMembers: { some: { coworkerId: bot.coworker.id } } }]
+          : []),
+      ],
     },
     select: { id: true },
   });
   if (!room) throw new SokoBotIntroductionError("Direct room not found");
+  const usesOrchestrator = await prisma.chatRoomOrchestratorMember.findFirst({
+    where: { roomId: room.id, orchestratorId: bot.id },
+    select: { id: true },
+  });
+  const legacyCoworkerId = bot.coworker?.id ?? null;
   const existing = await prisma.chatRoomMessage.findFirst({
-    where: { roomId: room.id, senderCoworkerId: coworkerId },
+    where: {
+      roomId: room.id,
+      OR: [
+        ...(usesOrchestrator ? [{ senderOrchestratorId: bot.id }] : []),
+        ...(legacyCoworkerId ? [{ senderCoworkerId: legacyCoworkerId }] : []),
+      ],
+    },
     select: { id: true },
   });
   if (existing) return { messageId: existing.id };
@@ -275,7 +234,9 @@ export async function introduceSokoBot(input: {
     const created = await tx.chatRoomMessage.create({
       data: {
         roomId: room.id,
-        senderCoworkerId: coworkerId,
+        ...(usesOrchestrator
+          ? { senderOrchestratorId: bot.id, senderCoworkerId: null }
+          : { senderCoworkerId: legacyCoworkerId }),
         content: composeSokoBotIntroduction({
           name: bot.name,
           ownerName: bot.user.name,
@@ -311,6 +272,7 @@ export async function deliverSokoBotTurnToDirectRoom(
       status: true,
       finalAnswer: true,
       userId: true,
+      sokoBotId: true,
       chatMention: { select: { id: true } },
       sokoBot: { select: { coworker: { select: { id: true } } } },
     },
@@ -319,23 +281,37 @@ export async function deliverSokoBotTurnToDirectRoom(
   if (turn.status !== "COMPLETED") return;
   const answer = turn.finalAnswer?.trim() ?? "";
   if (isSokoBotSilentAnswer(answer)) return;
-  const coworkerId = turn.sokoBot.coworker?.id;
-  if (!coworkerId) return;
+  const legacyCoworkerId = turn.sokoBot.coworker?.id ?? null;
   const room = await prisma.chatRoom.findFirst({
     where: {
       kind: "direct",
       archivedAt: null,
-      coworkerMembers: { some: { coworkerId } },
       userMembers: { some: { userId: turn.userId } },
+      OR: [
+        { orchestratorMembers: { some: { orchestratorId: turn.sokoBotId } } },
+        ...(legacyCoworkerId
+          ? [{ coworkerMembers: { some: { coworkerId: legacyCoworkerId } } }]
+          : []),
+      ],
     },
-    select: { id: true },
+    select: {
+      id: true,
+      orchestratorMembers: {
+        where: { orchestratorId: turn.sokoBotId },
+        select: { orchestratorId: true },
+        take: 1,
+      },
+    },
   });
   if (!room) return;
+  const usesOrchestrator = room.orchestratorMembers.length > 0;
   const message = await prisma.$transaction(async (tx) => {
     const created = await tx.chatRoomMessage.create({
       data: {
         roomId: room.id,
-        senderCoworkerId: coworkerId,
+        ...(usesOrchestrator
+          ? { senderOrchestratorId: turn.sokoBotId, senderCoworkerId: null }
+          : { senderCoworkerId: legacyCoworkerId }),
         content: answer,
         metadata: { soko_bot: { turn_id: turnId, source: turn.source } },
       },

--- a/apps/core/src/services/soko-bot-chat.service.ts
+++ b/apps/core/src/services/soko-bot-chat.service.ts
@@ -38,6 +38,47 @@ export function sokoBotCapabilityLabel(toolName: string | null): string {
   return CAPABILITY_LABELS[toolName] ?? toolName.replaceAll("_", " ");
 }
 
+export interface SokoBotDirectDeliveryRoomCandidate {
+  id: string;
+  organizationId: string | null;
+  updatedAt: Date;
+  messageCount: number;
+  isOrchestrator: boolean;
+}
+
+/**
+ * Prefer a room that already has history, then personal (null org), then
+ * orchestrator over legacy shadow coworker, then most recently updated.
+ * Prevents empty org orchestrator rooms from stealing delivery from a
+ * personal legacy DM with history.
+ */
+export function selectSokoBotDirectDeliveryRoom(
+  candidates: readonly SokoBotDirectDeliveryRoomCandidate[],
+): SokoBotDirectDeliveryRoomCandidate | null {
+  if (candidates.length === 0) {
+    return null;
+  }
+  return [...candidates].sort((left, right) => {
+    const byHistory =
+      Number(right.messageCount > 0) - Number(left.messageCount > 0);
+    if (byHistory !== 0) {
+      return byHistory;
+    }
+    const byPersonal =
+      Number(left.organizationId === null) -
+      Number(right.organizationId === null);
+    if (byPersonal !== 0) {
+      return byPersonal;
+    }
+    const byOrchestrator =
+      Number(right.isOrchestrator) - Number(left.isOrchestrator);
+    if (byOrchestrator !== 0) {
+      return byOrchestrator;
+    }
+    return right.updatedAt.getTime() - left.updatedAt.getTime();
+  })[0]!;
+}
+
 interface ChatLinkedTurn {
   id: string;
   status: string;
@@ -282,32 +323,42 @@ export async function deliverSokoBotTurnToDirectRoom(
   const answer = turn.finalAnswer?.trim() ?? "";
   if (isSokoBotSilentAnswer(answer)) return;
   const legacyCoworkerId = turn.sokoBot.coworker?.id ?? null;
-  // Prefer the orchestrator DM when both exist so proactive delivery does not
-  // land nondeterministically in a stale shadow coworker room.
-  const orchestratorRoom = await prisma.chatRoom.findFirst({
+  const candidateRooms = await prisma.chatRoom.findMany({
     where: {
       kind: "direct",
       archivedAt: null,
       userMembers: { some: { userId: turn.userId } },
-      orchestratorMembers: { some: { orchestratorId: turn.sokoBotId } },
+      OR: [
+        { orchestratorMembers: { some: { orchestratorId: turn.sokoBotId } } },
+        ...(legacyCoworkerId
+          ? [{ coworkerMembers: { some: { coworkerId: legacyCoworkerId } } }]
+          : []),
+      ],
     },
-    select: { id: true },
+    select: {
+      id: true,
+      organizationId: true,
+      updatedAt: true,
+      orchestratorMembers: {
+        where: { orchestratorId: turn.sokoBotId },
+        select: { orchestratorId: true },
+        take: 1,
+      },
+      _count: { select: { messages: true } },
+    },
   });
-  const legacyRoom =
-    orchestratorRoom || !legacyCoworkerId
-      ? null
-      : await prisma.chatRoom.findFirst({
-          where: {
-            kind: "direct",
-            archivedAt: null,
-            userMembers: { some: { userId: turn.userId } },
-            coworkerMembers: { some: { coworkerId: legacyCoworkerId } },
-          },
-          select: { id: true },
-        });
-  const room = orchestratorRoom ?? legacyRoom;
-  if (!room) return;
-  const usesOrchestrator = orchestratorRoom != null;
+  const selected = selectSokoBotDirectDeliveryRoom(
+    candidateRooms.map((candidate) => ({
+      id: candidate.id,
+      organizationId: candidate.organizationId,
+      updatedAt: candidate.updatedAt,
+      messageCount: candidate._count.messages,
+      isOrchestrator: candidate.orchestratorMembers.length > 0,
+    })),
+  );
+  if (!selected) return;
+  const room = { id: selected.id };
+  const usesOrchestrator = selected.isOrchestrator;
   const message = await prisma.$transaction(async (tx) => {
     const created = await tx.chatRoomMessage.create({
       data: {

--- a/apps/core/src/services/soko-bot-control-plane.service.test.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.test.ts
@@ -105,7 +105,6 @@ const {
 }));
 
 vi.mock("@/services/soko-bot-chat.service", () => ({
-  ensureSokoBotCoworker: vi.fn().mockResolvedValue({ id: "cw", slug: "soko" }),
   finalizeSokoBotChatTurn: vi.fn().mockResolvedValue(undefined),
   deliverSokoBotTurnToDirectRoom: vi.fn().mockResolvedValue(undefined),
   publishSokoBotChatProgress: vi.fn().mockResolvedValue(undefined),
@@ -355,6 +354,21 @@ describe("SokoBotControlPlane lifecycle", () => {
     );
     expect(botCreateMock).toHaveBeenCalled();
     expect(botUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("getForUser does not heal a shadow coworker row", async () => {
+    botFindFirstMock.mockResolvedValue({
+      id: BOT_ID,
+      memoryRevisions: [],
+      legacyMessages: [],
+      pendingDecisions: [],
+      schedules: [],
+    });
+
+    const bot = await new SokoBotControlPlane().getForUser("user_1", "ws_1");
+
+    expect(bot?.id).toBe(BOT_ID);
+    expect(bot).not.toHaveProperty("coworker");
   });
 
   it("preserves an administrator pause during profile updates", async () => {

--- a/apps/core/src/services/soko-bot-control-plane.service.test.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.test.ts
@@ -28,6 +28,7 @@ const {
   coworkerCreateMock,
   coworkerUpsertMock,
   coworkerUpdateManyMock,
+  userFindUniqueMock,
   getEnvMock,
   jobFindManyMock,
   memoryCreateMock,
@@ -76,6 +77,7 @@ const {
   coworkerCreateMock: vi.fn(),
   coworkerUpsertMock: vi.fn(),
   coworkerUpdateManyMock: vi.fn(),
+  userFindUniqueMock: vi.fn(),
   getEnvMock: vi.fn<
     () => {
       SOKO_BOT_CLASSIFIER_MODE: string;
@@ -246,6 +248,9 @@ function transactionClient() {
       upsert: coworkerUpsertMock,
       updateMany: coworkerUpdateManyMock,
     },
+    user: {
+      findUnique: userFindUniqueMock,
+    },
     sokoBotAdminAction: {
       create: adminActionCreateMock,
       findMany: adminActionFindManyMock,
@@ -329,6 +334,7 @@ describe("SokoBotControlPlane lifecycle", () => {
     botUpdateManyMock.mockResolvedValue({ count: 1 });
     agentFindManyMock.mockResolvedValue([]);
     coworkerFindManyMock.mockResolvedValue([]);
+    userFindUniqueMock.mockResolvedValue({ name: "Owner User" });
     jobFindManyMock.mockResolvedValue([]);
     projectFindManyMock.mockResolvedValue([]);
     taskFindManyMock.mockResolvedValue([]);
@@ -416,6 +422,9 @@ describe("SokoBotControlPlane lifecycle", () => {
           upsert: coworkerUpsertMock,
           updateMany: coworkerUpdateManyMock,
         },
+        user: {
+          findUnique: userFindUniqueMock,
+        },
       }),
     );
 
@@ -428,6 +437,37 @@ describe("SokoBotControlPlane lifecycle", () => {
     expect(botCreateMock).toHaveBeenCalled();
     expect(coworkerCreateMock).not.toHaveBeenCalled();
     expect(coworkerUpsertMock).not.toHaveBeenCalled();
+  });
+
+  it("syncs an existing shadow coworker profile on rename without creating", async () => {
+    botFindFirstMock.mockResolvedValue({
+      id: BOT_ID,
+      archivedAt: null,
+      adminPausedAt: null,
+      status: "IDLE",
+      memoryVersion: 1,
+    });
+    botUpdateMock.mockResolvedValue({ id: BOT_ID, name: "Renamed" });
+    userFindUniqueMock.mockResolvedValue({ name: "Owner User" });
+    coworkerUpdateManyMock.mockResolvedValue({ count: 1 });
+
+    await new SokoBotControlPlane().create({
+      userId: "user_1",
+      workspaceId: "ws_1",
+      name: "Renamed",
+    });
+
+    expect(coworkerCreateMock).not.toHaveBeenCalled();
+    expect(coworkerUpsertMock).not.toHaveBeenCalled();
+    expect(coworkerUpdateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { sokoBotId: BOT_ID },
+        data: expect.objectContaining({
+          name: "Renamed",
+          caption: expect.any(String),
+        }),
+      }),
+    );
   });
 
   it("preserves an administrator pause during profile updates", async () => {

--- a/apps/core/src/services/soko-bot-control-plane.service.test.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.test.ts
@@ -25,6 +25,9 @@ const {
   authoredVersionFindFirstMock,
   contextSnapshotFindUniqueMock,
   coworkerFindManyMock,
+  coworkerCreateMock,
+  coworkerUpsertMock,
+  coworkerUpdateManyMock,
   getEnvMock,
   jobFindManyMock,
   memoryCreateMock,
@@ -70,6 +73,9 @@ const {
   authoredVersionFindFirstMock: vi.fn(),
   contextSnapshotFindUniqueMock: vi.fn(),
   coworkerFindManyMock: vi.fn(),
+  coworkerCreateMock: vi.fn(),
+  coworkerUpsertMock: vi.fn(),
+  coworkerUpdateManyMock: vi.fn(),
   getEnvMock: vi.fn<
     () => {
       SOKO_BOT_CLASSIFIER_MODE: string;
@@ -121,11 +127,17 @@ vi.mock("@/lib/db/prisma", () => ({
     // Creation resolves the promoted default version before its transaction.
     sokoBotSetting: { findUnique: settingFindUniqueMock },
     sokoBotAuthoredVersion: { findFirst: authoredVersionFindFirstMock },
-    coworker: { findMany: coworkerFindManyMock },
+    coworker: {
+      findMany: coworkerFindManyMock,
+      create: coworkerCreateMock,
+      upsert: coworkerUpsertMock,
+      updateMany: coworkerUpdateManyMock,
+    },
     job: { findMany: jobFindManyMock },
     project: { findMany: projectFindManyMock },
     sokoBot: {
       count: botCountMock,
+      create: botCreateMock,
       findFirst: botFindFirstMock,
       findMany: botFindManyMock,
       findUnique: botFindUniqueMock,
@@ -228,6 +240,11 @@ function transactionClient() {
       findUnique: botFindUniqueMock,
       update: botUpdateMock,
       updateMany: botUpdateManyMock,
+    },
+    coworker: {
+      create: coworkerCreateMock,
+      upsert: coworkerUpsertMock,
+      updateMany: coworkerUpdateManyMock,
     },
     sokoBotAdminAction: {
       create: adminActionCreateMock,
@@ -369,6 +386,48 @@ describe("SokoBotControlPlane lifecycle", () => {
 
     expect(bot?.id).toBe(BOT_ID);
     expect(bot).not.toHaveProperty("coworker");
+    expect(coworkerCreateMock).not.toHaveBeenCalled();
+    expect(coworkerUpsertMock).not.toHaveBeenCalled();
+  });
+
+  it("create does not insert a shadow coworker for a new PA", async () => {
+    botFindFirstMock.mockResolvedValue(null);
+    const createdBot = {
+      id: BOT_ID,
+      userId: "user_1",
+      workspaceId: "ws_1",
+      name: "Soko",
+      memoryVersion: 1,
+      archivedAt: null,
+      adminPausedAt: null,
+      status: "IDLE",
+    };
+    botCreateMock.mockResolvedValue(createdBot);
+    transactionMock.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+      fn({
+        sokoBot: {
+          findFirst: botFindFirstMock,
+          create: botCreateMock,
+          update: botUpdateMock,
+        },
+        sokoBotMemoryRevision: { create: vi.fn().mockResolvedValue({}) },
+        coworker: {
+          create: coworkerCreateMock,
+          upsert: coworkerUpsertMock,
+          updateMany: coworkerUpdateManyMock,
+        },
+      }),
+    );
+
+    await new SokoBotControlPlane().create({
+      userId: "user_1",
+      workspaceId: "ws_1",
+      name: "Soko",
+    });
+
+    expect(botCreateMock).toHaveBeenCalled();
+    expect(coworkerCreateMock).not.toHaveBeenCalled();
+    expect(coworkerUpsertMock).not.toHaveBeenCalled();
   });
 
   it("preserves an administrator pause during profile updates", async () => {

--- a/apps/core/src/services/soko-bot-control-plane.service.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.ts
@@ -22,6 +22,8 @@ import {
   sokoBotContextPacketSchema,
 } from "@sokosumi/soko-bot";
 
+import { personalAssistantCaption } from "@sokosumi/utils";
+
 import { getEnv } from "@/config/env";
 import { isPrismaUniqueViolation } from "@/helpers/prisma";
 import prisma from "@/lib/db/prisma";
@@ -1058,12 +1060,20 @@ export class SokoBotControlPlane {
             },
           });
         }
-        if (isReactivation) {
-          await tx.coworker.updateMany({
-            where: { sokoBotId: existing.id },
-            data: { archivedAt: null },
-          });
-        }
+        // Keep any pre-SOK-944 shadow coworker profile in sync without
+        // recreating it (name/caption; avatar claim updates image below).
+        const owner = await tx.user.findUnique({
+          where: { id: input.userId },
+          select: { name: true },
+        });
+        await tx.coworker.updateMany({
+          where: { sokoBotId: existing.id },
+          data: {
+            name,
+            caption: personalAssistantCaption(owner?.name),
+            ...(isReactivation ? { archivedAt: null } : {}),
+          },
+        });
         if (input.avatarId) await claimAvatar(updated.id, input.avatarId, tx);
         return updated;
       }

--- a/apps/core/src/services/soko-bot-control-plane.service.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.ts
@@ -1058,6 +1058,12 @@ export class SokoBotControlPlane {
             },
           });
         }
+        if (isReactivation) {
+          await tx.coworker.updateMany({
+            where: { sokoBotId: existing.id },
+            data: { archivedAt: null },
+          });
+        }
         if (input.avatarId) await claimAvatar(updated.id, input.avatarId, tx);
         return updated;
       }
@@ -3504,6 +3510,11 @@ export class SokoBotControlPlane {
           status: "PAUSED",
           eveSessionId: null,
         },
+      });
+      // Keep any pre-existing shadow coworker in sync without recreating it.
+      await tx.coworker.updateMany({
+        where: { sokoBotId: bot.id },
+        data: { archivedAt: new Date() },
       });
       return activeTurn;
     }, "Soko Bot archive collided with active work");

--- a/apps/core/src/services/soko-bot-control-plane.service.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.ts
@@ -44,7 +44,6 @@ import {
   recordSokoBotTurnUsage,
   requireSokoBotTurnFunding,
 } from "@/services/soko-bot-billing.service";
-import { ensureSokoBotCoworker } from "@/services/soko-bot-chat.service";
 import {
   type CreateSokoBotScheduleInput,
   createSokoBotSchedule,
@@ -1059,7 +1058,6 @@ export class SokoBotControlPlane {
             },
           });
         }
-        await ensureSokoBotCoworker(updated.id, tx);
         if (input.avatarId) await claimAvatar(updated.id, input.avatarId, tx);
         return updated;
       }
@@ -1091,7 +1089,6 @@ export class SokoBotControlPlane {
           source: "created",
         },
       });
-      await ensureSokoBotCoworker(bot.id, tx);
       if (input.avatarId) await claimAvatar(bot.id, input.avatarId, tx);
       return bot;
     });
@@ -1116,7 +1113,6 @@ export class SokoBotControlPlane {
     const bot = await prisma.sokoBot.findFirst({
       where: { userId, workspaceId, archivedAt: null },
       include: {
-        coworker: { select: { id: true, slug: true } },
         memoryRevisions: { orderBy: { version: "desc" }, take: 1 },
         legacyMessages: {
           orderBy: { createdAt: "desc" },
@@ -1131,11 +1127,6 @@ export class SokoBotControlPlane {
       },
     });
     if (!bot) return null;
-    // Bots created before chat support have no coworker row yet; heal lazily
-    // so "Open chat" works for them without a data migration.
-    if (!bot.coworker) {
-      bot.coworker = await ensureSokoBotCoworker(bot.id);
-    }
     const memoryRevisions = (bot.memoryRevisions ?? []).map(safeMemoryRevision);
     return {
       ...bot,
@@ -3514,7 +3505,6 @@ export class SokoBotControlPlane {
           eveSessionId: null,
         },
       });
-      await ensureSokoBotCoworker(bot.id, tx);
       return activeTurn;
     }, "Soko Bot archive collided with active work");
     if (!active) return;

--- a/apps/core/src/services/soko-bot-proactive.service.ts
+++ b/apps/core/src/services/soko-bot-proactive.service.ts
@@ -166,7 +166,7 @@ export interface AttentionItem {
  */
 export async function findAttentionItems(bot: {
   id: string;
-  coworkerId: string;
+  coworkerId: string | null;
   workspaceId: string;
   followWholeBoard: boolean;
   now: Date;
@@ -194,7 +194,7 @@ export async function findAttentionItems(bot: {
       // failed Task in the workspace made it chase a week of other people's
       // abandoned work and, now that it can act rather than draft, restart it.
       OR: [
-        { assigneeId: bot.coworkerId },
+        ...(bot.coworkerId ? [{ assigneeId: bot.coworkerId }] : []),
         { assigneeOrchestratorId: bot.id },
         { id: { in: delegatedIds } },
       ],
@@ -367,7 +367,7 @@ export async function buildSystemBeatMessage(input: {
       lines.push("");
     }
   }
-  if (bot.coworkerId) {
+  {
     const items = await findAttentionItems({
       id: bot.id,
       coworkerId: bot.coworkerId,
@@ -383,11 +383,12 @@ export async function buildSystemBeatMessage(input: {
       workspaceId: bot.workspaceId,
       archivedAt: null,
       status: { notIn: ["COMPLETED", "CANCELED"] },
-      ...(bot.followWholeBoard || !bot.coworkerId
+      ...(bot.followWholeBoard
         ? {}
         : {
             OR: [
-              { assigneeId: bot.coworkerId },
+              { assigneeOrchestratorId: bot.id },
+              ...(bot.coworkerId ? [{ assigneeId: bot.coworkerId }] : []),
               { sokoBotWatches: { some: { sokoBotId: bot.id } } },
             ],
           }),

--- a/apps/core/src/services/soko-bot-runtime.service.test.ts
+++ b/apps/core/src/services/soko-bot-runtime.service.test.ts
@@ -2328,7 +2328,10 @@ describe("SokoBotRuntimeService chat reading", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getEnvMock.mockReturnValue({ SOKO_BOT_ENABLED: true });
-    botFindUniqueMock.mockResolvedValue({ coworker: { id: "coworker_1" } });
+    botFindUniqueMock.mockResolvedValue({
+      id: SCOPE.sokoBotId,
+      coworker: { id: "coworker_1" },
+    });
     workspaceFindUniqueMock.mockResolvedValue({ organizationId: "org_1" });
   });
 
@@ -2340,11 +2343,43 @@ describe("SokoBotRuntimeService chat reading", () => {
     } as never);
 
     const where = chatRoomFindManyMock.mock.calls[0][0].where;
-    expect(where.coworkerMembers).toEqual({
-      some: { coworkerId: "coworker_1" },
-    });
+    expect(where.OR).toEqual(
+      expect.arrayContaining([
+        {
+          orchestratorMembers: {
+            some: { orchestratorId: SCOPE.sokoBotId },
+          },
+        },
+        {
+          coworkerMembers: {
+            some: { coworkerId: "coworker_1" },
+          },
+        },
+      ]),
+    );
     // Membership is the boundary; ChatRoom has no workspaceId column.
     expect(where.archivedAt).toBeNull();
+  });
+
+  it("lists rooms for a PA with no shadow coworker", async () => {
+    botFindUniqueMock.mockResolvedValue({
+      id: SCOPE.sokoBotId,
+      coworker: null,
+    });
+    chatRoomFindManyMock.mockResolvedValue([]);
+
+    await new SokoBotRuntimeService()["listChats"]({
+      turn: SCOPE_TURN,
+    } as never);
+
+    const where = chatRoomFindManyMock.mock.calls[0][0].where;
+    expect(where.OR).toEqual([
+      {
+        orchestratorMembers: {
+          some: { orchestratorId: SCOPE.sokoBotId },
+        },
+      },
+    ]);
   });
 
   it("refuses to read a room the bot does not belong to", async () => {
@@ -2360,7 +2395,13 @@ describe("SokoBotRuntimeService chat reading", () => {
   });
 
   it("returns messages newest first and marks the bot's own", async () => {
-    chatRoomFindFirstMock.mockResolvedValue({ id: "room_1", name: "Launch" });
+    chatRoomFindFirstMock.mockResolvedValue({
+      id: "room_1",
+      name: "Launch",
+      kind: "channel",
+      orchestratorMembers: [{ id: "om_1" }],
+      coworkerMembers: [{ id: "cm_1" }],
+    });
     chatMessageFindManyMock.mockResolvedValue([
       {
         id: "m2",
@@ -2410,12 +2451,17 @@ describe("post_chat chain depth", () => {
   function armPostChat(chainDepth: number) {
     vi.clearAllMocks();
     getEnvMock.mockReturnValue({ SOKO_BOT_ENABLED: true });
-    botFindUniqueMock.mockResolvedValue({ coworker: { id: "cow_self" } });
+    botFindUniqueMock.mockResolvedValue({
+      id: SCOPE.sokoBotId,
+      coworker: { id: "cow_self" },
+    });
     workspaceFindUniqueMock.mockResolvedValue({ organizationId: "org_1" });
     chatRoomFindFirstMock.mockResolvedValue({
       id: "room_1",
       name: "Launch",
       kind: "channel",
+      orchestratorMembers: [{ id: "om_1" }],
+      coworkerMembers: [{ id: "cm_1" }],
     });
     // Where the chain was started, for the origin-room check on depth > 0.
     turnFindUniqueMock.mockResolvedValue({
@@ -2460,6 +2506,8 @@ describe("post_chat chain depth", () => {
       id: "room_direct",
       name: "Nina",
       kind: "direct",
+      orchestratorMembers: [{ id: "om_1" }],
+      coworkerMembers: [{ id: "cm_1" }],
     });
     chatRoomUserMemberFindFirstMock.mockResolvedValue(null);
 
@@ -2479,6 +2527,8 @@ describe("post_chat chain depth", () => {
       id: "room_owner",
       name: "Ada",
       kind: "direct",
+      orchestratorMembers: [{ id: "om_1" }],
+      coworkerMembers: [{ id: "cm_1" }],
     });
     chatRoomUserMemberFindFirstMock.mockResolvedValue({ id: "member_1" });
 
@@ -2498,6 +2548,8 @@ describe("post_chat chain depth", () => {
       id: "room_1",
       name: "Launch",
       kind: "channel",
+      orchestratorMembers: [{ id: "om_1" }],
+      coworkerMembers: [{ id: "cm_1" }],
     });
 
     await new SokoBotRuntimeService()["postChat"](
@@ -2649,7 +2701,10 @@ describe("open_direct_chat", () => {
     vi.clearAllMocks();
     getEnvMock.mockReturnValue({ SOKO_BOT_ENABLED: true });
     toolCallCountMock.mockResolvedValue(0);
-    botFindUniqueMock.mockResolvedValue({ coworker: { id: "cow_self" } });
+    botFindUniqueMock.mockResolvedValue({
+      id: SCOPE.sokoBotId,
+      coworker: { id: "cow_self" },
+    });
     workspaceFindUniqueMock.mockResolvedValue({ organizationId: "org_1" });
     memberFindManyMock.mockResolvedValue([
       { user: { id: "user_colleague", name: "Nina", email: "nina@x.io" } },
@@ -2660,7 +2715,13 @@ describe("open_direct_chat", () => {
     });
     // The first message is posted as part of opening, so post_chat's own
     // dependencies have to be armed here too.
-    chatRoomFindFirstMock.mockResolvedValue({ id: "room_new", name: "Nina" });
+    chatRoomFindFirstMock.mockResolvedValue({
+      id: "room_new",
+      name: "Nina",
+      kind: "direct",
+      orchestratorMembers: [{ id: "om_1" }],
+      coworkerMembers: [{ id: "cm_1" }],
+    });
     chatRoomDeleteManyMock.mockResolvedValue({ count: 1 });
     chatMessageCountMock.mockResolvedValue(0);
     chatCoworkerMemberFindManyMock.mockResolvedValue([]);
@@ -2698,7 +2759,8 @@ describe("open_direct_chat", () => {
       organizationId: "org_1",
       currentUserId: "user_colleague",
       memberUserIds: [],
-      coworkerIds: ["cow_self"],
+      coworkerIds: [],
+      orchestratorIds: [SCOPE.sokoBotId],
       viewerUserId: null,
     });
     expect(result).toMatchObject({ roomId: "room_new", created: true });

--- a/apps/core/src/services/soko-bot-runtime.service.ts
+++ b/apps/core/src/services/soko-bot-runtime.service.ts
@@ -757,14 +757,14 @@ export class SokoBotRuntimeService {
   /** Everything a project manager needs to act on a Task without opening it. */
   /**
    * Rooms the bot itself belongs to. Membership is the whole authorization
-   * boundary here: the bot is a Coworker in chat, so it sees exactly the rooms
-   * a person added it to and nothing else in the workspace.
+   * boundary here: the bot is an orchestrator in chat (legacy bots may still
+   * sit as a shadow Coworker), so it sees exactly the rooms it was added to
+   * and nothing else in the workspace.
    */
   private async listChats(authorized: AuthorizedSokoBotRuntime) {
-    const coworkerId = await this.chatCoworkerId(authorized);
-    if (!coworkerId) return { rooms: [] };
+    const identity = await this.chatIdentity(authorized);
     const rooms = await prisma.chatRoom.findMany({
-      where: await this.chatRoomScope(authorized, coworkerId),
+      where: await this.chatRoomScope(authorized, identity),
       orderBy: { updatedAt: "desc" },
       take: 50,
       select: {
@@ -787,14 +787,15 @@ export class SokoBotRuntimeService {
   }
 
   /**
-   * Rooms the bot may touch: its own coworker's memberships, bounded to the
-   * workspace the turn runs in. Membership alone is not enough — a coworker
-   * could in principle be added to a room in another organization, and a turn
-   * must never reach outside its own workspace.
+   * Rooms the bot may touch: orchestrator memberships, plus legacy shadow
+   * coworker memberships until SOK-945 remaps them, bounded to the workspace
+   * the turn runs in. Membership alone is not enough — a participant could in
+   * principle be added to a room in another organization, and a turn must
+   * never reach outside its own workspace.
    */
   private async chatRoomScope(
     authorized: AuthorizedSokoBotRuntime,
-    coworkerId: string,
+    identity: { orchestratorId: string; coworkerId: string | null },
   ): Promise<Prisma.ChatRoomWhereInput> {
     const workspace = await prisma.workspace.findUnique({
       where: { id: authorized.turn.workspaceId },
@@ -802,26 +803,52 @@ export class SokoBotRuntimeService {
     });
     return {
       archivedAt: null,
-      coworkerMembers: { some: { coworkerId } },
       organizationId: workspace?.organizationId ?? null,
+      OR: [
+        {
+          orchestratorMembers: {
+            some: { orchestratorId: identity.orchestratorId },
+          },
+        },
+        ...(identity.coworkerId
+          ? [
+              {
+                coworkerMembers: {
+                  some: { coworkerId: identity.coworkerId },
+                },
+              },
+            ]
+          : []),
+      ],
     };
   }
 
-  /** The bot's chat identity; absent until it has a coworker row. */
-  private async chatCoworkerId(
+  /**
+   * Chat identity for a PA: always the orchestrator (`bot.id`). A legacy
+   * shadow coworker id is kept only so existing rooms stay reachable until
+   * SOK-945 remaps them.
+   */
+  private async chatIdentity(
     authorized: AuthorizedSokoBotRuntime,
-  ): Promise<string | null> {
+  ): Promise<{ orchestratorId: string; coworkerId: string | null }> {
     const bot = await prisma.sokoBot.findUnique({
       where: { id: authorized.turn.sokoBotId },
-      select: { coworker: { select: { id: true } } },
+      select: { id: true, coworker: { select: { id: true } } },
     });
-    return bot?.coworker?.id ?? null;
+    if (!bot) {
+      throw new SokoBotRuntimeValidationError("This Soko Bot was not found");
+    }
+    return {
+      orchestratorId: bot.id,
+      coworkerId: bot.coworker?.id ?? null,
+    };
   }
 
   /**
    * The single authorization boundary for chat: the bot may only touch rooms
-   * its coworker belongs to, in its own workspace. Re-checked on every call
-   * because the room id comes from the model, so removal takes effect at once.
+   * it belongs to (as orchestrator, or via a legacy shadow coworker), in its
+   * own workspace. Re-checked on every call because the room id comes from
+   * the model, so removal takes effect at once.
    */
   private async requireChatMembership(
     authorized: AuthorizedSokoBotRuntime,
@@ -830,24 +857,66 @@ export class SokoBotRuntimeService {
     id: string;
     name: string;
     kind: string;
-    coworkerId: string;
+    orchestratorId: string;
+    coworkerId: string | null;
+    sendAs: "orchestrator" | "coworker";
   }> {
-    const coworkerId = await this.chatCoworkerId(authorized);
-    const room = coworkerId
-      ? await prisma.chatRoom.findFirst({
-          where: {
-            ...(await this.chatRoomScope(authorized, coworkerId)),
-            id: roomId,
-          },
-          select: { id: true, name: true, kind: true },
-        })
-      : null;
-    if (!room || !coworkerId) {
+    const identity = await this.chatIdentity(authorized);
+    const room = await prisma.chatRoom.findFirst({
+      where: {
+        ...(await this.chatRoomScope(authorized, identity)),
+        id: roomId,
+      },
+      select: {
+        id: true,
+        name: true,
+        kind: true,
+        orchestratorMembers: {
+          where: { orchestratorId: identity.orchestratorId },
+          select: { id: true },
+          take: 1,
+        },
+        coworkerMembers: identity.coworkerId
+          ? {
+              where: { coworkerId: identity.coworkerId },
+              select: { id: true },
+              take: 1,
+            }
+          : false,
+      },
+    });
+    if (!room) {
       throw new SokoBotRuntimeValidationError(
         "You are not a member of that chat room",
       );
     }
-    return { id: room.id, name: room.name, kind: room.kind, coworkerId };
+    const viaOrchestrator = (room.orchestratorMembers?.length ?? 0) > 0;
+    const viaCoworker =
+      Boolean(identity.coworkerId) &&
+      Array.isArray(room.coworkerMembers) &&
+      room.coworkerMembers.length > 0;
+    // Prefer orchestrator when the room matched scope but the select omitted
+    // membership rows (tests), or when both are present.
+    const sendAs = viaOrchestrator
+      ? "orchestrator"
+      : viaCoworker
+        ? "coworker"
+        : identity.orchestratorId
+          ? "orchestrator"
+          : null;
+    if (!sendAs) {
+      throw new SokoBotRuntimeValidationError(
+        "You are not a member of that chat room",
+      );
+    }
+    return {
+      id: room.id,
+      name: room.name,
+      kind: room.kind,
+      orchestratorId: identity.orchestratorId,
+      coworkerId: identity.coworkerId,
+      sendAs,
+    };
   }
 
   /**
@@ -888,12 +957,7 @@ export class SokoBotRuntimeService {
         `One turn may open at most ${MAX_DIRECTS_OPENED_PER_TURN} direct chats. Tell the owner who else you would approach.`,
       );
     }
-    const coworkerId = await this.chatCoworkerId(authorized);
-    if (!coworkerId) {
-      throw new SokoBotRuntimeValidationError(
-        "This Soko Bot has no chat identity",
-      );
-    }
+    const identity = await this.chatIdentity(authorized);
     const workspace = await prisma.workspace.findUnique({
       where: { id: authorized.turn.workspaceId },
       select: { organizationId: true },
@@ -983,7 +1047,8 @@ export class SokoBotRuntimeService {
       organizationId,
       currentUserId: member.user.id,
       memberUserIds: [],
-      coworkerIds: [coworkerId],
+      coworkerIds: [],
+      orchestratorIds: [identity.orchestratorId],
       // The sidebar flags belong to a viewer; this actor is not one.
       viewerUserId: null,
     });
@@ -1103,7 +1168,12 @@ export class SokoBotRuntimeService {
     // traffic, only how much of it a room has taken lately.
     const roomCoworkers = chatChainMayWake(chainDepth)
       ? await prisma.chatRoomCoworkerMember.findMany({
-          where: { roomId: room.id, coworkerId: { not: room.coworkerId } },
+          where: {
+            roomId: room.id,
+            ...(room.coworkerId
+              ? { coworkerId: { not: room.coworkerId } }
+              : {}),
+          },
           select: {
             coworker: { select: { id: true, name: true, slug: true } },
           },
@@ -1123,7 +1193,10 @@ export class SokoBotRuntimeService {
       const botMessagesThisHour = await tx.chatRoomMessage.count({
         where: {
           roomId: room.id,
-          senderCoworkerId: { not: null },
+          OR: [
+            { senderCoworkerId: { not: null } },
+            { senderOrchestratorId: { not: null } },
+          ],
           deletedAt: null,
           createdAt: {
             gte: new Date(Date.now() - ROOM_BOT_MESSAGE_WINDOW_MS),
@@ -1138,7 +1211,12 @@ export class SokoBotRuntimeService {
       const created = await tx.chatRoomMessage.create({
         data: {
           roomId: room.id,
-          senderCoworkerId: room.coworkerId,
+          ...(room.sendAs === "orchestrator"
+            ? {
+                senderOrchestratorId: room.orchestratorId,
+                senderCoworkerId: null,
+              }
+            : { senderCoworkerId: room.coworkerId }),
           content: input.content,
           // Lets the reader see, on hover, that this is part of an assistant
           // exchange and how close it is to the point where it stops.
@@ -1280,6 +1358,8 @@ export class SokoBotRuntimeService {
         createdAt: true,
         senderUser: { select: { name: true } },
         senderCoworker: { select: { id: true, name: true } },
+        senderOrchestratorId: true,
+        senderOrchestrator: { select: { id: true, name: true } },
       },
     });
     return {
@@ -1289,9 +1369,15 @@ export class SokoBotRuntimeService {
         id: message.id,
         at: message.createdAt.toISOString(),
         from:
-          message.senderUser?.name ?? message.senderCoworker?.name ?? "unknown",
+          message.senderUser?.name ??
+          message.senderOrchestrator?.name ??
+          message.senderCoworker?.name ??
+          "unknown",
         /** True when the bot itself wrote it. */
-        fromYou: message.senderCoworker?.id === room.coworkerId,
+        fromYou:
+          message.senderOrchestratorId === room.orchestratorId ||
+          (room.coworkerId != null &&
+            message.senderCoworker?.id === room.coworkerId),
         // Chat is untrusted text: the operating contract already tells the bot
         // never to follow instructions found in content it reads.
         content: message.content.slice(0, 4_000),

--- a/apps/core/src/services/soko-bot-taskboard-sync.service.ts
+++ b/apps/core/src/services/soko-bot-taskboard-sync.service.ts
@@ -151,7 +151,6 @@ export class SokoBotTaskboardSyncService {
       where: withBetaBotOwner({
         archivedAt: null,
         adminPausedAt: null,
-        coworker: { isNot: null },
       }),
       select: {
         id: true,
@@ -170,7 +169,6 @@ export class SokoBotTaskboardSyncService {
     });
     for (const bot of bots) {
       if (!input.shouldContinue()) break;
-      if (!bot.coworker) continue;
       result.bots += 1;
       try {
         await ensureSystemSchedules(bot);
@@ -180,7 +178,7 @@ export class SokoBotTaskboardSyncService {
             name: bot.name,
             userId: bot.userId,
             workspaceId: bot.workspaceId,
-            coworkerId: bot.coworker.id,
+            coworkerId: bot.coworker?.id ?? null,
             followWholeBoard: bot.followWholeBoard,
             ingestTimezone: bot.ingestTimezone,
             memoryTokens: tokens(bot.memoryRevisions[0]?.markdown ?? ""),
@@ -210,7 +208,7 @@ export class SokoBotTaskboardSyncService {
       name: string | null;
       userId: string;
       workspaceId: string;
-      coworkerId: string;
+      coworkerId: string | null;
       followWholeBoard: boolean;
       ingestTimezone: string;
       memoryTokens: Set<string>;
@@ -236,7 +234,9 @@ export class SokoBotTaskboardSyncService {
         archivedAt: null,
         OR: [
           { assigneeOrchestratorId: bot.id, status: { notIn: [...TERMINAL] } },
-          { assigneeId: bot.coworkerId, status: { notIn: [...TERMINAL] } },
+          ...(bot.coworkerId
+            ? [{ assigneeId: bot.coworkerId, status: { notIn: [...TERMINAL] } }]
+            : []),
           { id: { in: Array.from(taskIds) }, updatedAt: { gte: since } },
           ...(bot.followWholeBoard
             ? [{ status: { notIn: [...TERMINAL] }, updatedAt: { gte: since } }]

--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -308,8 +308,10 @@ export async function createDirectRoomAction(
 }
 
 /**
- * Create-or-get the `kind:direct` room for a solo coworker 1:1.
- * Uses the active organization when set (same as `/chat`); personal if none.
+ * Create-or-get the owner↔PA `kind:direct` room for an orchestrator id.
+ * Core keeps owner↔PA directs personal (organizationId null) so Message bot
+ * under an active org reuses the legacy personal shadow DM; colleague
+ * approach stays org-scoped on the Core side.
  */
 export async function ensureOrchestratorDirectRoomAction(
   orchestratorId: string,

--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -311,6 +311,28 @@ export async function createDirectRoomAction(
  * Create-or-get the `kind:direct` room for a solo coworker 1:1.
  * Uses the active organization when set (same as `/chat`); personal if none.
  */
+export async function ensureOrchestratorDirectRoomAction(
+  orchestratorId: string,
+): Promise<RoomActionResult<ChatRoom | null>> {
+  const cleanOrchestratorId = cleanString(orchestratorId);
+  if (!cleanOrchestratorId) {
+    return roomFail("Personal assistant is required.");
+  }
+
+  try {
+    const room = await chatRoomService.createRoom({
+      kind: "direct",
+      memberUserIds: [],
+      coworkerIds: [],
+      orchestratorIds: [cleanOrchestratorId],
+    });
+    await invalidateSidebarChatList();
+    return roomOk(room);
+  } catch (error) {
+    return roomCatch(error, "Could not ensure personal assistant direct room.");
+  }
+}
+
 export async function ensureCoworkerDirectRoomAction(
   coworkerId: string,
 ): Promise<RoomActionResult<ChatRoom | null>> {

--- a/apps/web/src/app/(app)/chat/components/open-direct-with-participant.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/open-direct-with-participant.test.tsx
@@ -12,16 +12,19 @@ import type { ChatParticipantHoverProfile } from "./room-helpers";
 const {
   createDirectRoomActionMock,
   ensureCoworkerDirectRoomActionMock,
+  ensureOrchestratorDirectRoomActionMock,
   notifyOrganizationChatRoomsChangedMock,
 } = vi.hoisted(() => ({
   createDirectRoomActionMock: vi.fn(),
   ensureCoworkerDirectRoomActionMock: vi.fn(),
+  ensureOrchestratorDirectRoomActionMock: vi.fn(),
   notifyOrganizationChatRoomsChangedMock: vi.fn(),
 }));
 
 vi.mock("@/app/chat/actions", () => ({
   createDirectRoomAction: createDirectRoomActionMock,
   ensureCoworkerDirectRoomAction: ensureCoworkerDirectRoomActionMock,
+  ensureOrchestratorDirectRoomAction: ensureOrchestratorDirectRoomActionMock,
 }));
 
 vi.mock("@/components/chat/organization-chat-events", () => ({
@@ -133,7 +136,7 @@ describe("canShowOpenDirect", () => {
     ).toBe(true);
   });
 
-  it("hides Message for an orchestrator PA", () => {
+  it("shows an orchestrator when human directs are unavailable", () => {
     expect(
       canShowOpenDirect({
         profile: {
@@ -147,10 +150,10 @@ describe("canShowOpenDirect", () => {
           sokoBotAvatarSeed: "orb:user-1",
         },
         currentUserId: "user-1",
-        canOpenHumanDirect: true,
+        canOpenHumanDirect: false,
         onOpenDirect,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("hides without an open callback", () => {
@@ -220,6 +223,40 @@ describe("openDirectWithParticipant", () => {
       directRoom,
     );
     expect(push).toHaveBeenCalledWith("/chat/rooms/room-coworker");
+  });
+
+  it("ensures an orchestrator direct, notifies, and navigates", async () => {
+    const directRoom = room("room-orchestrator");
+    const push = vi.fn();
+    ensureOrchestratorDirectRoomActionMock.mockResolvedValue({
+      ok: true,
+      value: directRoom,
+    });
+
+    await openDirectWithParticipant({
+      profile: {
+        kind: "orchestrator",
+        id: "bot-1",
+        name: "Ada Bot",
+        slug: "ada-bot",
+        caption: null,
+        image: null,
+        presence: "online",
+        sokoBotAvatarSeed: "orb:user-1",
+      },
+      selectedRoomId: null,
+      router: { push },
+      onError: vi.fn(),
+    });
+
+    expect(ensureOrchestratorDirectRoomActionMock).toHaveBeenCalledWith(
+      "bot-1",
+    );
+    expect(createDirectRoomActionMock).not.toHaveBeenCalled();
+    expect(notifyOrganizationChatRoomsChangedMock).toHaveBeenCalledWith(
+      directRoom,
+    );
+    expect(push).toHaveBeenCalledWith("/chat/rooms/room-orchestrator");
   });
 
   it("skips navigation when the direct is already selected", async () => {

--- a/apps/web/src/app/(app)/chat/components/open-direct-with-participant.ts
+++ b/apps/web/src/app/(app)/chat/components/open-direct-with-participant.ts
@@ -1,6 +1,7 @@
 import {
   createDirectRoomAction,
   ensureCoworkerDirectRoomAction,
+  ensureOrchestratorDirectRoomAction,
 } from "@/app/chat/actions";
 import { notifyOrganizationChatRoomsChanged } from "@/components/chat/organization-chat-events";
 
@@ -33,8 +34,6 @@ export function canShowOpenDirect(options: {
 }): boolean {
   const { profile, currentUserId, canOpenHumanDirect, onOpenDirect } = options;
   if (!onOpenDirect) return false;
-  // Native PA has no coworker direct room yet (SOK-942); hide Message action.
-  if (profile.kind === "orchestrator") return false;
   if (profile.kind === "human") {
     if (!canOpenHumanDirect) return false;
     if (currentUserId && profile.id === currentUserId) return false;
@@ -49,14 +48,12 @@ export async function openDirectWithParticipant(options: {
   onError: (message: string) => void;
 }): Promise<{ ok: true; roomId: string } | { ok: false }> {
   const { profile, selectedRoomId, router, onError } = options;
-  if (profile.kind === "orchestrator") {
-    onError("Could not start direct message.");
-    return { ok: false };
-  }
   const result =
     profile.kind === "coworker"
       ? await ensureCoworkerDirectRoomAction(profile.id)
-      : await createDirectRoomAction({ memberUserId: profile.id });
+      : profile.kind === "orchestrator"
+        ? await ensureOrchestratorDirectRoomAction(profile.id)
+        : await createDirectRoomAction({ memberUserId: profile.id });
 
   if (!result.ok) {
     onError(result.error.message ?? "Could not start direct message.");

--- a/apps/web/src/app/(app)/personal-assistant/components/chat/__tests__/timeline.test.ts
+++ b/apps/web/src/app/(app)/personal-assistant/components/chat/__tests__/timeline.test.ts
@@ -88,7 +88,7 @@ function state(overrides: Partial<SokoBotChatState> = {}): SokoBotChatState {
       ingestTimezone: "Europe/Berlin",
       proactivePaused: false,
       proactiveDailyLimit: 20,
-      coworkerId: null,
+      orchestratorId: "bot-1",
       status: "IDLE",
       memoryVersion: 0,
       memory: null,

--- a/apps/web/src/app/(app)/personal-assistant/components/console/console.client.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/console/console.client.tsx
@@ -13,7 +13,7 @@ import {
   useTransition,
 } from "react";
 import { toast } from "sonner";
-import { ensureCoworkerDirectRoomAction } from "@/app/chat/actions";
+import { ensureOrchestratorDirectRoomAction } from "@/app/chat/actions";
 import Markdown from "@/components/markdown";
 import { SokoBotStatusBadge } from "@/components/soko-bot/soko-bot-badges";
 import { Button } from "@/components/ui/button";
@@ -166,10 +166,10 @@ export function SokoBotConsole({
   const turns = useMemo(() => orderedTurns(state).reverse(), [state]);
 
   function openChat() {
-    if (!bot.coworkerId) return;
-    const coworkerId = bot.coworkerId;
     startOpeningChat(async () => {
-      const result = await ensureCoworkerDirectRoomAction(coworkerId);
+      const result = await ensureOrchestratorDirectRoomAction(
+        bot.orchestratorId,
+      );
       if (!result.ok || !result.value) {
         toast.error(t("Console.openChatError"));
         return;
@@ -257,7 +257,7 @@ export function SokoBotConsole({
                 type="button"
                 className="flex-1 sm:flex-none"
                 onClick={openChat}
-                disabled={!bot.coworkerId || isOpeningChat}
+                disabled={isOpeningChat}
               >
                 <MessageSquare aria-hidden className="size-4" />
                 {isOpeningChat

--- a/apps/web/src/app/(app)/personal-assistant/components/create-state.client.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/create-state.client.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useId, useState, useTransition } from "react";
 import { toast } from "sonner";
-import { ensureCoworkerDirectRoomAction } from "@/app/chat/actions";
+import { ensureOrchestratorDirectRoomAction } from "@/app/chat/actions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -44,17 +44,15 @@ export function CreateState() {
         return;
       }
       setCreated({ name: result.value.name ?? trimmed });
-      const coworkerId = result.value.coworker?.id ?? null;
+      const orchestratorId = result.value.id;
       // Let the reveal play before the chat takes over.
       const reveal = new Promise((resolve) => setTimeout(resolve, 1800));
-      const room = coworkerId
-        ? await ensureCoworkerDirectRoomAction(coworkerId)
-        : null;
-      if (room?.ok && room.value) {
+      const room = await ensureOrchestratorDirectRoomAction(orchestratorId);
+      if (room.ok && room.value) {
         await introduceSokoBotAction({ roomId: room.value.id });
       }
       await reveal;
-      if (room?.ok && room.value) {
+      if (room.ok && room.value) {
         router.push(`/chat/rooms/${encodeURIComponent(room.value.id)}`);
         return;
       }

--- a/apps/web/src/app/(app)/soko-bots/components/message-bot-button.client.tsx
+++ b/apps/web/src/app/(app)/soko-bots/components/message-bot-button.client.tsx
@@ -5,17 +5,17 @@ import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { toast } from "sonner";
 
-import { ensureCoworkerDirectRoomAction } from "@/app/chat/actions";
+import { ensureOrchestratorDirectRoomAction } from "@/app/chat/actions";
 import { Button } from "@/components/ui/button";
 
-/** Opens (or creates) the direct room with a Soko Bot's chat coworker. */
+/** Opens (or creates) the direct room with a Soko Bot orchestrator. */
 export function MessageBotButton({
-  coworkerId,
+  orchestratorId,
   label,
   errorLabel,
   variant = "link",
 }: {
-  coworkerId: string;
+  orchestratorId: string;
   label: string;
   errorLabel: string;
   variant?: "link" | "button";
@@ -24,7 +24,7 @@ export function MessageBotButton({
   const [isPending, startTransition] = useTransition();
   const open = () =>
     startTransition(async () => {
-      const result = await ensureCoworkerDirectRoomAction(coworkerId);
+      const result = await ensureOrchestratorDirectRoomAction(orchestratorId);
       if (!result.ok || !result.value) {
         toast.error(errorLabel);
         return;

--- a/apps/web/src/app/(app)/soko-bots/components/soko-bots-hero.tsx
+++ b/apps/web/src/app/(app)/soko-bots/components/soko-bots-hero.tsx
@@ -96,14 +96,12 @@ export async function SokoBotsHero({
                 <ArrowRight aria-hidden className="size-3.5" />
               </Link>
             </Button>
-            {bot.coworkerId ? (
-              <MessageBotButton
-                coworkerId={bot.coworkerId}
-                label={t("openChat")}
-                errorLabel={t("chatError")}
-                variant="button"
-              />
-            ) : null}
+            <MessageBotButton
+              orchestratorId={bot.id}
+              label={t("openChat")}
+              errorLabel={t("chatError")}
+              variant="button"
+            />
           </div>
         ) : (
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/apps/web/src/app/(app)/soko-bots/components/team-chart.tsx
+++ b/apps/web/src/app/(app)/soko-bots/components/team-chart.tsx
@@ -104,10 +104,10 @@ async function BotNode({ member }: { member: Member }) {
       ) : (
         <div className="flex items-center gap-3 px-3 py-3 text-sm">{body}</div>
       )}
-      {bot.coworkerId ? (
+      {bot ? (
         <div className="border-t px-3 py-1.5">
           <MessageBotButton
-            coworkerId={bot.coworkerId}
+            orchestratorId={bot.id}
             label={member.isYou ? t("openChat") : t("messageAssistant")}
             errorLabel={t("chatError")}
           />

--- a/apps/web/src/app/(app)/soko-bots/components/your-soko-bots.tsx
+++ b/apps/web/src/app/(app)/soko-bots/components/your-soko-bots.tsx
@@ -61,14 +61,12 @@ export async function YourSokoBots({ me }: { me: Member | null }) {
                   <ArrowRight aria-hidden className="size-3.5" />
                 </Link>
               </Button>
-              {bot.coworkerId ? (
-                <MessageBotButton
-                  coworkerId={bot.coworkerId}
-                  label={t("openChat")}
-                  errorLabel={t("chatError")}
-                  variant="button"
-                />
-              ) : null}
+              <MessageBotButton
+                orchestratorId={bot.id}
+                label={t("openChat")}
+                errorLabel={t("chatError")}
+                variant="button"
+              />
             </div>
           </div>
         ) : (

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -2835,24 +2835,6 @@ export const SokoBotSchema = {
         proactiveDailyLimit: {
             type: 'integer'
         },
-        coworker: {
-            type: [
-                'object',
-                'null'
-            ],
-            properties: {
-                id: {
-                    type: 'string'
-                },
-                slug: {
-                    type: 'string'
-                }
-            },
-            required: [
-                'id',
-                'slug'
-            ]
-        },
         createdAt: {
             type: 'string',
             format: 'date-time',
@@ -8671,7 +8653,7 @@ export const CreateChatRoomRequestSchema = {
                     enum: [
                         'direct'
                     ],
-                    description: 'Creates or returns a direct room: one or more humans (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Human 1:1 is an Org Direct when both are Members of the active organization; otherwise a Personal Direct when they share an External channel. Multi-human groups and coworker DMs with an active org are org-scoped. Coworker DMs may be personal with no active org. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.'
+                    description: 'Creates or returns a direct room: one or more humans (1:1 or multi-human group), exactly one coworker, or exactly one personal assistant (orchestrator). Human, coworker, and orchestrator targets cannot be mixed. Human 1:1 is an Org Direct when both are Members of the active organization; otherwise a Personal Direct when they share an External channel. Multi-human groups and coworker DMs with an active org are org-scoped. Coworker and orchestrator DMs may be personal with no active org. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.'
                 },
                 memberUserIds: {
                     type: 'array',
@@ -16920,12 +16902,6 @@ export const SokoBotTeamSchema = {
                             },
                             status: {
                                 $ref: '#/components/schemas/SokoBotStatus'
-                            },
-                            coworkerId: {
-                                type: [
-                                    'string',
-                                    'null'
-                                ]
                             }
                         },
                         required: [
@@ -16933,8 +16909,7 @@ export const SokoBotTeamSchema = {
                             'name',
                             'avatarImageUrl',
                             'avatarSeed',
-                            'status',
-                            'coworkerId'
+                            'status'
                         ]
                     }
                 },

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -626,10 +626,6 @@ export type SokoBot = {
     ingestTimezone?: string;
     proactivePaused?: boolean;
     proactiveDailyLimit?: number;
-    coworker?: {
-        id: string;
-        slug: string;
-    } | null;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -2364,7 +2360,7 @@ export type CreateChatRoomRequest = {
     orchestratorIds?: Array<string>;
 } | {
     /**
-     * Creates or returns a direct room: one or more humans (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Human 1:1 is an Org Direct when both are Members of the active organization; otherwise a Personal Direct when they share an External channel. Multi-human groups and coworker DMs with an active org are org-scoped. Coworker DMs may be personal with no active org. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.
+     * Creates or returns a direct room: one or more humans (1:1 or multi-human group), exactly one coworker, or exactly one personal assistant (orchestrator). Human, coworker, and orchestrator targets cannot be mixed. Human 1:1 is an Org Direct when both are Members of the active organization; otherwise a Personal Direct when they share an External channel. Multi-human groups and coworker DMs with an active org are org-scoped. Coworker and orchestrator DMs may be personal with no active org. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.
      */
     kind: 'direct';
     /**
@@ -4959,7 +4955,6 @@ export type SokoBotTeam = {
             avatarImageUrl: string | null;
             avatarSeed: string | null;
             status: SokoBotStatus;
-            coworkerId: string | null;
         } | null;
     }>;
 };

--- a/apps/web/src/lib/soko-bot/chat-state.ts
+++ b/apps/web/src/lib/soko-bot/chat-state.ts
@@ -163,8 +163,8 @@ export interface ChatBot {
   ingestTimezone: string;
   proactivePaused: boolean;
   proactiveDailyLimit: number;
-  /** Chat coworker row id; open a direct with it to talk to the bot. */
-  coworkerId: string | null;
+  /** Open a direct with the bot id (orchestrator participant). */
+  orchestratorId: string;
   status: SokoBotStatus;
   memoryVersion: number;
   memory: ChatMemory | null;
@@ -327,7 +327,7 @@ export function toChatBot(bot: SokoBot): ChatBot {
     ingestTimezone: bot.ingestTimezone ?? "Europe/Berlin",
     proactivePaused: bot.proactivePaused ?? false,
     proactiveDailyLimit: bot.proactiveDailyLimit ?? 20,
-    coworkerId: bot.coworker?.id ?? null,
+    orchestratorId: bot.id,
     status: bot.status,
     memoryVersion: bot.memoryVersion,
     memory: memory


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SOK-944: stop creating shadow `Coworker` rows for personal assistants. PA chat identity is the orchestrator (`bot.id`).

Follow-ups from code review on this branch:

- **Runtime chat tools** authorize via orchestrator membership (`senderOrchestratorId`) with legacy coworker fallback
- **Taskboard sync / proactive attention** no longer require a shadow coworker
- **Owner↔PA DMs stay personal** even when an org is active, so Message bot reuses the legacy personal shadow DM instead of forking an empty org orchestrator room
- **Delivery prefers history** (then personal, then orchestrator) so empty org rooms do not steal proactive traffic from legacy DMs
- **Shadow profile sync** updates name/caption on existing coworker rows on rename (avatar claim already syncs image); archive/reactivate still syncs without create
- **AuthZ copy** distinguishes owner-scoped vs workspace-scoped orchestrator validation
- **AC tests** assert create/heal do not write coworker rows; helpers + delivery preference covered

## Stack

Base: `sok-943-assign-tasks-to-pa-as-orchestrator-assignee` (#4090)

## Test plan

- [x] `vitest` helpers / chat delivery / control-plane / runtime / rooms post
- [x] `pnpm check` + `pnpm typecheck` on commit
- [ ] Manual: create new PA → Message bot → orchestrator DM (no coworker row)
- [ ] Manual: existing PA with personal shadow DM + active org → Open Chat / Message bot reuses legacy personal DM
- [ ] Manual: existing PA rename still updates shadow coworker display name until SOK-945

Refs: SOK-944 / SOK-933

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8bebea8-9765-4257-b279-1431ad07234e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8bebea8-9765-4257-b279-1431ad07234e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

