### PR TITLE
fix(agents): bootstrap Corepack pnpm for environment builds

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "Sokosumi Monorepo",
   "agentCanUpdateSnapshot": true,
-  "install": "pnpm install && node scripts/cloud-agent-db/provision.mjs",
-  "start": "node scripts/cloud-agent-db/with-db.mjs -- pnpm dev"
+  "install": "bash scripts/cloud-agent-db/ensure-pnpm.sh install && node scripts/cloud-agent-db/provision.mjs",
+  "start": "node scripts/cloud-agent-db/with-db.mjs -- bash scripts/cloud-agent-db/ensure-pnpm.sh dev"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,18 +393,19 @@ Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily). Se
 
 ## Cursor Cloud specific instructions
 
-These notes cover non-obvious, durable facts about running this repo in the Cursor Cloud VM. The update script runs `pnpm install` then provisions an ephemeral Neon agent database when secrets are present (see below). Node, tooling, and non-DB `.env` values may still come from the VM snapshot.
+These notes cover non-obvious, durable facts about running this repo in the Cursor Cloud VM. The update script runs Corepack-backed `pnpm install` (`scripts/cloud-agent-db/ensure-pnpm.sh`) then provisions an ephemeral Neon agent database when secrets are present (see below). Node, tooling, and non-DB `.env` values may still come from the VM snapshot.
 
 ### Runtime versions
 
 - **Node 24 is the required runtime** (`engines: 24.x`, root `.nvmrc` = `lts/krypton`). The base image's `/exec-daemon/node` is Node 22 and is early in `PATH`, so Node 24 (installed via nvm) is symlinked into `/usr/local/cargo/bin` (which is first in `PATH`) as `node`/`npm`/`npx`/`corepack`/`pnpm`. This makes `node -v` = 24 and `pnpm -v` = 12.2.1 in **every** shell (login or not). If a future run somehow sees Node 22, recreate those symlinks from `~/.nvm/versions/node/v24*/bin`.
+- **pnpm via Corepack:** Environment `install`/`start` call `scripts/cloud-agent-db/ensure-pnpm.sh`, which `corepack prepare`s the `packageManager` pin and deletes `~/.local/share/pnpm/.tools/pnpm`. A leftover pnpm 12 standalone placeholder there is not a valid shell script and fails builds with `Syntax error: ")" unexpected`.
 
 ### Database (Cloud agent Neon branch)
 
 Cloud agents get a **disposable Neon branch** forked from production/`main`, not a shared mutable DB and not live production writes.
 
-- **Provision:** `.cursor/environment.json` `install` runs `node scripts/cloud-agent-db/provision.mjs` after `pnpm install` when `CURSOR_AGENT=1` and `NEON_API_KEY` + `NEON_PROJECT_ID` are set (Cursor Runtime Secrets). Branch name: `cloud-agent-<CURSOR_CONVERSATION_ID>`. Parent is always `NEON_PARENT_BRANCH` (default `main`). Resume reuses the same branch and refreshes the **72h** `expires_at` TTL. Pending migrations run via `pnpm prisma:migrate:deploy` (`DATABASE_URL_UNPOOLED`). After migrate, upserts guarded auth fixtures (`admin@sokosumi.test` / `alice@sokosumi.test` / `bob@sokosumi.test` / `zero@sokosumi.test` / `Password123!`) on agent branches only — **not** a full catalog seed.
-- **Use:** Prefer `node scripts/cloud-agent-db/with-db.mjs -- <command>` so ambient/stale `DATABASE_URL` cannot win. `start` already wraps `pnpm dev`. Login shells source `.cursor/cloud-agent-db.env` via bashrc/profile.
+- **Provision:** `.cursor/environment.json` `install` runs `bash scripts/cloud-agent-db/ensure-pnpm.sh install` then `node scripts/cloud-agent-db/provision.mjs` when `CURSOR_AGENT=1` and `NEON_API_KEY` + `NEON_PROJECT_ID` are set (Cursor Runtime Secrets). Branch name: `cloud-agent-<CURSOR_CONVERSATION_ID>`. Parent is always `NEON_PARENT_BRANCH` (default `main`). Resume reuses the same branch and refreshes the **72h** `expires_at` TTL. Pending migrations run via `pnpm prisma:migrate:deploy` (`DATABASE_URL_UNPOOLED`). After migrate, upserts guarded auth fixtures (`admin@sokosumi.test` / `alice@sokosumi.test` / `bob@sokosumi.test` / `zero@sokosumi.test` / `Password123!`) on agent branches only — **not** a full catalog seed.
+- **Use:** Prefer `node scripts/cloud-agent-db/with-db.mjs -- <command>` so ambient/stale `DATABASE_URL` cannot win. `start` already wraps `ensure-pnpm.sh dev`. Login shells source `.cursor/cloud-agent-db.env` via bashrc/profile.
 - **Teardown:** deletes only `cloud-agent-*` branches — never production/`main`. Triggers: PR merged/closed (GitHub Action parses `bc-…` from PR body), agent completes with no PR (`pnpm cloud-agent-db:teardown`), agent archived (same when possible). Idle **72h** expiry is Neon `expires_at` only (no scheduled Action GC).
 - **Do not** put a static production `DATABASE_URL` in Cursor secrets. Full runbook: [`docs/agents/cloud-agent-database.md`](./docs/agents/cloud-agent-database.md).
 

--- a/docs/agents/cloud-agent-database.md
+++ b/docs/agents/cloud-agent-database.md
@@ -30,10 +30,12 @@ branch named `cloud-agent-<run-id>`.
 
 ## Provision (how agents get the URL)
 
-`.cursor/environment.json` runs provision after `pnpm install`:
+`.cursor/environment.json` runs provision after a Corepack-backed `pnpm install`
+(`scripts/cloud-agent-db/ensure-pnpm.sh` avoids a broken pnpm 12 `.tools`
+placeholder that fails environment builds with `Syntax error: ")" unexpected`):
 
 ```bash
-pnpm install && node scripts/cloud-agent-db/provision.mjs
+bash scripts/cloud-agent-db/ensure-pnpm.sh install && node scripts/cloud-agent-db/provision.mjs
 ```
 
 When `CURSOR_AGENT=1` and Neon secrets are present, provision:

--- a/scripts/cloud-agent-db/ensure-pnpm.sh
+++ b/scripts/cloud-agent-db/ensure-pnpm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Activate Corepack pnpm for this repo and drop broken standalone installs.
+#
+# pnpm 12+ under ~/.local/share/pnpm/.tools ships a native-binary placeholder
+# that install.js is supposed to replace. When that postinstall does not run,
+# invoking the placeholder via /bin/sh fails with:
+#   Syntax error: ")" unexpected
+# Environment builds were hitting that path during `pnpm install`.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}"
+
+PM="$(node -p "require('./package.json').packageManager")"
+corepack enable
+corepack prepare "${PM}" --activate
+rm -rf "${HOME}/.local/share/pnpm/.tools/pnpm"
+hash -r 2>/dev/null || true
+
+exec corepack pnpm "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recurring Cursor environment builds were failing install with:

```text
~/.local/share/pnpm/.tools/pnpm/12.2.1/bin/pnpm: Syntax error: ")" unexpected
```

pnpm 12’s standalone `.tools` tree ships a native-binary **placeholder** that `install.js` is supposed to replace. When that postinstall does not run, `/bin/sh` executes the placeholder and exits 2 — before `pnpm install` can start.

## Fix

- Add `scripts/cloud-agent-db/ensure-pnpm.sh` to `corepack prepare` the repo `packageManager` pin, delete `~/.local/share/pnpm/.tools/pnpm`, then run `corepack pnpm …`
- Point `.cursor/environment.json` `install` / `start` at that helper
- Document the failure mode in `AGENTS.md` and `docs/agents/cloud-agent-database.md`

## Verification

- Local smoke: broken `.tools` shim first on `PATH` reproduces the build error; `ensure-pnpm.sh -v` removes it and prints `12.2.1`
- Draft environment build `bld-20260902-a12c034d-3056-4690-8660-9c865f2edaae` on this branch: **SUCCEEDED** (previous recurring builds were `INSTALL_FAILED` on the same pnpm syntax error)

## Notes

After merge to `main`, let a successful (non-draft) environment build become the active snapshot so new agents stop booting from failed installs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dca802a8-2c54-4620-83ac-8a4abc0be612?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dca802a8-2c54-4620-83ac-8a4abc0be612&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

