### PR TITLE
feat(core): notify on every message in a room for readers who ask

### DIFF
--- a/apps/core/src/helpers/chat-direct-message-notifications.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.ts
@@ -1,9 +1,6 @@
-import * as Sentry from "@sentry/node";
-import { NotificationKind } from "@sokosumi/database";
-
 import { CHAT_DIRECT_MESSAGE_MESSAGE_KEY } from "@/helpers/notification-delivery";
-import { createNotification } from "@/helpers/notifications";
-import prisma from "@/lib/db/prisma";
+
+import { fanOutChatNotifications } from "./chat-notification-fanout";
 
 export const MAX_HUMAN_MEMBERS_FOR_DIRECT_MESSAGE_NOTIFICATIONS = 2;
 
@@ -37,73 +34,9 @@ export interface EmitChatDirectMessageNotificationsParams {
 export async function emitChatDirectMessageNotifications(
   params: EmitChatDirectMessageNotificationsParams,
 ): Promise<void> {
-  const recipientUserIds = [
-    ...new Set(
-      params.recipientUserIds.filter(
-        (userId) =>
-          params.authorUserId === null || userId !== params.authorUserId,
-      ),
-    ),
-  ];
-
-  if (recipientUserIds.length === 0) {
-    return;
-  }
-
-  const mutedMemberships = await prisma.chatRoomUserMember.findMany({
-    where: {
-      roomId: params.roomId,
-      userId: { in: recipientUserIds },
-      mutedAt: { not: null },
-    },
-    select: { userId: true },
+  await fanOutChatNotifications({
+    ...params,
+    messageKey: CHAT_DIRECT_MESSAGE_MESSAGE_KEY,
+    notificationType: "chat-direct-message-notification",
   });
-  const mutedUserIds = new Set(
-    mutedMemberships.map((membership) => membership.userId),
-  );
-  const notifyUserIds = recipientUserIds.filter(
-    (userId) => !mutedUserIds.has(userId),
-  );
-
-  if (notifyUserIds.length === 0) {
-    return;
-  }
-
-  let workspaceId: string | null = null;
-  if (params.organizationId) {
-    const workspace = await prisma.workspace.findUnique({
-      where: { organizationId: params.organizationId },
-      select: { id: true },
-    });
-    workspaceId = workspace?.id ?? null;
-  }
-
-  for (const userId of notifyUserIds) {
-    try {
-      await createNotification({
-        userId,
-        kind: NotificationKind.CHAT,
-        referenceId: params.roomId,
-        eventId: params.messageId,
-        messageKey: CHAT_DIRECT_MESSAGE_MESSAGE_KEY,
-        messageParams: {
-          authorName: params.authorName,
-          roomName: params.roomName,
-        },
-        metadata: {
-          messageId: params.messageId,
-          workspaceId,
-        },
-      });
-    } catch (error) {
-      Sentry.captureException(error, {
-        extra: {
-          roomId: params.roomId,
-          messageId: params.messageId,
-          userId,
-          notificationType: "chat-direct-message-notification",
-        },
-      });
-    }
-  }
 }

--- a/apps/core/src/helpers/chat-mention-notifications.ts
+++ b/apps/core/src/helpers/chat-mention-notifications.ts
@@ -1,9 +1,6 @@
-import * as Sentry from "@sentry/node";
-import { NotificationKind } from "@sokosumi/database";
-
 import { CHAT_MENTION_MESSAGE_KEY } from "@/helpers/notification-delivery";
-import { createNotification } from "@/helpers/notifications";
-import prisma from "@/lib/db/prisma";
+
+import { fanOutChatNotifications } from "./chat-notification-fanout";
 
 export interface EmitChatMentionNotificationsParams {
   roomId: string;
@@ -19,72 +16,15 @@ export interface EmitChatMentionNotificationsParams {
 export async function emitChatMentionNotifications(
   params: EmitChatMentionNotificationsParams,
 ): Promise<void> {
-  const recipientUserIds = [
-    ...new Set(
-      params.mentionedUserIds.filter(
-        (userId) => userId !== params.authorUserId,
-      ),
-    ),
-  ];
-
-  if (recipientUserIds.length === 0) {
-    return;
-  }
-
-  const mutedMemberships = await prisma.chatRoomUserMember.findMany({
-    where: {
-      roomId: params.roomId,
-      userId: { in: recipientUserIds },
-      mutedAt: { not: null },
-    },
-    select: { userId: true },
+  await fanOutChatNotifications({
+    roomId: params.roomId,
+    roomName: params.roomName,
+    organizationId: params.organizationId,
+    messageId: params.messageId,
+    authorUserId: params.authorUserId,
+    authorName: params.authorName,
+    recipientUserIds: params.mentionedUserIds,
+    messageKey: CHAT_MENTION_MESSAGE_KEY,
+    notificationType: "chat-mention-notification",
   });
-  const mutedUserIds = new Set(
-    mutedMemberships.map((membership) => membership.userId),
-  );
-  const notifyUserIds = recipientUserIds.filter(
-    (userId) => !mutedUserIds.has(userId),
-  );
-
-  if (notifyUserIds.length === 0) {
-    return;
-  }
-
-  let workspaceId: string | null = null;
-  if (params.organizationId) {
-    const workspace = await prisma.workspace.findUnique({
-      where: { organizationId: params.organizationId },
-      select: { id: true },
-    });
-    workspaceId = workspace?.id ?? null;
-  }
-
-  for (const userId of notifyUserIds) {
-    try {
-      await createNotification({
-        userId,
-        kind: NotificationKind.CHAT,
-        referenceId: params.roomId,
-        eventId: params.messageId,
-        messageKey: CHAT_MENTION_MESSAGE_KEY,
-        messageParams: {
-          authorName: params.authorName,
-          roomName: params.roomName,
-        },
-        metadata: {
-          messageId: params.messageId,
-          workspaceId,
-        },
-      });
-    } catch (error) {
-      Sentry.captureException(error, {
-        extra: {
-          roomId: params.roomId,
-          messageId: params.messageId,
-          userId,
-          notificationType: "chat-mention-notification",
-        },
-      });
-    }
-  }
 }

--- a/apps/core/src/helpers/chat-notification-fanout.test.ts
+++ b/apps/core/src/helpers/chat-notification-fanout.test.ts
@@ -1,0 +1,170 @@
+import { NotificationKind } from "@sokosumi/database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createNotificationMock,
+  workspaceFindUniqueMock,
+  membershipFindManyMock,
+  captureExceptionMock,
+} = vi.hoisted(() => ({
+  createNotificationMock: vi.fn(),
+  workspaceFindUniqueMock: vi.fn(),
+  membershipFindManyMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/notifications", () => ({
+  createNotification: (...args: unknown[]) => createNotificationMock(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    workspace: {
+      findUnique: workspaceFindUniqueMock,
+    },
+    chatRoomUserMember: {
+      findMany: membershipFindManyMock,
+    },
+  },
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+import { fanOutChatNotifications } from "./chat-notification-fanout";
+
+const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
+const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440002";
+const AUTHOR_ID = "user_author";
+const ALICE_ID = "user_alice";
+const BOB_ID = "user_bob";
+
+function params(
+  overrides: Partial<Parameters<typeof fanOutChatNotifications>[0]> = {},
+) {
+  return {
+    roomId: ROOM_ID,
+    roomName: "general",
+    organizationId: "org_1" as string | null,
+    messageId: MESSAGE_ID,
+    authorUserId: AUTHOR_ID as string | null,
+    authorName: "Patrick",
+    recipientUserIds: [ALICE_ID],
+    messageKey: "Notifications.Chat.roomMessage",
+    notificationType: "chat-room-message",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createNotificationMock.mockResolvedValue({ created: true });
+  workspaceFindUniqueMock.mockResolvedValue({ id: "workspace_1" });
+  membershipFindManyMock.mockResolvedValue([]);
+});
+
+describe("fanOutChatNotifications", () => {
+  it("writes one notification per recipient under the given message key", async () => {
+    await fanOutChatNotifications(
+      params({ recipientUserIds: [ALICE_ID, BOB_ID] }),
+    );
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(2);
+    expect(createNotificationMock).toHaveBeenCalledWith({
+      userId: ALICE_ID,
+      kind: NotificationKind.CHAT,
+      referenceId: ROOM_ID,
+      eventId: MESSAGE_ID,
+      messageKey: "Notifications.Chat.roomMessage",
+      messageParams: { authorName: "Patrick", roomName: "general" },
+      metadata: { messageId: MESSAGE_ID, workspaceId: "workspace_1" },
+    });
+  });
+
+  it("drops the author and repeats, so one reader gets one notification", async () => {
+    await fanOutChatNotifications(
+      params({
+        recipientUserIds: [AUTHOR_ID, ALICE_ID, ALICE_ID],
+      }),
+    );
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: ALICE_ID }),
+    );
+  });
+
+  /**
+   * A coworker author has no user id, so nobody in the room is the author and
+   * the whole roster stays.
+   */
+  it("keeps every recipient when the author is not a user", async () => {
+    await fanOutChatNotifications(
+      params({
+        authorUserId: null,
+        recipientUserIds: [AUTHOR_ID, ALICE_ID],
+      }),
+    );
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify a reader who muted the room", async () => {
+    membershipFindManyMock.mockResolvedValue([{ userId: BOB_ID }]);
+
+    await fanOutChatNotifications(
+      params({ recipientUserIds: [ALICE_ID, BOB_ID] }),
+    );
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: ALICE_ID }),
+    );
+  });
+
+  it("stops before the workspace lookup when nobody is left to notify", async () => {
+    membershipFindManyMock.mockResolvedValue([{ userId: ALICE_ID }]);
+
+    await fanOutChatNotifications(params());
+
+    expect(workspaceFindUniqueMock).not.toHaveBeenCalled();
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("does not read a workspace for a room outside an organization", async () => {
+    await fanOutChatNotifications(params({ organizationId: null }));
+
+    expect(workspaceFindUniqueMock).not.toHaveBeenCalled();
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { messageId: MESSAGE_ID, workspaceId: null },
+      }),
+    );
+  });
+
+  /**
+   * One reader's failed write must not cost the others theirs, so the loop
+   * reports and continues.
+   */
+  it("reports a failed write and still notifies the rest", async () => {
+    const failure = new Error("write failed");
+    createNotificationMock
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({ created: true });
+
+    await fanOutChatNotifications(
+      params({ recipientUserIds: [ALICE_ID, BOB_ID] }),
+    );
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(2);
+    expect(captureExceptionMock).toHaveBeenCalledWith(failure, {
+      extra: {
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+        userId: ALICE_ID,
+        notificationType: "chat-room-message",
+      },
+    });
+  });
+});

--- a/apps/core/src/helpers/chat-notification-fanout.ts
+++ b/apps/core/src/helpers/chat-notification-fanout.ts
@@ -1,0 +1,107 @@
+import * as Sentry from "@sentry/node";
+import { NotificationKind } from "@sokosumi/database";
+
+import { createNotification } from "@/helpers/notifications";
+import prisma from "@/lib/db/prisma";
+
+export interface FanOutChatNotificationsParams {
+  roomId: string;
+  roomName: string;
+  organizationId: string | null;
+  messageId: string;
+  /** Human author to skip. Null when the author is a coworker. */
+  authorUserId: string | null;
+  authorName: string;
+  recipientUserIds: readonly string[];
+  /** Decides which preference row the reader reads this under. */
+  messageKey: string;
+  /** Sentry tag, so a failed emit names which chat notification it was. */
+  notificationType: string;
+}
+
+/**
+ * The steps every chat notification shares: drop the author, drop the readers
+ * who muted the room, and write one notification each.
+ *
+ * A mention, a direct message and a room message differ only in the message
+ * key they carry and the preference row that key maps to. Keeping the fan-out
+ * in one place means a fix to the mute rule or the workspace lookup reaches all
+ * three, and a fourth chat notification is a message key rather than another
+ * copy of this function.
+ *
+ * One recipient's failure never costs the others theirs, so each write is
+ * caught and reported on its own.
+ */
+export async function fanOutChatNotifications(
+  params: FanOutChatNotificationsParams,
+): Promise<void> {
+  const recipientUserIds = [
+    ...new Set(
+      params.recipientUserIds.filter(
+        (userId) =>
+          params.authorUserId === null || userId !== params.authorUserId,
+      ),
+    ),
+  ];
+
+  if (recipientUserIds.length === 0) {
+    return;
+  }
+
+  const mutedMemberships = await prisma.chatRoomUserMember.findMany({
+    where: {
+      roomId: params.roomId,
+      userId: { in: recipientUserIds },
+      mutedAt: { not: null },
+    },
+    select: { userId: true },
+  });
+  const mutedUserIds = new Set(
+    mutedMemberships.map((membership) => membership.userId),
+  );
+  const notifyUserIds = recipientUserIds.filter(
+    (userId) => !mutedUserIds.has(userId),
+  );
+
+  if (notifyUserIds.length === 0) {
+    return;
+  }
+
+  let workspaceId: string | null = null;
+  if (params.organizationId) {
+    const workspace = await prisma.workspace.findUnique({
+      where: { organizationId: params.organizationId },
+      select: { id: true },
+    });
+    workspaceId = workspace?.id ?? null;
+  }
+
+  for (const userId of notifyUserIds) {
+    try {
+      await createNotification({
+        userId,
+        kind: NotificationKind.CHAT,
+        referenceId: params.roomId,
+        eventId: params.messageId,
+        messageKey: params.messageKey,
+        messageParams: {
+          authorName: params.authorName,
+          roomName: params.roomName,
+        },
+        metadata: {
+          messageId: params.messageId,
+          workspaceId,
+        },
+      });
+    } catch (error) {
+      Sentry.captureException(error, {
+        extra: {
+          roomId: params.roomId,
+          messageId: params.messageId,
+          userId,
+          notificationType: params.notificationType,
+        },
+      });
+    }
+  }
+}

--- a/apps/core/src/helpers/chat-room-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-room-message-notifications.test.ts
@@ -5,12 +5,12 @@ const {
   createNotificationMock,
   workspaceFindUniqueMock,
   membershipFindManyMock,
-  preferenceFindManyMock,
+  userFindManyMock,
 } = vi.hoisted(() => ({
   createNotificationMock: vi.fn(),
   workspaceFindUniqueMock: vi.fn(),
   membershipFindManyMock: vi.fn(),
-  preferenceFindManyMock: vi.fn(),
+  userFindManyMock: vi.fn(),
 }));
 
 vi.mock("@/helpers/notifications", () => ({
@@ -19,15 +19,9 @@ vi.mock("@/helpers/notifications", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    workspace: {
-      findUnique: workspaceFindUniqueMock,
-    },
-    chatRoomUserMember: {
-      findMany: membershipFindManyMock,
-    },
-    notificationPreference: {
-      findMany: preferenceFindManyMock,
-    },
+    workspace: { findUnique: workspaceFindUniqueMock },
+    chatRoomUserMember: { findMany: membershipFindManyMock },
+    user: { findMany: userFindManyMock },
   },
 }));
 
@@ -35,10 +29,7 @@ vi.mock("@sentry/node", () => ({
   captureException: vi.fn(),
 }));
 
-import {
-  emitChatRoomMessageNotifications,
-  shouldEmitChatRoomMessageNotifications,
-} from "./chat-room-message-notifications";
+import { emitChatRoomMessageNotifications } from "./chat-room-message-notifications";
 
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440002";
@@ -47,25 +38,35 @@ const SUBSCRIBER_ID = "user_alice";
 const QUIET_ID = "user_bob";
 const MENTIONED_ID = "user_carol";
 
-/** Members of the room, as the membership query returns them. */
-function members(...userIds: string[]) {
-  return userIds.map((userId) => ({ userId }));
+/** A reader who turned every message in a room on, both channels. */
+function subscriber(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    pushOptIn: true,
+    notificationPreferences: [
+      { category: "CHAT_ROOM_MESSAGE", channel: "IN_APP", enabled: true },
+      { category: "CHAT_ROOM_MESSAGE", channel: "OS_BANNER", enabled: true },
+    ],
+    ...overrides,
+  };
 }
 
-/** The rows of readers who turned every message in a room on. */
-function optedIn(...userIds: string[]) {
-  return userIds.map((userId) => ({ userId }));
+/** A reader who never opened the settings page: the row is off by default. */
+function stranger(id: string) {
+  return { id, pushOptIn: true, notificationPreferences: [] };
 }
 
-function emit(excludeUserIds?: string[]) {
+function emit(overrides: Record<string, unknown> = {}) {
   return emitChatRoomMessageNotifications({
     roomId: ROOM_ID,
     roomName: "general",
+    roomKind: "channel",
     organizationId: "org_1",
     messageId: MESSAGE_ID,
     authorUserId: AUTHOR_ID,
     authorName: "Ada",
-    ...(excludeUserIds ? { excludeUserIds } : {}),
+    memberUserIds: [AUTHOR_ID, SUBSCRIBER_ID],
+    ...overrides,
   });
 }
 
@@ -74,31 +75,11 @@ beforeEach(() => {
   createNotificationMock.mockResolvedValue({ created: true });
   workspaceFindUniqueMock.mockResolvedValue({ id: "workspace_1" });
   membershipFindManyMock.mockResolvedValue([]);
-  preferenceFindManyMock.mockResolvedValue([]);
-});
-
-describe("shouldEmitChatRoomMessageNotifications", () => {
-  it("covers a channel", () => {
-    expect(shouldEmitChatRoomMessageNotifications({ kind: "channel" })).toBe(
-      true,
-    );
-  });
-
-  /** A direct message has its own row, and must not arrive twice. */
-  it("leaves a direct room alone", () => {
-    expect(shouldEmitChatRoomMessageNotifications({ kind: "direct" })).toBe(
-      false,
-    );
-  });
+  userFindManyMock.mockResolvedValue([subscriber(SUBSCRIBER_ID)]);
 });
 
 describe("emitChatRoomMessageNotifications", () => {
   it("notifies the members who asked for every message", async () => {
-    membershipFindManyMock
-      .mockResolvedValueOnce(members(AUTHOR_ID, SUBSCRIBER_ID, QUIET_ID))
-      .mockResolvedValueOnce([]);
-    preferenceFindManyMock.mockResolvedValue(optedIn(SUBSCRIBER_ID));
-
     await emit();
 
     expect(createNotificationMock).toHaveBeenCalledTimes(1);
@@ -118,43 +99,82 @@ describe("emitChatRoomMessageNotifications", () => {
    * never opened the settings page writes nothing at all.
    */
   it("writes nothing when nobody turned the row on", async () => {
-    membershipFindManyMock.mockResolvedValue(
-      members(AUTHOR_ID, SUBSCRIBER_ID, QUIET_ID),
-    );
+    userFindManyMock.mockResolvedValue([
+      stranger(SUBSCRIBER_ID),
+      stranger(QUIET_ID),
+    ]);
+
+    await emit({ memberUserIds: [AUTHOR_ID, SUBSCRIBER_ID, QUIET_ID] });
+
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The banner is the only channel this reader kept, and account-wide push is
+   * off, so nothing would reach them. Writing the row anyway would add one
+   * notification per member per message that no surface ever shows.
+   */
+  it("writes nothing for a reader whose only channel is a banner they cannot receive", async () => {
+    userFindManyMock.mockResolvedValue([
+      subscriber(SUBSCRIBER_ID, {
+        pushOptIn: false,
+        notificationPreferences: [
+          { category: "CHAT_ROOM_MESSAGE", channel: "IN_APP", enabled: false },
+          {
+            category: "CHAT_ROOM_MESSAGE",
+            channel: "OS_BANNER",
+            enabled: true,
+          },
+        ],
+      }),
+    ]);
 
     await emit();
 
     expect(createNotificationMock).not.toHaveBeenCalled();
   });
 
-  it("asks only about the members of this room", async () => {
-    membershipFindManyMock
-      .mockResolvedValueOnce(members(AUTHOR_ID, SUBSCRIBER_ID))
-      .mockResolvedValueOnce([]);
-    preferenceFindManyMock.mockResolvedValue(optedIn(SUBSCRIBER_ID));
+  it("asks only about the members of this room, and never about the author", async () => {
+    await emit({ memberUserIds: [AUTHOR_ID, SUBSCRIBER_ID] });
 
-    await emit();
-
-    expect(preferenceFindManyMock).toHaveBeenCalledWith({
-      where: {
-        userId: { in: [SUBSCRIBER_ID] },
-        category: "CHAT_ROOM_MESSAGE",
-        enabled: true,
+    expect(userFindManyMock).toHaveBeenCalledWith({
+      where: { id: { in: [SUBSCRIBER_ID] } },
+      select: {
+        id: true,
+        pushOptIn: true,
+        notificationPreferences: {
+          select: { category: true, channel: true, enabled: true },
+        },
       },
-      select: { userId: true },
     });
   });
 
-  /** The mention already arrived, so the same message must not arrive again. */
-  it("skips a member the caller has already notified", async () => {
+  it("reads this room's members when the caller has none to give", async () => {
+    // The roster, then the mute check the fan-out makes with the same model.
     membershipFindManyMock
-      .mockResolvedValueOnce(members(AUTHOR_ID, SUBSCRIBER_ID, MENTIONED_ID))
+      .mockResolvedValueOnce([{ userId: AUTHOR_ID }, { userId: SUBSCRIBER_ID }])
       .mockResolvedValueOnce([]);
-    preferenceFindManyMock.mockResolvedValue(
-      optedIn(SUBSCRIBER_ID, MENTIONED_ID),
-    );
 
-    await emit([MENTIONED_ID]);
+    await emit({ memberUserIds: undefined });
+
+    expect(membershipFindManyMock).toHaveBeenCalledWith({
+      where: { roomId: ROOM_ID },
+      select: { userId: true },
+    });
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  /** The mention already arrived, so the same message must not arrive twice. */
+  it("skips a member whose mention reaches them", async () => {
+    userFindManyMock.mockResolvedValue([
+      subscriber(SUBSCRIBER_ID),
+      subscriber(MENTIONED_ID),
+    ]);
+
+    await emit({
+      memberUserIds: [AUTHOR_ID, SUBSCRIBER_ID, MENTIONED_ID],
+      mentionedUserIds: [MENTIONED_ID],
+    });
 
     expect(createNotificationMock).toHaveBeenCalledTimes(1);
     expect(createNotificationMock).toHaveBeenCalledWith(
@@ -162,11 +182,64 @@ describe("emitChatRoomMessageNotifications", () => {
     );
   });
 
+  /**
+   * Mentions off, every message on. Skipping this reader because the message
+   * named them would leave them hearing about every message in the room except
+   * the one addressed to them.
+   */
+  it("notifies a mentioned member who silenced mentions", async () => {
+    userFindManyMock.mockResolvedValue([
+      subscriber(MENTIONED_ID, {
+        notificationPreferences: [
+          { category: "CHAT_ROOM_MESSAGE", channel: "IN_APP", enabled: true },
+          {
+            category: "CHAT_ROOM_MESSAGE",
+            channel: "OS_BANNER",
+            enabled: true,
+          },
+          { category: "CHAT_MENTION", channel: "IN_APP", enabled: false },
+          { category: "CHAT_MENTION", channel: "OS_BANNER", enabled: false },
+        ],
+      }),
+    ]);
+
+    await emit({
+      memberUserIds: [AUTHOR_ID, MENTIONED_ID],
+      mentionedUserIds: [MENTIONED_ID],
+    });
+
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: MENTIONED_ID }),
+    );
+  });
+
+  /** Two humans in a direct room: the direct-message row carries the message. */
+  it("leaves a direct room to the direct-message row", async () => {
+    await emit({ roomKind: "direct" });
+
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The direct-message row stops at two humans, so a bigger direct room is a
+   * room like any other here. Without this it was the one place a message
+   * reached nobody.
+   */
+  it("covers a direct room the direct-message row has given up on", async () => {
+    userFindManyMock.mockResolvedValue([subscriber(SUBSCRIBER_ID)]);
+
+    await emit({
+      roomKind: "direct",
+      memberUserIds: [AUTHOR_ID, SUBSCRIBER_ID, QUIET_ID],
+    });
+
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: SUBSCRIBER_ID }),
+    );
+  });
+
   it("skips a member who muted the room", async () => {
-    membershipFindManyMock
-      .mockResolvedValueOnce(members(AUTHOR_ID, SUBSCRIBER_ID))
-      .mockResolvedValueOnce(members(SUBSCRIBER_ID));
-    preferenceFindManyMock.mockResolvedValue(optedIn(SUBSCRIBER_ID));
+    membershipFindManyMock.mockResolvedValue([{ userId: SUBSCRIBER_ID }]);
 
     await emit();
 
@@ -174,13 +247,11 @@ describe("emitChatRoomMessageNotifications", () => {
   });
 
   it("never notifies the author of their own message", async () => {
-    membershipFindManyMock
-      .mockResolvedValueOnce(members(AUTHOR_ID))
-      .mockResolvedValueOnce([]);
-    preferenceFindManyMock.mockResolvedValue(optedIn(AUTHOR_ID));
+    userFindManyMock.mockResolvedValue([subscriber(AUTHOR_ID)]);
 
-    await emit();
+    await emit({ memberUserIds: [AUTHOR_ID] });
 
+    expect(userFindManyMock).not.toHaveBeenCalled();
     expect(createNotificationMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/helpers/chat-room-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-room-message-notifications.test.ts
@@ -1,0 +1,186 @@
+import { NotificationKind } from "@sokosumi/database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createNotificationMock,
+  workspaceFindUniqueMock,
+  membershipFindManyMock,
+  preferenceFindManyMock,
+} = vi.hoisted(() => ({
+  createNotificationMock: vi.fn(),
+  workspaceFindUniqueMock: vi.fn(),
+  membershipFindManyMock: vi.fn(),
+  preferenceFindManyMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/notifications", () => ({
+  createNotification: (...args: unknown[]) => createNotificationMock(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    workspace: {
+      findUnique: workspaceFindUniqueMock,
+    },
+    chatRoomUserMember: {
+      findMany: membershipFindManyMock,
+    },
+    notificationPreference: {
+      findMany: preferenceFindManyMock,
+    },
+  },
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+}));
+
+import {
+  emitChatRoomMessageNotifications,
+  shouldEmitChatRoomMessageNotifications,
+} from "./chat-room-message-notifications";
+
+const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
+const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440002";
+const AUTHOR_ID = "user_author";
+const SUBSCRIBER_ID = "user_alice";
+const QUIET_ID = "user_bob";
+const MENTIONED_ID = "user_carol";
+
+/** Members of the room, as the membership query returns them. */
+function members(...userIds: string[]) {
+  return userIds.map((userId) => ({ userId }));
+}
+
+/** The rows of readers who turned every message in a room on. */
+function optedIn(...userIds: string[]) {
+  return userIds.map((userId) => ({ userId }));
+}
+
+function emit(excludeUserIds?: string[]) {
+  return emitChatRoomMessageNotifications({
+    roomId: ROOM_ID,
+    roomName: "general",
+    organizationId: "org_1",
+    messageId: MESSAGE_ID,
+    authorUserId: AUTHOR_ID,
+    authorName: "Ada",
+    ...(excludeUserIds ? { excludeUserIds } : {}),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createNotificationMock.mockResolvedValue({ created: true });
+  workspaceFindUniqueMock.mockResolvedValue({ id: "workspace_1" });
+  membershipFindManyMock.mockResolvedValue([]);
+  preferenceFindManyMock.mockResolvedValue([]);
+});
+
+describe("shouldEmitChatRoomMessageNotifications", () => {
+  it("covers a channel", () => {
+    expect(shouldEmitChatRoomMessageNotifications({ kind: "channel" })).toBe(
+      true,
+    );
+  });
+
+  /** A direct message has its own row, and must not arrive twice. */
+  it("leaves a direct room alone", () => {
+    expect(shouldEmitChatRoomMessageNotifications({ kind: "direct" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("emitChatRoomMessageNotifications", () => {
+  it("notifies the members who asked for every message", async () => {
+    membershipFindManyMock
+      .mockResolvedValueOnce(members(AUTHOR_ID, SUBSCRIBER_ID, QUIET_ID))
+      .mockResolvedValueOnce([]);
+    preferenceFindManyMock.mockResolvedValue(optedIn(SUBSCRIBER_ID));
+
+    await emit();
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(createNotificationMock).toHaveBeenCalledWith({
+      userId: SUBSCRIBER_ID,
+      kind: NotificationKind.CHAT,
+      referenceId: ROOM_ID,
+      eventId: MESSAGE_ID,
+      messageKey: "Notifications.Chat.roomMessage",
+      messageParams: { authorName: "Ada", roomName: "general" },
+      metadata: { messageId: MESSAGE_ID, workspaceId: "workspace_1" },
+    });
+  });
+
+  /**
+   * The row is off until the reader turns it on, so a room full of members who
+   * never opened the settings page writes nothing at all.
+   */
+  it("writes nothing when nobody turned the row on", async () => {
+    membershipFindManyMock.mockResolvedValue(
+      members(AUTHOR_ID, SUBSCRIBER_ID, QUIET_ID),
+    );
+
+    await emit();
+
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("asks only about the members of this room", async () => {
+    membershipFindManyMock
+      .mockResolvedValueOnce(members(AUTHOR_ID, SUBSCRIBER_ID))
+      .mockResolvedValueOnce([]);
+    preferenceFindManyMock.mockResolvedValue(optedIn(SUBSCRIBER_ID));
+
+    await emit();
+
+    expect(preferenceFindManyMock).toHaveBeenCalledWith({
+      where: {
+        userId: { in: [SUBSCRIBER_ID] },
+        category: "CHAT_ROOM_MESSAGE",
+        enabled: true,
+      },
+      select: { userId: true },
+    });
+  });
+
+  /** The mention already arrived, so the same message must not arrive again. */
+  it("skips a member the caller has already notified", async () => {
+    membershipFindManyMock
+      .mockResolvedValueOnce(members(AUTHOR_ID, SUBSCRIBER_ID, MENTIONED_ID))
+      .mockResolvedValueOnce([]);
+    preferenceFindManyMock.mockResolvedValue(
+      optedIn(SUBSCRIBER_ID, MENTIONED_ID),
+    );
+
+    await emit([MENTIONED_ID]);
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: SUBSCRIBER_ID }),
+    );
+  });
+
+  it("skips a member who muted the room", async () => {
+    membershipFindManyMock
+      .mockResolvedValueOnce(members(AUTHOR_ID, SUBSCRIBER_ID))
+      .mockResolvedValueOnce(members(SUBSCRIBER_ID));
+    preferenceFindManyMock.mockResolvedValue(optedIn(SUBSCRIBER_ID));
+
+    await emit();
+
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("never notifies the author of their own message", async () => {
+    membershipFindManyMock
+      .mockResolvedValueOnce(members(AUTHOR_ID))
+      .mockResolvedValueOnce([]);
+    preferenceFindManyMock.mockResolvedValue(optedIn(AUTHOR_ID));
+
+    await emit();
+
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/helpers/chat-room-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-room-message-notifications.test.ts
@@ -134,6 +134,41 @@ describe("emitChatRoomMessageNotifications", () => {
     expect(createNotificationMock).not.toHaveBeenCalled();
   });
 
+  /**
+   * The other half of the same question: one channel is enough. A reader who
+   * kept only the banner and opted in to push hears about the message, and so
+   * does one who kept only the in-app row.
+   */
+  it("notifies a reader who kept one channel of the two", async () => {
+    userFindManyMock.mockResolvedValue([
+      subscriber(SUBSCRIBER_ID, {
+        notificationPreferences: [
+          { category: "CHAT_ROOM_MESSAGE", channel: "IN_APP", enabled: false },
+          {
+            category: "CHAT_ROOM_MESSAGE",
+            channel: "OS_BANNER",
+            enabled: true,
+          },
+        ],
+      }),
+      subscriber(QUIET_ID, {
+        pushOptIn: false,
+        notificationPreferences: [
+          { category: "CHAT_ROOM_MESSAGE", channel: "IN_APP", enabled: true },
+          {
+            category: "CHAT_ROOM_MESSAGE",
+            channel: "OS_BANNER",
+            enabled: false,
+          },
+        ],
+      }),
+    ]);
+
+    await emit({ memberUserIds: [AUTHOR_ID, SUBSCRIBER_ID, QUIET_ID] });
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
   it("asks only about the members of this room, and never about the author", async () => {
     await emit({ memberUserIds: [AUTHOR_ID, SUBSCRIBER_ID] });
 

--- a/apps/core/src/helpers/chat-room-message-notifications.ts
+++ b/apps/core/src/helpers/chat-room-message-notifications.ts
@@ -1,95 +1,122 @@
-import { CHAT_ROOM_MESSAGE_MESSAGE_KEY } from "@/helpers/notification-delivery";
+import type { NotificationCategory } from "@sokosumi/utils";
+import {
+  CHAT_ROOM_MESSAGE_MESSAGE_KEY,
+  resolveNotificationDelivery,
+} from "@/helpers/notification-delivery";
 import prisma from "@/lib/db/prisma";
 
+import { shouldEmitChatDirectMessageNotifications } from "./chat-direct-message-notifications";
 import { fanOutChatNotifications } from "./chat-notification-fanout";
 
-export interface ShouldEmitChatRoomMessageNotificationsParams {
-  kind: string;
+/** A reader, with everything the delivery decision needs. */
+interface Reader {
+  id: string;
+  pushOptIn: boolean;
+  notificationPreferences: {
+    category: string;
+    channel: string;
+    enabled: boolean;
+  }[];
 }
 
-/**
- * Direct rooms are excluded: their messages already have their own row, and a
- * reader who turned direct messages off should not receive the same message
- * again as a room message.
- */
-export function shouldEmitChatRoomMessageNotifications(
-  params: ShouldEmitChatRoomMessageNotificationsParams,
-): boolean {
-  return params.kind !== "direct";
-}
-
-/**
- * The members who asked to hear about every message in this room.
- *
- * `CHAT_ROOM_MESSAGE` is off until the reader turns it on
- * (`NOTIFICATION_CATEGORY_OFF_BY_DEFAULT`), so an absent row means no and a
- * stored row that is off means no. Asked as one query before anything is
- * written, because the alternative is a notification row per member per
- * message that nobody reads.
- */
-async function readersWhoAskedForEveryMessage(
-  userIds: readonly string[],
-): Promise<string[]> {
-  if (userIds.length === 0) {
-    return [];
-  }
-
-  const optedIn = await prisma.notificationPreference.findMany({
-    where: {
-      userId: { in: [...userIds] },
-      category: "CHAT_ROOM_MESSAGE",
-      enabled: true,
-    },
-    select: { userId: true },
+/** Whether a notification of this category would reach the reader at all. */
+function arrives(reader: Reader, category: NotificationCategory): boolean {
+  const delivery = resolveNotificationDelivery({
+    category,
+    preferences: reader.notificationPreferences,
+    pushOptIn: reader.pushOptIn,
   });
-  const optedInUserIds = new Set(
-    optedIn.map((preference) => preference.userId),
-  );
 
-  return userIds.filter((userId) => optedInUserIds.has(userId));
+  return delivery.inApp || delivery.osBanner;
 }
 
 export interface EmitChatRoomMessageNotificationsParams {
   roomId: string;
   roomName: string;
+  /** Decides whether the direct-message row already covers this room. */
+  roomKind: string;
   organizationId: string | null;
   messageId: string;
   /** Human author to skip. Null when the author is a coworker. */
   authorUserId: string | null;
   authorName: string;
-  /**
-   * Members already notified about this message, such as the ones it names.
-   * The author is dropped here too, so nobody is asked about a preference for
-   * a notification they were never going to receive.
-   */
-  excludeUserIds?: readonly string[];
+  /** The room's humans, when the caller already read them. */
+  memberUserIds?: readonly string[];
+  /** The members this message named, who were sent a mention of their own. */
+  mentionedUserIds?: readonly string[];
 }
 
 /**
  * Emit CHAT notifications for every message in a room, for the members who
  * asked for them. Schedule via waitUntil.
  *
- * The members are read here rather than passed in, so a room that nobody
- * subscribed to costs the request nothing: both queries run inside the
- * scheduled work. The caller names the members it has already notified about
- * this message, so a mention arrives once rather than twice.
+ * Three questions decide who hears about a message, and all three are asked
+ * before anything is written:
+ *
+ * A direct room the direct-message row already covers is left alone, so one
+ * message never arrives twice. That row stops at two humans
+ * (`shouldEmitChatDirectMessageNotifications`), so a direct room with more
+ * than two is a room like any other here rather than a room nobody hears from.
+ *
+ * A member who was named in the message is skipped only when the mention
+ * actually reaches them. A reader who silenced mentions and asked for every
+ * message would otherwise hear about every message in the room except the one
+ * addressed to them.
+ *
+ * The rest are kept only when this category would reach them, asked through
+ * the same `resolveNotificationDelivery` that decides delivery at write time.
+ * A gate that asked a looser question would write a notification row per member
+ * per message that no surface ever shows.
  */
 export async function emitChatRoomMessageNotifications(
   params: EmitChatRoomMessageNotificationsParams,
 ): Promise<void> {
-  const excluded = new Set([
-    ...(params.excludeUserIds ?? []),
-    ...(params.authorUserId === null ? [] : [params.authorUserId]),
-  ]);
-  const members = await prisma.chatRoomUserMember.findMany({
-    where: { roomId: params.roomId },
-    select: { userId: true },
+  const memberUserIds =
+    params.memberUserIds ??
+    (
+      await prisma.chatRoomUserMember.findMany({
+        where: { roomId: params.roomId },
+        select: { userId: true },
+      })
+    ).map((member) => member.userId);
+
+  if (
+    shouldEmitChatDirectMessageNotifications({
+      kind: params.roomKind,
+      memberUserIds,
+    })
+  ) {
+    return;
+  }
+
+  const candidateUserIds = [
+    ...new Set(
+      memberUserIds.filter((userId) => userId !== params.authorUserId),
+    ),
+  ];
+
+  if (candidateUserIds.length === 0) {
+    return;
+  }
+
+  const readers: Reader[] = await prisma.user.findMany({
+    where: { id: { in: candidateUserIds } },
+    select: {
+      id: true,
+      pushOptIn: true,
+      notificationPreferences: {
+        select: { category: true, channel: true, enabled: true },
+      },
+    },
   });
-  const recipientUserIds = await readersWhoAskedForEveryMessage(
-    members
-      .map((member) => member.userId)
-      .filter((userId) => !excluded.has(userId)),
-  );
+  const mentioned = new Set(params.mentionedUserIds ?? []);
+  const recipientUserIds = readers
+    .filter(
+      (reader) =>
+        arrives(reader, "CHAT_ROOM_MESSAGE") &&
+        !(mentioned.has(reader.id) && arrives(reader, "CHAT_MENTION")),
+    )
+    .map((reader) => reader.id);
 
   if (recipientUserIds.length === 0) {
     return;

--- a/apps/core/src/helpers/chat-room-message-notifications.ts
+++ b/apps/core/src/helpers/chat-room-message-notifications.ts
@@ -1,0 +1,109 @@
+import { CHAT_ROOM_MESSAGE_MESSAGE_KEY } from "@/helpers/notification-delivery";
+import prisma from "@/lib/db/prisma";
+
+import { fanOutChatNotifications } from "./chat-notification-fanout";
+
+export interface ShouldEmitChatRoomMessageNotificationsParams {
+  kind: string;
+}
+
+/**
+ * Direct rooms are excluded: their messages already have their own row, and a
+ * reader who turned direct messages off should not receive the same message
+ * again as a room message.
+ */
+export function shouldEmitChatRoomMessageNotifications(
+  params: ShouldEmitChatRoomMessageNotificationsParams,
+): boolean {
+  return params.kind !== "direct";
+}
+
+/**
+ * The members who asked to hear about every message in this room.
+ *
+ * `CHAT_ROOM_MESSAGE` is off until the reader turns it on
+ * (`NOTIFICATION_CATEGORY_OFF_BY_DEFAULT`), so an absent row means no and a
+ * stored row that is off means no. Asked as one query before anything is
+ * written, because the alternative is a notification row per member per
+ * message that nobody reads.
+ */
+async function readersWhoAskedForEveryMessage(
+  userIds: readonly string[],
+): Promise<string[]> {
+  if (userIds.length === 0) {
+    return [];
+  }
+
+  const optedIn = await prisma.notificationPreference.findMany({
+    where: {
+      userId: { in: [...userIds] },
+      category: "CHAT_ROOM_MESSAGE",
+      enabled: true,
+    },
+    select: { userId: true },
+  });
+  const optedInUserIds = new Set(
+    optedIn.map((preference) => preference.userId),
+  );
+
+  return userIds.filter((userId) => optedInUserIds.has(userId));
+}
+
+export interface EmitChatRoomMessageNotificationsParams {
+  roomId: string;
+  roomName: string;
+  organizationId: string | null;
+  messageId: string;
+  /** Human author to skip. Null when the author is a coworker. */
+  authorUserId: string | null;
+  authorName: string;
+  /**
+   * Members already notified about this message, such as the ones it names.
+   * The author is dropped here too, so nobody is asked about a preference for
+   * a notification they were never going to receive.
+   */
+  excludeUserIds?: readonly string[];
+}
+
+/**
+ * Emit CHAT notifications for every message in a room, for the members who
+ * asked for them. Schedule via waitUntil.
+ *
+ * The members are read here rather than passed in, so a room that nobody
+ * subscribed to costs the request nothing: both queries run inside the
+ * scheduled work. The caller names the members it has already notified about
+ * this message, so a mention arrives once rather than twice.
+ */
+export async function emitChatRoomMessageNotifications(
+  params: EmitChatRoomMessageNotificationsParams,
+): Promise<void> {
+  const excluded = new Set([
+    ...(params.excludeUserIds ?? []),
+    ...(params.authorUserId === null ? [] : [params.authorUserId]),
+  ]);
+  const members = await prisma.chatRoomUserMember.findMany({
+    where: { roomId: params.roomId },
+    select: { userId: true },
+  });
+  const recipientUserIds = await readersWhoAskedForEveryMessage(
+    members
+      .map((member) => member.userId)
+      .filter((userId) => !excluded.has(userId)),
+  );
+
+  if (recipientUserIds.length === 0) {
+    return;
+  }
+
+  await fanOutChatNotifications({
+    roomId: params.roomId,
+    roomName: params.roomName,
+    organizationId: params.organizationId,
+    messageId: params.messageId,
+    authorUserId: params.authorUserId,
+    authorName: params.authorName,
+    recipientUserIds,
+    messageKey: CHAT_ROOM_MESSAGE_MESSAGE_KEY,
+    notificationType: "chat-room-message-notification",
+  });
+}

--- a/apps/core/src/helpers/notification-delivery.test.ts
+++ b/apps/core/src/helpers/notification-delivery.test.ts
@@ -109,6 +109,15 @@ describe("toNotificationCategory", () => {
     ).toBe("CHAT_DIRECT_MESSAGE");
   });
 
+  it("gives every message in a room its own row", () => {
+    expect(
+      toNotificationCategory(
+        NotificationKind.CHAT,
+        "Notifications.Chat.roomMessage",
+      ),
+    ).toBe("CHAT_ROOM_MESSAGE");
+  });
+
   it("has no category for a chat key it does not know", () => {
     expect(
       toNotificationCategory(NotificationKind.CHAT, "Notifications.Chat.wat"),
@@ -227,6 +236,35 @@ describe("resolveNotificationDelivery", () => {
   });
 });
 
+describe("resolveNotificationDelivery for every message in a room", () => {
+  it("delivers nothing for a reader who stored nothing", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: "CHAT_ROOM_MESSAGE",
+        preferences: [],
+        pushOptIn: true,
+      }),
+    ).toEqual({ inApp: false, osBanner: false });
+  });
+
+  it("delivers once the reader turns the row on", () => {
+    expect(
+      resolveNotificationDelivery({
+        category: "CHAT_ROOM_MESSAGE",
+        preferences: [
+          { category: "CHAT_ROOM_MESSAGE", channel: "IN_APP", enabled: true },
+          {
+            category: "CHAT_ROOM_MESSAGE",
+            channel: "OS_BANNER",
+            enabled: true,
+          },
+        ],
+        pushOptIn: true,
+      }),
+    ).toEqual({ inApp: true, osBanner: true });
+  });
+});
+
 describe("resolveNotificationMatrix", () => {
   it("answers for every cell, so the reader sees a complete matrix", () => {
     const matrix = resolveNotificationMatrix([]);
@@ -234,10 +272,46 @@ describe("resolveNotificationMatrix", () => {
     expect(matrix).toHaveLength(
       NOTIFICATION_CATEGORIES.length * NOTIFICATION_CHANNELS.length,
     );
-    expect(matrix.every((cell) => cell.enabled)).toBe(true);
+    expect(
+      matrix
+        .filter((cell) => cell.category !== "CHAT_ROOM_MESSAGE")
+        .every((cell) => cell.enabled),
+    ).toBe(true);
     expect(matrix).toContainEqual({
       category: "CHAT_MENTION",
       channel: "OS_BANNER",
+      enabled: true,
+    });
+  });
+
+  /**
+   * Every message in a room is the one row nobody receives today, so it is the
+   * one row that starts off. Reading it as on would turn a busy room into a
+   * stream of notifications for readers who never opened this page.
+   */
+  it("leaves every message in a room off until the reader asks", () => {
+    const matrix = resolveNotificationMatrix([]);
+
+    expect(matrix).toContainEqual({
+      category: "CHAT_ROOM_MESSAGE",
+      channel: "IN_APP",
+      enabled: false,
+    });
+    expect(matrix).toContainEqual({
+      category: "CHAT_ROOM_MESSAGE",
+      channel: "OS_BANNER",
+      enabled: false,
+    });
+  });
+
+  it("gives every message in a room the reader's own answer once they store one", () => {
+    const matrix = resolveNotificationMatrix([
+      { category: "CHAT_ROOM_MESSAGE", channel: "IN_APP", enabled: true },
+    ]);
+
+    expect(matrix).toContainEqual({
+      category: "CHAT_ROOM_MESSAGE",
+      channel: "IN_APP",
       enabled: true,
     });
   });
@@ -272,6 +346,10 @@ describe("resolveNotificationMatrix", () => {
     expect(matrix).toHaveLength(
       NOTIFICATION_CATEGORIES.length * NOTIFICATION_CHANNELS.length,
     );
-    expect(matrix.every((cell) => cell.enabled)).toBe(true);
+    expect(
+      matrix
+        .filter((cell) => cell.category !== "CHAT_ROOM_MESSAGE")
+        .every((cell) => cell.enabled),
+    ).toBe(true);
   });
 });

--- a/apps/core/src/helpers/notification-delivery.ts
+++ b/apps/core/src/helpers/notification-delivery.ts
@@ -1,10 +1,10 @@
 import type { NotificationKind } from "@sokosumi/database";
 import {
   NOTIFICATION_CATEGORIES,
-  NOTIFICATION_CHANNEL_DEFAULT,
   NOTIFICATION_CHANNELS,
   type NotificationCategory,
   type NotificationChannel,
+  notificationDefault,
 } from "@sokosumi/utils";
 
 /** The message key an @mention carries. Read by the category mapping below. */
@@ -13,6 +13,7 @@ export const CHAT_MENTION_MESSAGE_KEY = "Notifications.Chat.mentioned";
 /** The message key a direct message carries. */
 export const CHAT_DIRECT_MESSAGE_MESSAGE_KEY =
   "Notifications.Chat.directMessage";
+export const CHAT_ROOM_MESSAGE_MESSAGE_KEY = "Notifications.Chat.roomMessage";
 
 /**
  * The task keys that wait on the reader.
@@ -97,6 +98,9 @@ export function toNotificationCategory(
       if (messageKey === CHAT_DIRECT_MESSAGE_MESSAGE_KEY) {
         return "CHAT_DIRECT_MESSAGE";
       }
+      if (messageKey === CHAT_ROOM_MESSAGE_MESSAGE_KEY) {
+        return "CHAT_ROOM_MESSAGE";
+      }
       return null;
     default:
       return null;
@@ -113,7 +117,7 @@ function isEnabled(
       preference.category === category && preference.channel === channel,
   );
 
-  return stored?.enabled ?? NOTIFICATION_CHANNEL_DEFAULT[channel];
+  return stored?.enabled ?? notificationDefault(category, channel);
 }
 
 /**

--- a/apps/core/src/helpers/notifications.test.ts
+++ b/apps/core/src/helpers/notifications.test.ts
@@ -479,7 +479,7 @@ describe("createNotification push gating", () => {
     );
   });
 
-  it("splits the two chat rows, so muting mentions leaves direct messages alone", async () => {
+  it("splits the chat rows, so muting mentions leaves direct messages alone", async () => {
     const prismaMock = createPrismaMock();
     prismaMock.notification.create.mockResolvedValue(createChatRecord());
     mockReader({

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -489,9 +489,13 @@ describe("POST /chats/rooms/{id}/messages", () => {
         authorName: "Hannah",
         recipientUserIds: [ALICE_ID],
       });
-      // A direct room has its own row, so nothing is emitted as a room message.
-      expect(emitChatRoomMessageNotificationsMock).not.toHaveBeenCalled();
-      expect(waitUntilMock).toHaveBeenCalledTimes(2);
+      // Scheduled for every room. The emitter reads the roster and leaves a
+      // direct room of two to the direct-message row, which is the only place
+      // that decision can see how many humans are in it.
+      expect(emitChatRoomMessageNotificationsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ roomKind: "direct" }),
+      );
+      expect(waitUntilMock).toHaveBeenCalledTimes(3);
     });
 
     it("emits a room message for coworker posts in a channel", async () => {
@@ -518,6 +522,7 @@ describe("POST /chats/rooms/{id}/messages", () => {
       expect(emitChatRoomMessageNotificationsMock).toHaveBeenCalledWith({
         roomId: ROOM_ID,
         roomName: "general",
+        roomKind: "channel",
         organizationId: "org_1",
         messageId: MESSAGE_ID,
         authorUserId: null,
@@ -609,7 +614,49 @@ describe("POST /chats/rooms/{id}/messages", () => {
       );
       expect(dispatchMock).not.toHaveBeenCalled();
       expect(scheduleUnfurlsMock).toHaveBeenCalledWith(MESSAGE_ID);
-      expect(waitUntilMock).toHaveBeenCalledTimes(1);
+      // The unfurl, and the room message the subscribed members asked for.
+      expect(waitUntilMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("room message notifications", () => {
+    /**
+     * The human path hands the emitter what it read inside the write
+     * transaction: the roster the message was posted against, and the members
+     * it named. Without the names, a mentioned reader is notified twice.
+     */
+    it("tells the emitter who was posted to and who was named", async () => {
+      roomFindFirstMock.mockResolvedValue(
+        roomWithMembers({
+          userMembers: [
+            { userId: USER_ID, user: { name: "Patrick" } },
+            { userId: ALICE_ID, user: { name: "Alice" } },
+            { userId: BOB_ID, user: { name: "Bob" } },
+          ],
+          coworkerMembers: [],
+        }),
+      );
+      messageCreateMock.mockResolvedValue(
+        createdMessage({ senderUserId: USER_ID }),
+      );
+
+      const app = createApp(userAuthContext);
+      const response = await app.request(`/${ROOM_ID}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "hello @alice" }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(emitChatRoomMessageNotificationsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roomId: ROOM_ID,
+          roomKind: "channel",
+          authorUserId: USER_ID,
+          memberUserIds: [USER_ID, ALICE_ID, BOB_ID],
+          mentionedUserIds: [ALICE_ID],
+        }),
+      );
     });
   });
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -503,6 +503,44 @@ describe("POST /chats/rooms/{id}/messages", () => {
       expect(waitUntilMock).toHaveBeenCalledTimes(3);
     });
 
+    /**
+     * The direct-message row stops at two humans, so a direct room of three
+     * belongs to the room-message emitter alone. Both decisions read the same
+     * roster, and only the count tells them apart.
+     */
+    it("leaves a direct room of three humans to the room message", async () => {
+      roomFindFirstMock.mockResolvedValue({
+        id: ROOM_ID,
+        name: "Hannah",
+        kind: "direct",
+        organizationId: "org_1",
+      });
+      membershipFindManyMock.mockResolvedValue([
+        { userId: ALICE_ID },
+        { userId: BOB_ID },
+        { userId: USER_ID },
+      ]);
+      messageCreateMock.mockResolvedValue(
+        createdMessage({ senderCoworkerId: COWORKER_ID }),
+      );
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request(`/${ROOM_ID}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "you were assigned a task" }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
+      expect(emitChatRoomMessageNotificationsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roomKind: "direct",
+          memberUserIds: [ALICE_ID, BOB_ID, USER_ID],
+        }),
+      );
+    });
+
     it("emits a room message for coworker posts in a channel", async () => {
       roomFindFirstMock.mockResolvedValue({
         id: ROOM_ID,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -489,12 +489,17 @@ describe("POST /chats/rooms/{id}/messages", () => {
         authorName: "Hannah",
         recipientUserIds: [ALICE_ID],
       });
-      // Scheduled for every room. The emitter reads the roster and leaves a
-      // direct room of two to the direct-message row, which is the only place
-      // that decision can see how many humans are in it.
+      // Scheduled for every room. The emitter leaves a direct room of two to
+      // the direct-message row, which is the only place that decision can see
+      // how many humans are in it. The roster this route already read goes
+      // with it, so the emitter does not ask for it again.
       expect(emitChatRoomMessageNotificationsMock).toHaveBeenCalledWith(
-        expect.objectContaining({ roomKind: "direct" }),
+        expect.objectContaining({
+          roomKind: "direct",
+          memberUserIds: [ALICE_ID],
+        }),
       );
+      expect(membershipFindManyMock).toHaveBeenCalledTimes(1);
       expect(waitUntilMock).toHaveBeenCalledTimes(3);
     });
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -28,6 +28,7 @@ const {
   dispatchMock,
   emitChatMentionNotificationsMock,
   emitChatDirectMessageNotificationsMock,
+  emitChatRoomMessageNotificationsMock,
   waitUntilMock,
   scheduleUnfurlsMock,
 } = vi.hoisted(() => ({
@@ -46,6 +47,7 @@ const {
   dispatchMock: vi.fn(),
   emitChatMentionNotificationsMock: vi.fn(),
   emitChatDirectMessageNotificationsMock: vi.fn(),
+  emitChatRoomMessageNotificationsMock: vi.fn(),
   waitUntilMock: vi.fn(),
   scheduleUnfurlsMock: vi.fn(),
 }));
@@ -96,6 +98,18 @@ vi.mock(
     };
   },
 );
+
+vi.mock("@/helpers/chat-room-message-notifications", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/helpers/chat-room-message-notifications")
+    >();
+  return {
+    ...actual,
+    emitChatRoomMessageNotifications: (...args: unknown[]) =>
+      emitChatRoomMessageNotificationsMock(...args),
+  };
+});
 
 vi.mock("@/helpers/chat-room-message-realtime", () => ({
   publishChatRoomMessageRealtime: vi.fn().mockResolvedValue(undefined),
@@ -425,7 +439,8 @@ describe("POST /chats/rooms/{id}/messages", () => {
       expect(dispatchMock).not.toHaveBeenCalled();
       expect(readStateUpsertMock).not.toHaveBeenCalled();
       expect(scheduleUnfurlsMock).toHaveBeenCalledWith(MESSAGE_ID);
-      expect(waitUntilMock).toHaveBeenCalledTimes(1);
+      // The unfurl, and the room message the subscribed members asked for.
+      expect(waitUntilMock).toHaveBeenCalledTimes(2);
 
       // Membership is enforced in the room lookup itself.
       expect(roomFindFirstMock).toHaveBeenCalledWith(
@@ -474,10 +489,12 @@ describe("POST /chats/rooms/{id}/messages", () => {
         authorName: "Hannah",
         recipientUserIds: [ALICE_ID],
       });
+      // A direct room has its own row, so nothing is emitted as a room message.
+      expect(emitChatRoomMessageNotificationsMock).not.toHaveBeenCalled();
       expect(waitUntilMock).toHaveBeenCalledTimes(2);
     });
 
-    it("does not emit a Direct notification for coworker posts in a channel", async () => {
+    it("emits a room message for coworker posts in a channel", async () => {
       roomFindFirstMock.mockResolvedValue({
         id: ROOM_ID,
         name: "general",
@@ -498,7 +515,15 @@ describe("POST /chats/rooms/{id}/messages", () => {
       expect(response.status).toBe(201);
       expect(membershipFindManyMock).not.toHaveBeenCalled();
       expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
-      expect(waitUntilMock).toHaveBeenCalledTimes(1);
+      expect(emitChatRoomMessageNotificationsMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        roomName: "general",
+        organizationId: "org_1",
+        messageId: MESSAGE_ID,
+        authorUserId: null,
+        authorName: "Hannah",
+      });
+      expect(waitUntilMock).toHaveBeenCalledTimes(2);
     });
 
     it("rejects a coworker that is not a room member", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -5,10 +5,7 @@ import {
   shouldEmitChatDirectMessageNotifications,
 } from "@/helpers/chat-direct-message-notifications";
 import { emitChatMentionNotifications } from "@/helpers/chat-mention-notifications";
-import {
-  emitChatRoomMessageNotifications,
-  shouldEmitChatRoomMessageNotifications,
-} from "@/helpers/chat-room-message-notifications";
+import { emitChatRoomMessageNotifications } from "@/helpers/chat-room-message-notifications";
 import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { conflict } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -173,18 +170,17 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         }
       }
 
-      if (shouldEmitChatRoomMessageNotifications({ kind: room.kind })) {
-        waitUntil(
-          emitChatRoomMessageNotifications({
-            roomId: room.id,
-            roomName: room.name,
-            organizationId: room.organizationId,
-            messageId: message.id,
-            authorUserId: null,
-            authorName: message.senderCoworker?.name ?? "Someone",
-          }),
-        );
-      }
+      waitUntil(
+        emitChatRoomMessageNotifications({
+          roomId: room.id,
+          roomName: room.name,
+          roomKind: room.kind,
+          organizationId: room.organizationId,
+          messageId: message.id,
+          authorUserId: null,
+          authorName: message.senderCoworker?.name ?? "Someone",
+        }),
+      );
 
       return created(
         c,
@@ -500,19 +496,21 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         }
       }
 
-      if (shouldEmitChatRoomMessageNotifications({ kind: room.kind })) {
-        waitUntil(
-          emitChatRoomMessageNotifications({
-            roomId: room.id,
-            roomName: room.name,
-            organizationId: room.organizationId,
-            messageId: message.id,
-            authorUserId: userContext.userId,
-            authorName: message.senderUser?.name ?? "Someone",
-            excludeUserIds: mentionedUserIds,
-          }),
-        );
-      }
+      waitUntil(
+        emitChatRoomMessageNotifications({
+          roomId: room.id,
+          roomName: room.name,
+          roomKind: room.kind,
+          organizationId: room.organizationId,
+          messageId: message.id,
+          authorUserId: userContext.userId,
+          authorName: message.senderUser?.name ?? "Someone",
+          // Read inside the write transaction, so the roster is the one the
+          // message was posted against.
+          memberUserIds: room.memberUserIds,
+          mentionedUserIds,
+        }),
+      );
 
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));
     }

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -1,11 +1,14 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { waitUntil } from "@vercel/functions";
-
 import {
   emitChatDirectMessageNotifications,
   shouldEmitChatDirectMessageNotifications,
 } from "@/helpers/chat-direct-message-notifications";
 import { emitChatMentionNotifications } from "@/helpers/chat-mention-notifications";
+import {
+  emitChatRoomMessageNotifications,
+  shouldEmitChatRoomMessageNotifications,
+} from "@/helpers/chat-room-message-notifications";
 import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { conflict } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -168,6 +171,19 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             }),
           );
         }
+      }
+
+      if (shouldEmitChatRoomMessageNotifications({ kind: room.kind })) {
+        waitUntil(
+          emitChatRoomMessageNotifications({
+            roomId: room.id,
+            roomName: room.name,
+            organizationId: room.organizationId,
+            messageId: message.id,
+            authorUserId: null,
+            authorName: message.senderCoworker?.name ?? "Someone",
+          }),
+        );
       }
 
       return created(
@@ -482,6 +498,20 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             }),
           );
         }
+      }
+
+      if (shouldEmitChatRoomMessageNotifications({ kind: room.kind })) {
+        waitUntil(
+          emitChatRoomMessageNotifications({
+            roomId: room.id,
+            roomName: room.name,
+            organizationId: room.organizationId,
+            messageId: message.id,
+            authorUserId: userContext.userId,
+            authorName: message.senderUser?.name ?? "Someone",
+            excludeUserIds: mentionedUserIds,
+          }),
+        );
       }
 
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -140,34 +140,43 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));
 
-      if (room.kind === "direct") {
-        const memberUserIds = (
-          await prisma.chatRoomUserMember.findMany({
-            where: { roomId: room.id },
-            select: { userId: true },
-          })
-        ).map((member) => member.userId);
+      // Only a direct room needs the roster here, to count the humans in it.
+      // A channel leaves the read to the emitter, which runs after the
+      // response rather than in front of it.
+      const memberUserIds =
+        room.kind === "direct"
+          ? (
+              await prisma.chatRoomUserMember.findMany({
+                where: { roomId: room.id },
+                select: { userId: true },
+              })
+            ).map((member) => member.userId)
+          : undefined;
 
-        if (
-          shouldEmitChatDirectMessageNotifications({
-            kind: room.kind,
-            memberUserIds,
-          })
-        ) {
-          waitUntil(
-            emitChatDirectMessageNotifications({
-              roomId: room.id,
-              roomName: room.name,
-              organizationId: room.organizationId,
-              messageId: message.id,
-              authorUserId: null,
-              authorName: message.senderSokoBot
-                ? sokoBotDisplayName(message.senderSokoBot)
-                : (message.senderCoworker?.name ?? "Someone"),
-              recipientUserIds: memberUserIds,
-            }),
-          );
-        }
+      // The author is a coworker or Soko Bot, never a human, so the
+      // name comes from whichever one sent it.
+      const authorName = message.senderSokoBot
+        ? sokoBotDisplayName(message.senderSokoBot)
+        : (message.senderCoworker?.name ?? "Someone");
+
+      if (
+        memberUserIds &&
+        shouldEmitChatDirectMessageNotifications({
+          kind: room.kind,
+          memberUserIds,
+        })
+      ) {
+        waitUntil(
+          emitChatDirectMessageNotifications({
+            roomId: room.id,
+            roomName: room.name,
+            organizationId: room.organizationId,
+            messageId: message.id,
+            authorUserId: null,
+            authorName,
+            recipientUserIds: memberUserIds,
+          }),
+        );
       }
 
       waitUntil(
@@ -178,7 +187,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           organizationId: room.organizationId,
           messageId: message.id,
           authorUserId: null,
-          authorName: message.senderCoworker?.name ?? "Someone",
+          authorName,
+          // Already read for the direct-message decision, so the emitter is
+          // not asked to read the same roster again.
+          memberUserIds,
         }),
       );
 

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4121,6 +4121,8 @@
         "kindTaskAttentionHint": "Eine Aufgabe steht still, bis du handelst, etwa bei fehlender Freigabe oder fehlenden Credits.",
         "kindTaskUpdate": "Andere Aufgaben-Updates",
         "kindTaskUpdateHint": "Alles andere, was eine Aufgabe meldet, etwa Abschluss oder Abbruch.",
+        "kindChatRoomMessage": "Jede Nachricht in deinen Räumen",
+        "kindChatRoomMessageHint": "Jemand schreibt in einem Raum, in dem du bist. Aus, bis du es einschaltest.",
         "kindChatMention": "Erwähnungen im Chat",
         "kindChatMentionHint": "Jemand nennt dich in einem Chat.",
         "kindChatDirectMessage": "Direktnachrichten",
@@ -4128,7 +4130,7 @@
         "kindSystem": "Anfragen und Zugriff",
         "kindSystemHint": "Jemand fragt nach Zugriff, oder eine Entscheidung trifft ein.",
         "groupChat": "Chat",
-        "groupChatDescription": "Erwähnungen und Direktnachrichten",
+        "groupChatDescription": "Nachrichten im Raum, Erwähnungen und Direktnachrichten",
         "deliveryOff": "Aus",
         "deliveryInApp": "In App",
         "deliveryBanner": "Banner",
@@ -6414,7 +6416,8 @@
       },
       "Chat": {
         "mentioned": "{authorName} hat dich in {roomName} erwähnt",
-        "directMessage": "{authorName} hat dir eine Nachricht gesendet"
+        "directMessage": "{authorName} hat dir eine Nachricht gesendet",
+        "roomMessage": "{authorName} hat in {roomName} geschrieben"
       }
     }
   },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4152,6 +4152,8 @@
         "kindTaskAttentionHint": "A task stopped until you act, like needing approval or credits.",
         "kindTaskUpdate": "Other task updates",
         "kindTaskUpdateHint": "Anything else a task reports, like finishing or being canceled.",
+        "kindChatRoomMessage": "Every message in your rooms",
+        "kindChatRoomMessageHint": "Someone writes in a room you belong to. Off until you turn it on.",
         "kindChatMention": "Chat mentions",
         "kindChatMentionHint": "Someone names you in a chat.",
         "kindChatDirectMessage": "Direct messages",
@@ -4159,7 +4161,7 @@
         "kindSystem": "Requests and access",
         "kindSystemHint": "Someone asks for access, or a decision lands.",
         "groupChat": "Chat",
-        "groupChatDescription": "Mentions and direct messages",
+        "groupChatDescription": "Room messages, mentions, and direct messages",
         "deliveryOff": "Off",
         "deliveryInApp": "In app",
         "deliveryBanner": "Banner",
@@ -6414,7 +6416,8 @@
       },
       "Chat": {
         "mentioned": "{authorName} mentioned you in {roomName}",
-        "directMessage": "{authorName} sent you a message"
+        "directMessage": "{authorName} sent you a message",
+        "roomMessage": "{authorName} wrote in {roomName}"
       }
     }
   },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4121,6 +4121,8 @@
         "kindTaskAttentionHint": "Una tarea se detiene hasta que actúes, por ejemplo por falta de aprobación o de créditos.",
         "kindTaskUpdate": "Otras novedades de tareas",
         "kindTaskUpdateHint": "Todo lo demás que informa una tarea, como que termina o se cancela.",
+        "kindChatRoomMessage": "Todos los mensajes de tus salas",
+        "kindChatRoomMessageHint": "Alguien escribe en una sala a la que perteneces. Apagado hasta que lo actives.",
         "kindChatMention": "Menciones en el chat",
         "kindChatMentionHint": "Alguien te menciona en un chat.",
         "kindChatDirectMessage": "Mensajes directos",
@@ -4128,7 +4130,7 @@
         "kindSystem": "Solicitudes y acceso",
         "kindSystemHint": "Alguien pide acceso o llega una decisión.",
         "groupChat": "Chat",
-        "groupChatDescription": "Menciones y mensajes directos",
+        "groupChatDescription": "Mensajes de sala, menciones y mensajes directos",
         "deliveryOff": "Desactivado",
         "deliveryInApp": "En app",
         "deliveryBanner": "Banner",
@@ -6414,7 +6416,8 @@
       },
       "Chat": {
         "mentioned": "{authorName} te mencionó en {roomName}",
-        "directMessage": "{authorName} te envió un mensaje"
+        "directMessage": "{authorName} te envió un mensaje",
+        "roomMessage": "{authorName} escribió en {roomName}"
       }
     }
   },

--- a/apps/web/public/ably-push-sw.js
+++ b/apps/web/public/ably-push-sw.js
@@ -81,6 +81,7 @@ const MESSAGES = {
       "The schedule for {taskName} was removed after review",
     "Notifications.Chat.mentioned": "{authorName} mentioned you in {roomName}",
     "Notifications.Chat.directMessage": "{authorName} sent you a message",
+    "Notifications.Chat.roomMessage": "{authorName} wrote in {roomName}",
     "notifications.vendorGrant.pending":
       "{vendorName} requested vendor access to your workspace",
     "notifications.coworkerAccess.pending":
@@ -117,6 +118,8 @@ const MESSAGES = {
       "{authorName} hat dich in {roomName} erwähnt",
     "Notifications.Chat.directMessage":
       "{authorName} hat dir eine Nachricht gesendet",
+    "Notifications.Chat.roomMessage":
+      "{authorName} hat in {roomName} geschrieben",
     "notifications.vendorGrant.pending":
       "{vendorName} hat Vendor-Zugriff auf den Organisations-Workspace angefordert",
     "notifications.coworkerAccess.pending":
@@ -148,6 +151,7 @@ const MESSAGES = {
       "Se eliminó la programación de {taskName} después de revisarla",
     "Notifications.Chat.mentioned": "{authorName} te mencionó en {roomName}",
     "Notifications.Chat.directMessage": "{authorName} te envió un mensaje",
+    "Notifications.Chat.roomMessage": "{authorName} escribió en {roomName}",
     "notifications.vendorGrant.pending":
       "{vendorName} solicitó acceso de proveedor al workspace de la organización",
     "notifications.coworkerAccess.pending":

--- a/apps/web/src/app/(app)/account/components/notification-delivery.ts
+++ b/apps/web/src/app/(app)/account/components/notification-delivery.ts
@@ -93,6 +93,11 @@ export const NOTIFICATION_GROUPS: readonly GroupSpec[] = [
     descriptionKey: "groupChatDescription",
     kinds: [
       {
+        category: "CHAT_ROOM_MESSAGE",
+        labelKey: "kindChatRoomMessage",
+        hintKey: "kindChatRoomMessageHint",
+      },
+      {
         category: "CHAT_MENTION",
         labelKey: "kindChatMention",
         hintKey: "kindChatMentionHint",

--- a/apps/web/src/app/(app)/account/components/notification-kinds.test.tsx
+++ b/apps/web/src/app/(app)/account/components/notification-kinds.test.tsx
@@ -60,6 +60,8 @@ const MATRIX = [
   { category: "TASK_ATTENTION", channel: "OS_BANNER", enabled: false },
   { category: "TASK_UPDATE", channel: "IN_APP", enabled: true },
   { category: "TASK_UPDATE", channel: "OS_BANNER", enabled: false },
+  { category: "CHAT_ROOM_MESSAGE", channel: "IN_APP", enabled: false },
+  { category: "CHAT_ROOM_MESSAGE", channel: "OS_BANNER", enabled: false },
   { category: "CHAT_MENTION", channel: "IN_APP", enabled: true },
   { category: "CHAT_MENTION", channel: "OS_BANNER", enabled: false },
   { category: "CHAT_DIRECT_MESSAGE", channel: "IN_APP", enabled: true },
@@ -241,9 +243,34 @@ describe("NotificationKinds", () => {
     });
     // One request, so the group cannot end up half applied with the reader
     // watching its kinds settle one by one.
-    expect(lastWrite()).toHaveLength(4);
+    expect(lastWrite()).toHaveLength(6);
     expect(written("CHAT_MENTION", "IN_APP")).toBe(false);
     expect(written("CHAT_DIRECT_MESSAGE", "OS_BANNER")).toBe(false);
+  });
+
+  /**
+   * Nobody receives every message in a room today, so the row starts off and
+   * the reader turns it on. It is the one row where an untouched account is
+   * quieter than the ones around it.
+   */
+  it("shows every message in a room as off until the reader asks", async () => {
+    const user = userEvent.setup();
+    renderKinds();
+
+    await user.click(screen.getByRole("button", { name: /^groupChat/ }));
+
+    expect(stop("kindChatRoomMessage", "deliveryOff")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await pick("kindChatRoomMessage", "deliveryInApp");
+
+    await waitFor(() => {
+      expect(patchMyPreferences).toHaveBeenCalledTimes(1);
+    });
+    expect(written("CHAT_ROOM_MESSAGE", "IN_APP")).toBe(true);
+    expect(written("CHAT_ROOM_MESSAGE", "OS_BANNER")).toBe(false);
   });
 
   it("keeps the kinds in a group separately selectable", async () => {
@@ -274,11 +301,12 @@ describe("NotificationKinds", () => {
 
   it("does not ask for push when the banner it writes was already on", async () => {
     isAccountEnabled = false;
-    // Both chat kinds already banner, and one of them missing its in-app cell,
+    // Every chat kind already banner, and two of them missing an in-app cell,
     // so the group write changes something without asking for a new banner.
     renderKinds(
       MATRIX.map((cell) =>
-        cell.category === "CHAT_MENTION"
+        cell.category === "CHAT_MENTION" ||
+        cell.category === "CHAT_ROOM_MESSAGE"
           ? { ...cell, enabled: cell.channel === "OS_BANNER" }
           : cell,
       ),

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -12676,6 +12676,7 @@ export const NotificationPreferenceSchema = {
                 'JOB_UPDATE',
                 'TASK_ATTENTION',
                 'TASK_UPDATE',
+                'CHAT_ROOM_MESSAGE',
                 'CHAT_MENTION',
                 'CHAT_DIRECT_MESSAGE',
                 'SYSTEM'

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -3743,7 +3743,7 @@ export type NotificationPreference = {
     /**
      * What the notification is about
      */
-    category: 'JOB_ATTENTION' | 'JOB_UPDATE' | 'TASK_ATTENTION' | 'TASK_UPDATE' | 'CHAT_MENTION' | 'CHAT_DIRECT_MESSAGE' | 'SYSTEM';
+    category: 'JOB_ATTENTION' | 'JOB_UPDATE' | 'TASK_ATTENTION' | 'TASK_UPDATE' | 'CHAT_ROOM_MESSAGE' | 'CHAT_MENTION' | 'CHAT_DIRECT_MESSAGE' | 'SYSTEM';
     /**
      * Where it is delivered: in the app, or as an OS banner (which also needs pushOptIn)
      */

--- a/apps/web/src/lib/utils/__tests__/push-service-worker-messages.test.ts
+++ b/apps/web/src/lib/utils/__tests__/push-service-worker-messages.test.ts
@@ -15,7 +15,7 @@ import esMessages from "@/messages/es.json";
 
 /**
  * The service worker cannot reach next-intl, so it carries its own copy of the
- * two chat strings. `messages:parity` compares key paths only, so it cannot see
+ * notification strings. `messages:parity` compares key paths only, so it cannot see
  * a changed value. This test does: edit a catalog string without editing the
  * worker and it fails. SOK-876 removes the copy and this guard with it.
  */

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -237,8 +237,6 @@ export {
 } from "./notification-feed-kinds.js";
 export {
   NOTIFICATION_CATEGORIES,
-  NOTIFICATION_CATEGORY_OFF_BY_DEFAULT,
-  NOTIFICATION_CHANNEL_DEFAULT,
   NOTIFICATION_CHANNELS,
   type NotificationCategory,
   type NotificationChannel,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -237,10 +237,12 @@ export {
 } from "./notification-feed-kinds.js";
 export {
   NOTIFICATION_CATEGORIES,
+  NOTIFICATION_CATEGORY_OFF_BY_DEFAULT,
   NOTIFICATION_CHANNEL_DEFAULT,
   NOTIFICATION_CHANNELS,
   type NotificationCategory,
   type NotificationChannel,
+  notificationDefault,
 } from "./notification-preferences.js";
 export {
   type BuildOAuthClientScopeParamOptions,

--- a/packages/utils/src/notification-preferences.ts
+++ b/packages/utils/src/notification-preferences.ts
@@ -11,6 +11,10 @@
  * to the reader, and one row for both meant silencing the ones that need you to
  * be rid of the ones that do not.
  *
+ * Chat is three rows: every message in a room you belong to, the messages that
+ * name you, and your direct messages. The first is the only one that is off
+ * until you ask for it (`NOTIFICATION_CATEGORY_OFF_BY_DEFAULT`).
+ *
  * Web reads the same vocabulary from the generated Core client, not from here:
  * the Core DTO boundary keeps domain values out of web's direct imports.
  */
@@ -19,6 +23,7 @@ export const NOTIFICATION_CATEGORIES = [
   "JOB_UPDATE",
   "TASK_ATTENTION",
   "TASK_UPDATE",
+  "CHAT_ROOM_MESSAGE",
   "CHAT_MENTION",
   "CHAT_DIRECT_MESSAGE",
   "SYSTEM",
@@ -55,3 +60,30 @@ export const NOTIFICATION_CHANNEL_DEFAULT: Record<
   IN_APP: true,
   OS_BANNER: true,
 };
+
+/**
+ * The categories that stay off until the reader turns them on.
+ *
+ * The rest default to on, because they were already arriving before this
+ * matrix existed and a default of off would silence them. Every message in a
+ * room is the opposite case: nobody receives it today, and switching it on for
+ * everyone would turn a busy room into a stream of notifications the reader
+ * never asked for. So it is off, and an absent row means no rather than yes.
+ */
+export const NOTIFICATION_CATEGORY_OFF_BY_DEFAULT: readonly NotificationCategory[] =
+  ["CHAT_ROOM_MESSAGE"];
+
+/** Whether a category and channel is delivered when the reader stored nothing. */
+export function notificationDefault(
+  category: NotificationCategory | null,
+  channel: NotificationChannel,
+): boolean {
+  if (
+    category !== null &&
+    NOTIFICATION_CATEGORY_OFF_BY_DEFAULT.includes(category)
+  ) {
+    return false;
+  }
+
+  return NOTIFICATION_CHANNEL_DEFAULT[channel];
+}

--- a/packages/utils/src/notification-preferences.ts
+++ b/packages/utils/src/notification-preferences.ts
@@ -53,10 +53,7 @@ export type NotificationChannel = (typeof NOTIFICATION_CHANNELS)[number];
  * A default of off there would instead silence a reader who did opt in and
  * never touched the matrix.
  */
-export const NOTIFICATION_CHANNEL_DEFAULT: Record<
-  NotificationChannel,
-  boolean
-> = {
+const NOTIFICATION_CHANNEL_DEFAULT: Record<NotificationChannel, boolean> = {
   IN_APP: true,
   OS_BANNER: true,
 };
@@ -70,8 +67,9 @@ export const NOTIFICATION_CHANNEL_DEFAULT: Record<
  * everyone would turn a busy room into a stream of notifications the reader
  * never asked for. So it is off, and an absent row means no rather than yes.
  */
-export const NOTIFICATION_CATEGORY_OFF_BY_DEFAULT: readonly NotificationCategory[] =
-  ["CHAT_ROOM_MESSAGE"];
+const NOTIFICATION_CATEGORY_OFF_BY_DEFAULT: readonly NotificationCategory[] = [
+  "CHAT_ROOM_MESSAGE",
+];
 
 /** Whether a category and channel is delivered when the reader stored nothing. */
 export function notificationDefault(


### PR DESCRIPTION
Layer 10 of SOK-877. Based on [#4093](https://github.com/masumi-network/sokosumi/pull/4093); review that one first.

## Why

Chat notified you when a message named you or was sent to you directly. To follow a room you had to keep it open.

## What changes

`CHAT_ROOM_MESSAGE` is a new preference row: every message in a room you belong to.

It is the first row that is **off by default**. `NOTIFICATION_CATEGORY_OFF_BY_DEFAULT` names it and `notificationDefault` reads it, so an absent row means no rather than yes. Every other row defaults to on, because those notifications already arrived before the matrix existed. This one nobody receives today, and switching it on for everyone would turn a busy room into a stream nobody asked for.

The emitter asks who subscribed before it writes anything:

- one query for the room's members, one for the members with the row on, both inside `waitUntil`, so a room nobody subscribed to costs the request nothing and writes no notification rows
- direct rooms are excluded, because their messages already have their own row
- the caller names the members it has already notified, so a message that mentions you arrives once
- muting the room still wins, same as for mentions and direct messages

`Notifications.Chat.roomMessage` renders as "{authorName} wrote in {roomName}" in the feed, in all three locales.

### Fan-out shared instead of copied

Mentions and direct messages each carried their own copy of the same mute filter, workspace lookup and write loop. A third copy would have made the mute rule three places to fix, so the three now call one `fanOutChatNotifications` and differ only in the message key and the Sentry tag.

## Verification

- `pnpm --filter @sokosumi/core test` — the suite passes; four files time out when the core and web suites run back to back on a loaded machine and pass on their own (`src/routes/sync`, `src/routes/v1/index`, `src/routes/v1/workspaces`, `src/routes/well-known/oauth-issuer-metadata`), none of them touched here
- `pnpm --filter web test`, `pnpm --filter web messages:parity`, `pnpm --filter web typecheck`, `biome check` — clean
- Mutation-checked: including direct rooms, ignoring the opt-in filter, ignoring the already-notified list, and emptying `NOTIFICATION_CATEGORY_OFF_BY_DEFAULT` are each caught by a failing test.