### PR TITLE
feat(web): move You page workspace switch into card row

### DIFF
--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.test.tsx
@@ -424,4 +424,24 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     expect(createPersonalWorkspaceAction).not.toHaveBeenCalled();
     expect(screen.queryByTestId("workspace-switcher-create-choice")).toBeNull();
   });
+
+  it("renders a row-layout trigger for full-width sections", () => {
+    render(
+      <HeaderWorkspaceSwitch
+        sessionUser={sessionUser}
+        members={[orgMember]}
+        hasPersonalWorkspace={true}
+        activeOrganizationId="org-a"
+        isPending={false}
+        onSelectWorkspace={vi.fn()}
+        layout="row"
+      />,
+    );
+
+    const trigger = screen.getByTestId("you-workspace-switch");
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.className).toContain("w-full");
+    expect(screen.getByText("Org A")).toBeInTheDocument();
+    expect(screen.queryByText("test@example.com")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -43,6 +43,7 @@ interface HeaderWorkspaceSwitchProps {
   activeOrganizationId: string | null;
   isPending: boolean;
   onSelectWorkspace: (workspaceId: string | null) => void | Promise<void>;
+  layout?: "chip" | "row";
 }
 
 interface WorkspaceItem {
@@ -126,7 +127,9 @@ export default function HeaderWorkspaceSwitch({
   activeOrganizationId,
   isPending,
   onSelectWorkspace,
+  layout = "chip",
 }: HeaderWorkspaceSwitchProps) {
+  const isRowLayout = layout === "row";
   const tOrganizationSwitcher = useTranslations(
     "Components.OrganizationSwitcher",
   );
@@ -250,7 +253,12 @@ export default function HeaderWorkspaceSwitch({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className="text-foreground hover:opacity-80 flex h-8 min-w-0 items-center text-sm transition-opacity md:h-auto"
+            className={cn(
+              "text-foreground flex min-w-0 items-center text-sm transition-opacity",
+              isRowLayout
+                ? "hover:bg-accent h-11 w-full gap-2 px-3 font-normal md:h-10"
+                : "h-8 hover:opacity-80 md:h-auto",
+            )}
             disabled={isPending}
             aria-busy={!activeWorkspace}
             aria-label={
@@ -258,39 +266,83 @@ export default function HeaderWorkspaceSwitch({
                 ? undefined
                 : tOrganizationSwitcher("switchWorkspace")
             }
+            data-testid={isRowLayout ? "you-workspace-switch" : undefined}
           >
-            <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-1.5">
+            <div
+              className={cn(
+                "grid min-w-0 items-center gap-x-1.5",
+                isRowLayout
+                  ? "w-full grid-cols-[auto_minmax(0,1fr)_auto]"
+                  : "grid-cols-[minmax(0,1fr)_auto_auto]",
+              )}
+            >
               {activeWorkspace ? (
                 <>
-                  <span className="max-w-24 truncate text-right leading-none font-medium md:max-w-none md:leading-tight">
+                  {isRowLayout ? (
+                    <HeaderWorkspaceAvatar
+                      sessionUser={sessionUser}
+                      organization={activeWorkspace.organization ?? null}
+                      className="size-4 shrink-0"
+                      logoSize={12}
+                      decorative
+                    />
+                  ) : null}
+                  <span
+                    className={cn(
+                      "truncate font-medium",
+                      isRowLayout
+                        ? "min-w-0 text-left leading-tight"
+                        : "max-w-24 text-right leading-none md:max-w-none md:leading-tight",
+                    )}
+                  >
                     {activeWorkspace.name}
                   </span>
-                  <HeaderWorkspaceAvatar
-                    sessionUser={sessionUser}
-                    organization={activeWorkspace.organization ?? null}
-                    className="size-4 shrink-0"
-                    logoSize={12}
-                    decorative
-                  />
+                  {isRowLayout ? null : (
+                    <HeaderWorkspaceAvatar
+                      sessionUser={sessionUser}
+                      organization={activeWorkspace.organization ?? null}
+                      className="size-4 shrink-0"
+                      logoSize={12}
+                      decorative
+                    />
+                  )}
                 </>
               ) : (
                 <span
                   data-testid="workspace-switcher-skeleton"
-                  className="col-span-2 flex items-center justify-end gap-1.5"
+                  className={cn(
+                    "col-span-2 flex items-center gap-1.5",
+                    isRowLayout ? "justify-start" : "justify-end",
+                  )}
                   aria-hidden
                 >
+                  {isRowLayout ? (
+                    <span className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />
+                  ) : null}
                   <span className="bg-muted h-3 w-20 animate-pulse rounded-md" />
-                  <span className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />
+                  {isRowLayout ? null : (
+                    <span className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />
+                  )}
                 </span>
               )}
-              <ChevronsUpDown className="text-muted-foreground size-4 shrink-0 self-center md:row-span-2 md:size-4.5" />
-              <span className="text-muted-foreground col-span-2 col-start-1 max-md:hidden max-w-full truncate text-right text-xs leading-tight">
-                {sessionUser.email}
-              </span>
+              <ChevronsUpDown
+                className={cn(
+                  "text-muted-foreground size-4 shrink-0 self-center",
+                  !isRowLayout && "md:row-span-2 md:size-4.5",
+                )}
+              />
+              {isRowLayout ? null : (
+                <span className="text-muted-foreground col-span-2 col-start-1 max-md:hidden max-w-full truncate text-right text-xs leading-tight">
+                  {sessionUser.email}
+                </span>
+              )}
             </div>
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-72" align="end">
+        <DropdownMenuContent
+          className="w-72"
+          align={isRowLayout ? "start" : "end"}
+        >
           {hasPersonalWorkspace ? (
             <WorkspaceMenuItem
               sessionUser={sessionUser}

--- a/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
@@ -93,7 +93,7 @@ describe("YouPageClient", () => {
     vi.clearAllMocks();
   });
 
-  it("renders identity, workspace switch, and credits summary", () => {
+  it("renders identity, workspace switch card row, and credits summary", () => {
     renderYouPage();
 
     expect(screen.getByTestId("you-page")).toBeInTheDocument();
@@ -101,7 +101,13 @@ describe("YouPageClient", () => {
       screen.getByRole("heading", { name: "Patrick Tobler" }),
     ).toBeInTheDocument();
     expect(screen.getByText("patrick@example.com")).toBeInTheDocument();
-    expect(screen.getByTestId("you-workspace-switch")).toBeInTheDocument();
+    const workspaceSwitch = screen.getByTestId("you-workspace-switch");
+    expect(workspaceSwitch).toBeInTheDocument();
+    expect(
+      workspaceSwitch.compareDocumentPosition(
+        screen.getByRole("heading", { name: "Patrick Tobler" }),
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(screen.getByText(/balanceCreditsLabel 15750/)).toBeInTheDocument();
     expect(screen.getByText("Pro")).toBeInTheDocument();
   });

--- a/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
@@ -179,11 +179,11 @@ describe("YouPageClient", () => {
     expect(screen.getByTestId("you-logout")).toBeInTheDocument();
   });
 
-  it("uses destructive styling and the logout confirmation flow", () => {
+  it("uses the destructive button variant and the logout confirmation flow", () => {
     renderYouPage();
 
     const logout = screen.getByTestId("you-logout");
-    expect(logout.className).toContain("text-destructive");
+    expect(logout.className).toContain("bg-destructive");
 
     fireEvent.click(logout);
 

--- a/apps/web/src/app/(app)/you/components/you-page.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.tsx
@@ -293,10 +293,10 @@ export function YouPageClient({
 
         <Button
           type="button"
-          variant="ghost"
+          variant="destructive"
           size="sm"
           onClick={handleLogout}
-          className="text-destructive hover:text-destructive h-11 w-full justify-start gap-2 font-normal md:h-8"
+          className="h-11 w-full gap-2 md:h-8"
           data-testid="you-logout"
         >
           <LogOut className="size-4 shrink-0" aria-hidden />

--- a/apps/web/src/app/(app)/you/components/you-page.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.tsx
@@ -146,25 +146,26 @@ export function YouPageClient({
         )}
       >
         <header className="space-y-4">
+          <YouMenuGroup>
+            <HeaderWorkspaceSwitch
+              sessionUser={sessionUser}
+              members={members}
+              hasPersonalWorkspace={hasPersonalWorkspace}
+              activeOrganizationId={activeOrganizationId}
+              isPending={isPending}
+              onSelectWorkspace={handleSelectWorkspace}
+              layout="row"
+            />
+          </YouMenuGroup>
           <div className="flex items-start gap-4">
             <YouPageAvatar
               sessionUser={sessionUser}
               displayName={displayName}
             />
             <div className="min-w-0 flex-1 space-y-1">
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                <h1 className="truncate text-xl leading-tight font-semibold">
-                  {displayName}
-                </h1>
-                <HeaderWorkspaceSwitch
-                  sessionUser={sessionUser}
-                  members={members}
-                  hasPersonalWorkspace={hasPersonalWorkspace}
-                  activeOrganizationId={activeOrganizationId}
-                  isPending={isPending}
-                  onSelectWorkspace={handleSelectWorkspace}
-                />
-              </div>
+              <h1 className="truncate text-xl leading-tight font-semibold">
+                {displayName}
+              </h1>
               <p className="text-muted-foreground truncate text-sm">
                 {sessionUser.email}
               </p>
@@ -334,7 +335,7 @@ function YouPageAvatar({
 
 function YouMenuGroup({ children }: { children: React.ReactNode }) {
   return (
-    <div className="border-border divide-border divide-y overflow-hidden rounded-lg border">
+    <div className="border-border bg-card-background divide-border divide-y overflow-hidden rounded-lg border">
       {children}
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the You page workspace switcher out of the name line into its own full-width `bg-card-background` card row above the identity header, matching the existing You menu group pattern.

Also applies `bg-card-background` to `YouMenuGroup`, and switches Log out to the shared filled `variant="destructive"` Button.

## Changes

- `HeaderWorkspaceSwitch` gains `layout="row"` for a full-width left-aligned trigger (chip layout unchanged for the header)
- You page places the switcher in a `YouMenuGroup` above avatar/name/email
- You logout uses `Button variant="destructive"` instead of ghost + red text
- Tests assert switch order, row layout, and destructive logout classes

## Verification

- `pnpm --filter web test` on You page + workspace switch (passing)
- Biome + typecheck via pre-commit hook
- Manual `/you` walkthrough for card-row switch and destructive logout

[You page workspace card row](https://cursor.com/agents/bc-418e0a27-96c8-4266-be1e-e2d625bbe3f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-page-workspace-card-row.png)
[Workspace dropdown from card row](https://cursor.com/agents/bc-418e0a27-96c8-4266-be1e-e2d625bbe3f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-page-workspace-dropdown.png)
[Destructive Log out button](https://cursor.com/agents/bc-418e0a27-96c8-4266-be1e-e2d625bbe3f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-page-logout-destructive.png)
[you-workspace-switch-card-row-demo.mp4](https://cursor.com/agents/bc-418e0a27-96c8-4266-be1e-e2d625bbe3f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-workspace-switch-card-row-demo.mp4)

Related: SOK-925

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-418e0a27-96c8-4266-be1e-e2d625bbe3f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-418e0a27-96c8-4266-be1e-e2d625bbe3f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

