### PR TITLE
fix(web): restore workspace switcher to header from You

### DIFF
--- a/apps/web/src/app/(app)/components/header/header-mobile-search.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/header-mobile-search.client.test.tsx
@@ -226,9 +226,7 @@ describe("HeaderMobileSearchControl", () => {
 
     expect(screen.getByTestId("header-trailing-tools")).toBeInTheDocument();
     expect(
-      container.querySelector(
-        "[data-testid='header-desktop-workspace-chrome']",
-      ),
+      container.querySelector("[data-testid='header-workspace-chrome']"),
     ).toBeNull();
   });
 });

--- a/apps/web/src/app/(app)/components/header/header-profile-section.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.client.test.tsx
@@ -99,7 +99,7 @@ describe("HeaderProfileSectionClient", () => {
     headerWorkspaceSwitchMock.mockClear();
   });
 
-  it("keeps Workspace switch desktop-only (hidden on mobile)", async () => {
+  it("shows Workspace switch on mobile and desktop", async () => {
     useSessionMock.mockReturnValue({
       data: {
         session: {
@@ -114,9 +114,10 @@ describe("HeaderProfileSectionClient", () => {
       activeOrganizationId: "org-a",
     });
 
-    const chrome = screen.getByTestId("header-desktop-workspace-chrome");
-    expect(chrome.className).toContain("hidden");
-    expect(chrome.className).toContain("md:flex");
+    const chrome = screen.getByTestId("header-workspace-chrome");
+    expect(chrome.className).toContain("flex");
+    expect(chrome.className).not.toContain("hidden");
+    expect(chrome.className).not.toContain("md:flex");
     expect(screen.getByTestId("header-workspace-switch-mock")).toBeTruthy();
   });
 

--- a/apps/web/src/app/(app)/components/header/header-profile-section.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.client.tsx
@@ -39,13 +39,12 @@ export default function HeaderProfileSectionClient({
   return (
     <div
       className={cn(
-        // Desktop-only Workspace switch. Mobile account/Workspace live on You.
-        "hidden h-auto items-center gap-1.5 md:flex",
+        "flex h-auto items-center gap-1.5",
         isPending
           ? "pointer-events-none animate-pulse opacity-60"
           : "transition-opacity",
       )}
-      data-testid="header-desktop-workspace-chrome"
+      data-testid="header-workspace-chrome"
     >
       <HeaderWorkspaceSwitch
         sessionUser={sessionUser}

--- a/apps/web/src/app/(app)/components/header/header-profile-section.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.tsx
@@ -12,9 +12,9 @@ interface HeaderProfileSectionProps {
 function HeaderProfileSectionSkeleton() {
   return (
     <div
-      className="hidden h-auto items-center gap-1.5 md:flex"
+      className="flex h-auto items-center gap-1.5"
       aria-hidden
-      data-testid="header-desktop-workspace-chrome-skeleton"
+      data-testid="header-workspace-chrome-skeleton"
     >
       <div className="bg-muted h-3 w-20 animate-pulse rounded-md" />
       <div className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />

--- a/apps/web/src/app/(app)/components/header/header-trailing-tools.tsx
+++ b/apps/web/src/app/(app)/components/header/header-trailing-tools.tsx
@@ -2,9 +2,8 @@ import { HeaderMobileSearchControl } from "@/app/components/header/header-mobile
 import { HeaderNotificationBell } from "@/app/components/header/header-notification-bell.client";
 
 /**
- * Mobile/desktop trailing tools after desktop Workspace chrome:
+ * Mobile/desktop trailing tools after Workspace chrome:
  * Notification Center, then mobile header Search (SOK-924).
- * Mobile Workspace switch + account avatar live on You (SOK-926).
  */
 export function HeaderTrailingTools() {
   return (

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.test.tsx
@@ -424,24 +424,4 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     expect(createPersonalWorkspaceAction).not.toHaveBeenCalled();
     expect(screen.queryByTestId("workspace-switcher-create-choice")).toBeNull();
   });
-
-  it("renders a row-layout trigger for full-width sections", () => {
-    render(
-      <HeaderWorkspaceSwitch
-        sessionUser={sessionUser}
-        members={[orgMember]}
-        hasPersonalWorkspace={true}
-        activeOrganizationId="org-a"
-        isPending={false}
-        onSelectWorkspace={vi.fn()}
-        layout="row"
-      />,
-    );
-
-    const trigger = screen.getByTestId("you-workspace-switch");
-    expect(trigger).toBeInTheDocument();
-    expect(trigger.className).toContain("w-full");
-    expect(screen.getByText("Org A")).toBeInTheDocument();
-    expect(screen.queryByText("test@example.com")).not.toBeInTheDocument();
-  });
 });

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -43,7 +43,6 @@ interface HeaderWorkspaceSwitchProps {
   activeOrganizationId: string | null;
   isPending: boolean;
   onSelectWorkspace: (workspaceId: string | null) => void | Promise<void>;
-  layout?: "chip" | "row";
 }
 
 interface WorkspaceItem {
@@ -127,9 +126,7 @@ export default function HeaderWorkspaceSwitch({
   activeOrganizationId,
   isPending,
   onSelectWorkspace,
-  layout = "chip",
 }: HeaderWorkspaceSwitchProps) {
-  const isRowLayout = layout === "row";
   const tOrganizationSwitcher = useTranslations(
     "Components.OrganizationSwitcher",
   );
@@ -253,12 +250,7 @@ export default function HeaderWorkspaceSwitch({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className={cn(
-              "text-foreground flex min-w-0 items-center text-sm transition-opacity",
-              isRowLayout
-                ? "hover:bg-accent h-11 w-full gap-2 px-3 font-normal md:h-10"
-                : "h-8 hover:opacity-80 md:h-auto",
-            )}
+            className="text-foreground hover:opacity-80 flex h-8 min-w-0 items-center text-sm transition-opacity md:h-auto"
             disabled={isPending}
             aria-busy={!activeWorkspace}
             aria-label={
@@ -266,83 +258,39 @@ export default function HeaderWorkspaceSwitch({
                 ? undefined
                 : tOrganizationSwitcher("switchWorkspace")
             }
-            data-testid={isRowLayout ? "you-workspace-switch" : undefined}
           >
-            <div
-              className={cn(
-                "grid min-w-0 items-center gap-x-1.5",
-                isRowLayout
-                  ? "w-full grid-cols-[auto_minmax(0,1fr)_auto]"
-                  : "grid-cols-[minmax(0,1fr)_auto_auto]",
-              )}
-            >
+            <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-1.5">
               {activeWorkspace ? (
                 <>
-                  {isRowLayout ? (
-                    <HeaderWorkspaceAvatar
-                      sessionUser={sessionUser}
-                      organization={activeWorkspace.organization ?? null}
-                      className="size-4 shrink-0"
-                      logoSize={12}
-                      decorative
-                    />
-                  ) : null}
-                  <span
-                    className={cn(
-                      "truncate font-medium",
-                      isRowLayout
-                        ? "min-w-0 text-left leading-tight"
-                        : "max-w-24 text-right leading-none md:max-w-none md:leading-tight",
-                    )}
-                  >
+                  <span className="max-w-24 truncate text-right leading-none font-medium md:max-w-none md:leading-tight">
                     {activeWorkspace.name}
                   </span>
-                  {isRowLayout ? null : (
-                    <HeaderWorkspaceAvatar
-                      sessionUser={sessionUser}
-                      organization={activeWorkspace.organization ?? null}
-                      className="size-4 shrink-0"
-                      logoSize={12}
-                      decorative
-                    />
-                  )}
+                  <HeaderWorkspaceAvatar
+                    sessionUser={sessionUser}
+                    organization={activeWorkspace.organization ?? null}
+                    className="size-4 shrink-0"
+                    logoSize={12}
+                    decorative
+                  />
                 </>
               ) : (
                 <span
                   data-testid="workspace-switcher-skeleton"
-                  className={cn(
-                    "col-span-2 flex items-center gap-1.5",
-                    isRowLayout ? "justify-start" : "justify-end",
-                  )}
+                  className="col-span-2 flex items-center justify-end gap-1.5"
                   aria-hidden
                 >
-                  {isRowLayout ? (
-                    <span className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />
-                  ) : null}
                   <span className="bg-muted h-3 w-20 animate-pulse rounded-md" />
-                  {isRowLayout ? null : (
-                    <span className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />
-                  )}
+                  <span className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />
                 </span>
               )}
-              <ChevronsUpDown
-                className={cn(
-                  "text-muted-foreground size-4 shrink-0 self-center",
-                  !isRowLayout && "md:row-span-2 md:size-4.5",
-                )}
-              />
-              {isRowLayout ? null : (
-                <span className="text-muted-foreground col-span-2 col-start-1 max-md:hidden max-w-full truncate text-right text-xs leading-tight">
-                  {sessionUser.email}
-                </span>
-              )}
+              <ChevronsUpDown className="text-muted-foreground size-4 shrink-0 self-center md:row-span-2 md:size-4.5" />
+              <span className="text-muted-foreground col-span-2 col-start-1 max-md:hidden max-w-full truncate text-right text-xs leading-tight">
+                {sessionUser.email}
+              </span>
             </div>
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent
-          className="w-72"
-          align={isRowLayout ? "start" : "end"}
-        >
+        <DropdownMenuContent className="w-72" align="end">
           {hasPersonalWorkspace ? (
             <WorkspaceMenuItem
               sessionUser={sessionUser}

--- a/apps/web/src/app/(app)/you/components/you-page-content.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page-content.tsx
@@ -9,7 +9,6 @@ import { getEnvPublicConfig } from "@/config/env.public";
 import { getSession } from "@/lib/auth/auth.server";
 import { hasAdminRole } from "@/lib/auth/has-admin-role";
 import { isBetaAccessEmail } from "@/lib/beta-access";
-import { userService } from "@/lib/services";
 import { resolvePlanName } from "@/lib/utils/plan-label";
 
 import { YouPageClient } from "./you-page.client";
@@ -29,7 +28,6 @@ export async function YouPageContent() {
     { showVendors: showDeveloperVendors },
     creditsResult,
     { members },
-    workspaceAccess,
   ] = await Promise.all([
     getTranslations("App.Header.Plan"),
     getDeveloperVendorAdminAccess(),
@@ -38,7 +36,6 @@ export async function YouPageContent() {
       userId: session.user.id,
       activeOrganizationId,
     }),
-    userService.getWorkspaceAccess(),
   ]);
 
   const credits = mapAccountCreditsChrome(creditsResult);
@@ -51,9 +48,6 @@ export async function YouPageContent() {
   return (
     <YouPageClient
       sessionUser={session.user}
-      members={members}
-      hasPersonalWorkspace={workspaceAccess?.hasPersonalWorkspace ?? false}
-      activeOrganizationId={activeOrganizationId}
       calendarMenuEnabled={calendarMenuEnabled}
       planName={planName}
       totalCredits={credits.totalCredits}

--- a/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
@@ -22,23 +22,6 @@ vi.mock("@/hooks/use-self-presence", () => ({
   useSelfPresence: () => "online",
 }));
 
-vi.mock("@/lib/auth/auth.client", () => ({
-  useSession: () => ({ data: null }),
-}));
-
-const handleSelectWorkspaceMock = vi.fn();
-
-vi.mock("@/app/components/user-avatar/workspace-switcher", () => ({
-  useWorkspaceSwitcher: () => ({
-    isPending: false,
-    handleSelectWorkspace: handleSelectWorkspaceMock,
-  }),
-}));
-
-vi.mock("@/app/components/header/header-workspace-switch.client", () => ({
-  default: () => <div data-testid="you-workspace-switch">workspace</div>,
-}));
-
 import { YouPageClient } from "@/app/you/components/you-page.client";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
 
@@ -69,9 +52,6 @@ function renderYouPage(
   return render(
     <YouPageClient
       sessionUser={sessionUser}
-      members={members}
-      hasPersonalWorkspace
-      activeOrganizationId={null}
       calendarMenuEnabled={false}
       planName="Pro"
       totalCredits={15_750}
@@ -93,7 +73,7 @@ describe("YouPageClient", () => {
     vi.clearAllMocks();
   });
 
-  it("renders identity, workspace switch card row, and credits summary", () => {
+  it("renders identity with status and plan under the email", () => {
     renderYouPage();
 
     const shell = screen.getByTestId("you-page");
@@ -105,15 +85,18 @@ describe("YouPageClient", () => {
       screen.getByRole("heading", { name: "Patrick Tobler" }),
     ).toBeInTheDocument();
     expect(screen.getByText("patrick@example.com")).toBeInTheDocument();
-    const workspaceSwitch = screen.getByTestId("you-workspace-switch");
-    expect(workspaceSwitch).toBeInTheDocument();
+    expect(screen.queryByTestId("you-workspace-switch")).toBeNull();
+
+    const statusPlan = screen.getByTestId("you-status-plan");
+    expect(statusPlan).toBeInTheDocument();
+    expect(statusPlan).toHaveTextContent("online");
+    expect(statusPlan).toHaveTextContent("Pro");
     expect(
-      workspaceSwitch.compareDocumentPosition(
-        screen.getByRole("heading", { name: "Patrick Tobler" }),
-      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+      screen
+        .getByText("patrick@example.com")
+        .compareDocumentPosition(statusPlan) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(screen.getByText(/balanceCreditsLabel 15750/)).toBeInTheDocument();
-    expect(screen.getByText("Pro")).toBeInTheDocument();
   });
 
   it("shows a large avatar with initials", () => {

--- a/apps/web/src/app/(app)/you/components/you-page.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.tsx
@@ -15,7 +15,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type ReactElement, useState } from "react";
-import HeaderWorkspaceSwitch from "@/app/components/header/header-workspace-switch.client";
 import { AccountPopoverDrill } from "@/app/components/sidebar/components/account-popover-drill.client";
 import {
   isLowCreditsBalance,
@@ -27,7 +26,6 @@ import type {
   AccountPopoverPanel,
   AccountSummaryCreditProps,
 } from "@/app/components/sidebar/components/account-summary-types";
-import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
 import { openConsentPreferences } from "@/components/analytics/cookie-banner";
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { useGlobalModalsContext } from "@/components/modals/global-modals-context";
@@ -35,8 +33,6 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { useSelfPresence } from "@/hooks/use-self-presence";
-import { useSession } from "@/lib/auth/auth.client";
-import type { MemberWithOrganization } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { formatCreditsForDisplay } from "@/lib/utils/credits";
 import { getInitials } from "@/lib/utils/text";
@@ -49,18 +45,12 @@ const CALENDAR_HREF = "/calendar";
 
 export interface YouPageClientProps extends AccountSummaryCreditProps {
   sessionUser: SessionUser;
-  members: MemberWithOrganization[];
-  hasPersonalWorkspace: boolean;
-  activeOrganizationId: string | null;
   calendarMenuEnabled: boolean;
   adminSettingsChrome: AccountAdminSettingsChrome;
 }
 
 export function YouPageClient({
   sessionUser,
-  members,
-  hasPersonalWorkspace,
-  activeOrganizationId: serverActiveOrganizationId,
   calendarMenuEnabled,
   planName,
   totalCredits,
@@ -81,22 +71,8 @@ export function YouPageClient({
   const { showLogoutModal } = useGlobalModalsContext();
   const router = useRouter();
   const presence = useSelfPresence();
-  const { data: clientSession } = useSession();
-  const { isPending, handleSelectWorkspace } = useWorkspaceSwitcher();
   const [panel, setPanel] = useState<AccountPopoverPanel>({ kind: "root" });
   const [slideFrom, setSlideFrom] = useState<"right" | "left" | null>(null);
-
-  const clientActiveOrganizationId =
-    clientSession?.session.activeOrganizationId;
-  const hasClientActiveOrganization = clientActiveOrganizationId !== undefined;
-
-  const liveActiveOrganizationId = hasClientActiveOrganization
-    ? clientActiveOrganizationId
-    : serverActiveOrganizationId;
-
-  const activeOrganizationId = isPending
-    ? serverActiveOrganizationId
-    : liveActiveOrganizationId;
 
   const displayName = resolveAccountDisplayName(
     sessionUser.name,
@@ -199,52 +175,38 @@ export function YouPageClient({
           "space-y-6",
           slideFrom === "left" &&
             "animate-in fade-in slide-in-from-left-4 duration-200",
-          isPending && "pointer-events-none animate-pulse opacity-60",
         )}
       >
-        <header className="space-y-4">
-          <YouMenuGroup>
-            <HeaderWorkspaceSwitch
-              sessionUser={sessionUser}
-              members={members}
-              hasPersonalWorkspace={hasPersonalWorkspace}
-              activeOrganizationId={activeOrganizationId}
-              isPending={isPending}
-              onSelectWorkspace={handleSelectWorkspace}
-              layout="row"
-            />
-          </YouMenuGroup>
-          <div className="flex items-start gap-4">
-            <YouPageAvatar
-              sessionUser={sessionUser}
-              displayName={displayName}
-            />
-            <div className="min-w-0 flex-1 space-y-1">
-              <h1 className="truncate text-xl leading-tight font-semibold">
-                {displayName}
-              </h1>
-              <p className="text-muted-foreground truncate text-sm">
-                {sessionUser.email}
-              </p>
+        <header className="flex items-start gap-4">
+          <YouPageAvatar sessionUser={sessionUser} displayName={displayName} />
+          <div className="min-w-0 flex-1 space-y-1">
+            <h1 className="truncate text-xl leading-tight font-semibold">
+              {displayName}
+            </h1>
+            <p className="text-muted-foreground truncate text-sm">
+              {sessionUser.email}
+            </p>
+            <div
+              className="flex items-center justify-between gap-2 pt-1"
+              data-testid="you-status-plan"
+            >
+              <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
+                <span aria-hidden="true">
+                  <PresenceDot
+                    presence={presence}
+                    label={presenceLabel}
+                    className="size-2 border-0"
+                  />
+                </span>
+                {presenceLabel}
+              </span>
+              {planName !== null ? (
+                <span className="bg-muted rounded-full px-2 py-0.5 text-[0.6875rem] font-medium">
+                  <span className="sr-only">{`${t("planLabel")}: `}</span>
+                  {planName}
+                </span>
+              ) : null}
             </div>
-          </div>
-          <div className="flex items-center justify-between gap-2">
-            <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
-              <span aria-hidden="true">
-                <PresenceDot
-                  presence={presence}
-                  label={presenceLabel}
-                  className="size-2 border-0"
-                />
-              </span>
-              {presenceLabel}
-            </span>
-            {planName !== null ? (
-              <span className="bg-muted rounded-full px-2 py-0.5 text-[0.6875rem] font-medium">
-                <span className="sr-only">{`${t("planLabel")}: `}</span>
-                {planName}
-              </span>
-            ) : null}
           </div>
         </header>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up on SOK-926 You declutter:

- Restore the Workspace switcher in the app header on mobile and desktop
- Remove the Workspace switch card row from the You page
- Nest Online status and plan badge under the email in the You identity column
- Drop the unused `layout="row"` variant from `HeaderWorkspaceSwitch`

## Verification

Local (exit 0):

- Biome check on touched files
- Vitest: You page + header workspace/profile/mobile-search (40 passed)

CI: green on required checks (Biome, Typecheck, Build, Test Web/Core/Packages, Validate PR Title)

Bugbot: 0 High, 0 Medium

Manual UI on Vercel preview blocked by Vercel SSO; cloud VM has no Neon/`NEON_API_KEY` and no local Postgres for `verify-sokosumi`.

Refs SOK-926
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0a755a9-88b4-4354-b367-617667db14c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0a755a9-88b4-4354-b367-617667db14c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

