### PR TITLE
style(web): plain-link logout on You page

### DIFF
--- a/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
@@ -228,6 +228,7 @@ describe("YouPageClient", () => {
     const logout = screen.getByTestId("you-logout");
     expect(logout.className).not.toContain("bg-destructive");
     expect(logout.className).toContain("px-0");
+    expect(logout.className).toContain("justify-center");
 
     fireEvent.click(logout);
 

--- a/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
@@ -222,11 +222,12 @@ describe("YouPageClient", () => {
     expect(screen.getByTestId("you-logout")).toBeInTheDocument();
   });
 
-  it("uses the destructive button variant and the logout confirmation flow", () => {
+  it("uses a plain link style and the logout confirmation flow", () => {
     renderYouPage();
 
     const logout = screen.getByTestId("you-logout");
-    expect(logout.className).toContain("bg-destructive");
+    expect(logout.className).not.toContain("bg-destructive");
+    expect(logout.className).toContain("px-0");
 
     fireEvent.click(logout);
 

--- a/apps/web/src/app/(app)/you/components/you-page.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.tsx
@@ -315,7 +315,7 @@ export function YouPageClient({
           variant="link"
           size="sm"
           onClick={handleLogout}
-          className="text-muted-foreground hover:text-foreground h-11 w-full justify-start gap-2 px-0 font-normal no-underline hover:no-underline md:h-8"
+          className="text-muted-foreground hover:text-foreground h-11 w-full justify-center gap-2 px-0 font-normal no-underline hover:no-underline md:h-8"
           data-testid="you-logout"
         >
           <LogOut className="size-4 shrink-0" aria-hidden />

--- a/apps/web/src/app/(app)/you/components/you-page.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.tsx
@@ -312,10 +312,10 @@ export function YouPageClient({
 
         <Button
           type="button"
-          variant="destructive"
+          variant="link"
           size="sm"
           onClick={handleLogout}
-          className="h-11 w-full gap-2 md:h-8"
+          className="text-muted-foreground hover:text-foreground h-11 w-full justify-start gap-2 px-0 font-normal no-underline hover:no-underline md:h-8"
           data-testid="you-logout"
         >
           <LogOut className="size-4 shrink-0" aria-hidden />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the You page, Log out is a plain text link (no destructive fill/border) and is centered in its row.

## Verification

- `pnpm --filter web exec vitest run 'src/app/(app)/you/components/you-page.client.test.tsx'`
- Pre-commit: `pnpm check` + `pnpm typecheck`
- Manual: signed in → `/you` → Log out is muted centered text

[You page logout centered plain link](https://cursor.com/agents/bc-fb757cb8-1889-43bf-b49f-55431b8a5557/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-logout-centered-mobile.png)
[you-logout-centered-demo.mp4](https://cursor.com/agents/bc-fb757cb8-1889-43bf-b49f-55431b8a5557/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-logout-centered-demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb757cb8-1889-43bf-b49f-55431b8a5557?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb757cb8-1889-43bf-b49f-55431b8a5557&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

