### PR TITLE
feat(admin): show the behaviour lab what it is doing while it runs

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4357,7 +4357,18 @@
           "noBotLink": "Hier erstellen.",
           "runsAgainst": "Jeder Lauf ist ein echter Durchlauf von {bot}, dem Assistenten von {account}.",
           "unnamedBot": "deinem Assistenten",
-          "failedChecks": "Fehlgeschlagen: {labels}"
+          "failedChecks": "Fehlgeschlagen: {labels}",
+          "phaseStarting": "Durchlauf wird gestartet…",
+          "phaseQueued": "In der Warteschlange – wartet auf den Assistenten",
+          "phaseRunning": "Läuft",
+          "phaseJudging": "Durchlauf beendet – wird bewertet",
+          "liveRoute": "Route: {route}",
+          "liveNoSteps": "Noch keine Tool-Aufrufe.",
+          "stepWorking": "läuft",
+          "stepDone": "fertig",
+          "stepFailed": "fehlgeschlagen",
+          "previousRun": "Vorheriger Durchlauf",
+          "batchProgress": "{done} von {total} werden ausgeführt"
         },
         "KillSwitch": {
           "title": "Funktionsschalter",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4388,7 +4388,18 @@
           "noBotLink": "Create it here.",
           "runsAgainst": "Every run is a real turn on {bot}, the assistant belonging to {account}.",
           "unnamedBot": "your assistant",
-          "failedChecks": "Failed: {labels}"
+          "failedChecks": "Failed: {labels}",
+          "phaseStarting": "Starting the turn…",
+          "phaseQueued": "Queued — waiting for the assistant to pick it up",
+          "phaseRunning": "Running",
+          "phaseJudging": "Turn finished — judging",
+          "liveRoute": "Route: {route}",
+          "liveNoSteps": "No tool calls yet.",
+          "stepWorking": "running",
+          "stepDone": "done",
+          "stepFailed": "failed",
+          "previousRun": "Previous run",
+          "batchProgress": "Running {done} of {total}"
         },
         "KillSwitch": {
           "title": "Feature switch",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4357,7 +4357,18 @@
           "noBotLink": "Créalo aquí.",
           "runsAgainst": "Cada ejecución es un turno real de {bot}, el asistente de {account}.",
           "unnamedBot": "tu asistente",
-          "failedChecks": "Fallaron: {labels}"
+          "failedChecks": "Fallaron: {labels}",
+          "phaseStarting": "Iniciando el turno…",
+          "phaseQueued": "En cola: esperando a que el asistente lo tome",
+          "phaseRunning": "En ejecución",
+          "phaseJudging": "Turno terminado: evaluando",
+          "liveRoute": "Ruta: {route}",
+          "liveNoSteps": "Aún no hay llamadas a herramientas.",
+          "stepWorking": "en curso",
+          "stepDone": "listo",
+          "stepFailed": "falló",
+          "previousRun": "Ejecución anterior",
+          "batchProgress": "Ejecutando {done} de {total}"
         },
         "KillSwitch": {
           "title": "Interruptor de la función",

--- a/apps/web/src/components/admin/soko-bots/__tests__/scenario-lab-live-progress.test.tsx
+++ b/apps/web/src/components/admin/soko-bots/__tests__/scenario-lab-live-progress.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listRunsMock, setVersionMock, startTurnMock, judgeMock } = vi.hoisted(
+  () => ({
+    listRunsMock: vi.fn(),
+    setVersionMock: vi.fn(),
+    startTurnMock: vi.fn(),
+    judgeMock: vi.fn(),
+  }),
+);
+
+vi.mock("next-intl", () => ({
+  useFormatter: () => ({
+    dateTime: (value: Date) => value.toISOString(),
+    number: (value: number) => String(value),
+    relativeTime: () => "just now",
+  }),
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/lib/actions/soko-bot/action", () => ({
+  judgeSokoBotLabTurnAction: (...args: unknown[]) => judgeMock(...args),
+  listSokoBotLabRunsAction: (...args: unknown[]) => listRunsMock(...args),
+  setSokoBotVersionAction: (...args: unknown[]) => setVersionMock(...args),
+  simulateSokoBotTaskEventAction: vi.fn(async () => ({
+    ok: true,
+    value: { turnId: "turn_1" },
+  })),
+  runSokoBotLabIngestAction: vi.fn(async () => ({
+    ok: true,
+    value: { turnId: "turn_1" },
+  })),
+  startSokoBotTurnAction: (...args: unknown[]) => startTurnMock(...args),
+}));
+
+import type { SokoBotVersion } from "@/lib/clients/generated/core";
+import { ScenarioLab } from "../scenario-lab.client";
+
+const VERSIONS: SokoBotVersion[] = [
+  {
+    id: "v11",
+    name: "Version 11",
+    createdAt: "2026-08-01",
+    summary: "Current version",
+    model: "model/v11",
+    skills: [],
+    capabilities: null,
+    inferenceRegion: null,
+    systemPrompt: "Version 11 prompt",
+  },
+];
+
+function turn(status: string, toolCalls: unknown[]) {
+  return {
+    id: "turn_1",
+    status,
+    route: "DELEGATE_TASK",
+    toolCalls,
+    finalAnswer: null,
+    events: [],
+    delegations: [],
+    decisions: [],
+  };
+}
+
+describe("ScenarioLab live progress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listRunsMock.mockResolvedValue({ ok: true, value: [] });
+    setVersionMock.mockResolvedValue({ ok: true, value: { id: "bot" } });
+    judgeMock.mockResolvedValue({ ok: true, value: {} });
+  });
+
+  it("shows the step the assistant is on while the turn runs", async () => {
+    startTurnMock.mockResolvedValue({ ok: true, value: { turnId: "turn_1" } });
+    // Two polls: still running with one finished call and one in flight, then
+    // settled. The first is what a reader used to have no way of seeing.
+    const running = turn("RUNNING", [
+      { id: "c1", capability: "create_task", status: "COMPLETED" },
+      { id: "c2", capability: "create_schedule", status: "RUNNING" },
+    ]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ turn: running }),
+      })),
+    );
+
+    render(<ScenarioLab versionId="v11" versions={VERSIONS} />, {
+      wrapper: withNuqsTestingAdapter({}),
+    });
+
+    // Exactly "run": the page also has runAll and runAllVersions, and the
+    // first scenario is a plain prompt rather than a simulated trigger.
+    const runButtons = await screen.findAllByRole("button", { name: "run" });
+    fireEvent.click(runButtons[0] as HTMLElement);
+
+    await waitFor(() =>
+      expect(screen.getByText("create_schedule")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("create_task")).toBeInTheDocument();
+    // The route it took, without opening the turn.
+    expect(screen.getByText("liveRoute")).toBeInTheDocument();
+  });
+
+  it("names the old result as previous so it is not read as the live one", async () => {
+    listRunsMock.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          scenarioId: "delegate-with-daily-checkin",
+          turnId: "turn_0",
+          versionId: "v11",
+          createdAt: new Date().toISOString(),
+          passed: 7,
+          total: 7,
+          durationMs: 11_000,
+          costUsd: 0.02,
+          checks: [],
+          judge: null,
+          judgeModel: null,
+        },
+      ],
+    });
+    startTurnMock.mockResolvedValue({ ok: true, value: { turnId: "turn_1" } });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ turn: turn("RUNNING", []) }),
+      })),
+    );
+
+    render(<ScenarioLab versionId="v11" versions={VERSIONS} />, {
+      wrapper: withNuqsTestingAdapter({}),
+    });
+
+    // Exactly "run": the page also has runAll and runAllVersions, and the
+    // first scenario is a plain prompt rather than a simulated trigger.
+    const runButtons = await screen.findAllByRole("button", { name: "run" });
+    fireEvent.click(runButtons[0] as HTMLElement);
+
+    await waitFor(() =>
+      expect(screen.getByText("previousRun")).toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/web/src/components/admin/soko-bots/scenario-lab.client.tsx
+++ b/apps/web/src/components/admin/soko-bots/scenario-lab.client.tsx
@@ -29,7 +29,10 @@ import type {
 import type { ChatTurnDetail } from "@/lib/soko-bot/chat-state";
 import { cn } from "@/lib/utils";
 
-const POLL_MS = 3_000;
+// A run is watched, not waited on, so this is a refresh rate rather than a
+// timeout budget: at three seconds a whole scenario could finish between two
+// polls and never show a step.
+const POLL_MS = 1_200;
 const TIMEOUT_MS = 5 * 60_000;
 const HISTORY_PER_SCENARIO = 8;
 
@@ -70,6 +73,18 @@ function toHistory(runs: SokoBotLabRun[]): History {
   return history;
 }
 
+/** What the lab is doing right now, in the order it happens. */
+type LivePhase = "starting" | "queued" | "running" | "judging";
+
+interface LiveRun {
+  scenarioId: string;
+  phase: LivePhase;
+  /** Null until the trigger hands one back. */
+  turnId: string | null;
+  turn: ChatTurnDetail | null;
+  startedAt: number;
+}
+
 async function fetchTurn(turnId: string): Promise<ChatTurnDetail | null> {
   const response = await fetch(
     `/api/personal-assistant/turns/${encodeURIComponent(turnId)}`,
@@ -82,12 +97,22 @@ async function fetchTurn(turnId: string): Promise<ChatTurnDetail | null> {
 
 const FINAL_STATUSES = new Set(["COMPLETED", "FAILED", "CANCELLED"]);
 
-/** The EVENT turn the sync starts for a simulated Coworker event (next cron tick). */
-async function waitForTurn(turnId: string): Promise<ChatTurnDetail | null> {
+/**
+ * Watches a turn to completion, reporting every poll rather than only the
+ * last. The turn carries its tool calls as they land, so the caller can show
+ * the step the assistant is on instead of a spinner over the previous result.
+ */
+async function watchTurn(
+  turnId: string,
+  onProgress: (turn: ChatTurnDetail) => void,
+): Promise<ChatTurnDetail | null> {
   const deadline = Date.now() + TIMEOUT_MS;
   while (Date.now() < deadline) {
     const turn = await fetchTurn(turnId);
-    if (turn && FINAL_STATUSES.has(turn.status)) return turn;
+    if (turn) {
+      onProgress(turn);
+      if (FINAL_STATUSES.has(turn.status)) return turn;
+    }
     await new Promise((resolve) => setTimeout(resolve, POLL_MS));
   }
   return null;
@@ -99,6 +124,108 @@ async function waitForTurn(turnId: string): Promise<ChatTurnDetail | null> {
  * this browser so a prompt or model change can be compared with the last
  * runs. Runs create real tasks and approvals in the owner's workspace.
  */
+/** Ticks once a second so an elapsed time is not frozen at its first render. */
+function useElapsed(since: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (since === null) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(id);
+  }, [since]);
+  return since === null ? 0 : Math.max(0, Math.round((now - since) / 1000));
+}
+
+function formatDuration(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  return minutes > 0
+    ? `${minutes}:${String(seconds % 60).padStart(2, "0")}`
+    : `${seconds}s`;
+}
+
+/**
+ * What the assistant is doing, right now, in the order it happened.
+ *
+ * Without this the row kept showing the previous run's verdict under a
+ * spinner, which is the one thing a reader must not mistake for the current
+ * one — so this replaces that result while a run is in flight.
+ */
+function LiveRunPanel({ live }: { live: LiveRun }) {
+  const t = useTranslations("App.Admin.SokoBots.Lab");
+  const elapsed = useElapsed(live.startedAt);
+  const calls = live.turn?.toolCalls ?? [];
+  const phaseLabel =
+    live.phase === "starting"
+      ? t("phaseStarting")
+      : live.phase === "queued"
+        ? t("phaseQueued")
+        : live.phase === "judging"
+          ? t("phaseJudging")
+          : t("phaseRunning");
+
+  return (
+    <div className="border-primary/40 bg-primary/5 mt-3 rounded-md border px-3 py-2">
+      <p className="flex items-center gap-2 text-xs font-medium">
+        <span
+          className="bg-primary size-1.5 shrink-0 animate-pulse rounded-full"
+          aria-hidden
+        />
+        {phaseLabel}
+        <span className="text-muted-foreground ml-auto font-normal tabular-nums">
+          {formatDuration(elapsed)}
+        </span>
+      </p>
+
+      {live.turn?.route ? (
+        <p className="text-muted-foreground mt-1 text-xs">
+          {t("liveRoute", { route: live.turn.route })}
+        </p>
+      ) : null}
+
+      {calls.length > 0 ? (
+        <ol className="mt-2 space-y-1">
+          {calls.map((call, index) => (
+            <li
+              key={call.id}
+              className="flex items-baseline gap-2 font-mono text-[0.6875rem]"
+            >
+              <span className="text-muted-foreground w-4 shrink-0 text-right tabular-nums">
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1 truncate">{call.capability}</span>
+              <span
+                className={cn(
+                  "shrink-0",
+                  call.status === "FAILED"
+                    ? "text-semantic-destructive"
+                    : call.status === "COMPLETED"
+                      ? "text-muted-foreground"
+                      : "text-primary",
+                )}
+              >
+                {call.status === "FAILED"
+                  ? t("stepFailed")
+                  : call.status === "COMPLETED"
+                    ? t("stepDone")
+                    : t("stepWorking")}
+              </span>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="text-muted-foreground mt-2 text-xs">{t("liveNoSteps")}</p>
+      )}
+
+      {/* The one thing that explains a failed step without opening the turn. */}
+      {calls.find((call) => call.status === "FAILED")?.errorDetail ? (
+        <p className="text-semantic-destructive mt-2 text-xs">
+          {calls.find((call) => call.status === "FAILED")?.errorDetail}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 export function ScenarioLab({
   versionId,
   versions,
@@ -175,6 +302,15 @@ export function ScenarioLab({
   }
   const [running, setRunning] = useState<Set<string>>(new Set());
   const [failures, setFailures] = useState<Record<string, string>>({});
+  // One at a time: turns share the bot's session lock, so this is the run the
+  // whole page is waiting on rather than one of several.
+  const [live, setLive] = useState<LiveRun | null>(null);
+  /** Where a Run all has got to, so the wait has a denominator. */
+  const [batch, setBatch] = useState<{
+    done: number;
+    total: number;
+    startedAt: number;
+  } | null>(null);
 
   const loadHistory = useCallback(async () => {
     const result = await listSokoBotLabRunsAction({});
@@ -188,6 +324,13 @@ export function ScenarioLab({
   async function run(scenario: SokoBotScenario) {
     setRunning((current) => new Set(current).add(scenario.id));
     setFailures(({ [scenario.id]: _dropped, ...rest }) => rest);
+    setLive({
+      scenarioId: scenario.id,
+      phase: "starting",
+      turnId: null,
+      turn: null,
+      startedAt: Date.now(),
+    });
     try {
       let turnId: string | null;
       if (scenario.trigger?.kind === "ingest") {
@@ -248,7 +391,24 @@ export function ScenarioLab({
         }));
         return;
       }
-      const turn = await waitForTurn(turnId);
+      setLive((current) =>
+        current?.scenarioId === scenario.id
+          ? { ...current, phase: "queued", turnId }
+          : current,
+      );
+      const turn = await watchTurn(turnId, (progress) => {
+        setLive((current) =>
+          current?.scenarioId === scenario.id
+            ? {
+                ...current,
+                phase: FINAL_STATUSES.has(progress.status)
+                  ? "judging"
+                  : "running",
+                turn: progress,
+              }
+            : current,
+        );
+      });
       if (!turn) {
         setFailures((current) => ({
           ...current,
@@ -276,18 +436,49 @@ export function ScenarioLab({
         next.delete(scenario.id);
         return next;
       });
+      setLive((current) =>
+        current?.scenarioId === scenario.id ? null : current,
+      );
     }
   }
 
   async function runAll() {
     // Sequential: turns share the bot's session lock and the context they read.
-    for (const scenario of SOKO_BOT_SCENARIOS) await run(scenario);
+    setBatch({
+      done: 0,
+      total: SOKO_BOT_SCENARIOS.length,
+      startedAt: Date.now(),
+    });
+    try {
+      for (const scenario of SOKO_BOT_SCENARIOS) {
+        await run(scenario);
+        setBatch((current) =>
+          current ? { ...current, done: current.done + 1 } : current,
+        );
+      }
+    } finally {
+      setBatch(null);
+    }
   }
 
   async function runAllVersions() {
-    for (const version of versions) {
-      await chooseVersion(version.id);
-      for (const scenario of SOKO_BOT_SCENARIOS) await run(scenario);
+    setBatch({
+      done: 0,
+      total: versions.length * SOKO_BOT_SCENARIOS.length,
+      startedAt: Date.now(),
+    });
+    try {
+      for (const version of versions) {
+        await chooseVersion(version.id);
+        for (const scenario of SOKO_BOT_SCENARIOS) {
+          await run(scenario);
+          setBatch((current) =>
+            current ? { ...current, done: current.done + 1 } : current,
+          );
+        }
+      }
+    } finally {
+      setBatch(null);
     }
   }
 
@@ -384,6 +575,7 @@ export function ScenarioLab({
           </Button>
         </div>
       </div>
+      {batch ? <BatchProgress batch={batch} live={live} /> : null}
       <ol className="divide-y rounded-lg border">
         {SOKO_BOT_SCENARIOS.map((scenario) => (
           <ScenarioRow
@@ -393,6 +585,7 @@ export function ScenarioLab({
               (run) => run.versionId === activeVersion,
             )}
             running={running.has(scenario.id)}
+            live={live?.scenarioId === scenario.id ? live : null}
             disabled={anyRunning}
             failure={failures[scenario.id] ?? null}
             onRun={() => void run(scenario)}
@@ -403,10 +596,57 @@ export function ScenarioLab({
   );
 }
 
+/** How far a Run all has got, so the wait has a denominator and an end. */
+function BatchProgress({
+  batch,
+  live,
+}: {
+  batch: { done: number; total: number; startedAt: number };
+  live: LiveRun | null;
+}) {
+  const t = useTranslations("App.Admin.SokoBots.Lab");
+  const elapsed = useElapsed(batch.startedAt);
+  const current = SOKO_BOT_SCENARIOS.find(
+    (scenario) => scenario.id === live?.scenarioId,
+  );
+  const percent = Math.round((batch.done / Math.max(1, batch.total)) * 100);
+
+  return (
+    <div className="rounded-lg border px-4 py-3">
+      <p className="flex flex-wrap items-baseline gap-x-2 text-xs">
+        <span className="font-medium tabular-nums">
+          {t("batchProgress", { done: batch.done, total: batch.total })}
+        </span>
+        {current ? (
+          <span className="text-muted-foreground truncate">
+            {current.title}
+          </span>
+        ) : null}
+        <span className="text-muted-foreground ml-auto tabular-nums">
+          {formatDuration(elapsed)}
+        </span>
+      </p>
+      <div
+        className="bg-muted mt-2 h-1 overflow-hidden rounded-full"
+        role="progressbar"
+        aria-valuenow={batch.done}
+        aria-valuemin={0}
+        aria-valuemax={batch.total}
+      >
+        <div
+          className="bg-primary h-full transition-[width] duration-300"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
 function ScenarioRow({
   scenario,
   runs,
   running,
+  live,
   disabled,
   failure,
   onRun,
@@ -414,6 +654,7 @@ function ScenarioRow({
   scenario: SokoBotScenario;
   runs: RunRecord[];
   running: boolean;
+  live: LiveRun | null;
   disabled: boolean;
   failure: string | null;
   onRun: () => void;
@@ -421,16 +662,28 @@ function ScenarioRow({
   const t = useTranslations("App.Admin.SokoBots.Lab");
   const format = useFormatter();
   const [open, setOpen] = useState(false);
+  const rowRef = useRef<HTMLLIElement | null>(null);
   const latest = runs[0] ?? null;
+  // The row being run opens itself: the steps are the reason to look here, and
+  // needing a click to see them is what made a run feel like a frozen page.
+  const expanded = open || live !== null;
+
+  // A Run all works through twenty-two scenarios; without this the one being
+  // run is usually somewhere off-screen.
+  const isLive = live !== null;
+  useEffect(() => {
+    if (!isLive) return;
+    rowRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [isLive]);
 
   return (
-    <li className="px-4 py-3">
+    <li ref={rowRef} className="px-4 py-3">
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
           <button
             type="button"
             onClick={() => setOpen((value) => !value)}
-            aria-expanded={open}
+            aria-expanded={expanded}
             className="text-left"
           >
             <span className="text-sm font-medium">{scenario.title}</span>
@@ -439,7 +692,11 @@ function ScenarioRow({
             </span>
           </button>
         </div>
-        <ScoreTrail runs={runs} />
+        {/* Dimmed with the rest of the previous result: at full strength
+            beside a live run it reads as the score being produced. */}
+        <div className={cn(live && "opacity-60")}>
+          <ScoreTrail runs={runs} />
+        </div>
         <Button
           type="button"
           size="sm"
@@ -457,7 +714,8 @@ function ScenarioRow({
       {failure ? (
         <p className="text-semantic-destructive mt-2 text-xs">{failure}</p>
       ) : null}
-      {open ? (
+      {live ? <LiveRunPanel live={live} /> : null}
+      {expanded ? (
         <div className="mt-3 space-y-3">
           <blockquote className="text-muted-foreground border-l-2 pl-3 text-xs leading-relaxed">
             {scenario.trigger?.kind === "task_event"
@@ -467,7 +725,14 @@ function ScenarioRow({
                 : scenario.prompt}
           </blockquote>
           {latest ? (
-            <div className="space-y-2">
+            <div className={cn("space-y-2", live && "opacity-60")}>
+              {/* Named while a run is in flight, so the verdict on screen is
+                  never mistaken for the one being produced. */}
+              {live ? (
+                <p className="text-muted-foreground text-xs font-medium">
+                  {t("previousRun")}
+                </p>
+              ) : null}
               <p
                 className="text-muted-foreground text-xs tabular-nums"
                 suppressHydrationWarning


### PR DESCRIPTION
Starting a scenario left the row showing the **previous** run's verdict with a pulsing play icon over it. Nothing said which step the assistant was on, how long it had been going, or that the result on screen was already stale. With twenty-two scenarios, a Run all gave no sense of how far through it was.

## The data was already being fetched and thrown away

`waitForTurn` polled the turn every three seconds and discarded it unless it had settled — so the tool calls arriving on that turn were being dropped on every poll but the last. It reports each poll now, and a run shows its steps as they land: each capability numbered in order, `running` / `done` / `failed`, with a failed step's error inline so the common case needs no trip to the turn detail.

```
● Running                                   18s
  Route: DELEGATE_TASK
  1  list_schedules                        done
  2  find_coworkers                        done
  3  create_task                           done
  4  create_schedule                    running
```

## Phases are named, not implied

`starting` → `queued` → `running` → `judging`. The wait before a turn is picked up looked identical to a hung page, and judging after the turn settled looked like nothing at all.

## The previous result stops pretending to be the current one

It stays visible — comparing against the last run is the point of the lab — but dimmed and labelled **Previous run**, and that now includes its score trail. At full strength beside a live run the trail read as the score being produced, which is the specific confusion this set out to fix.

## Run all has a denominator

"Running 6 of 22", a progress bar, elapsed time, and the running scenario named. The row being run scrolls itself into view and opens itself, since needing a click to see the steps is most of what made a run feel frozen.

## One number changed

Poll interval 3s → 1.2s. At three seconds a short scenario could start and finish between two polls and never show a step at all.

## Verification

- Compared before and after at 1400px in a local harness, across all four phases and a failed step
- Two new tests: the live steps appear while the turn is still running, and the old result is labelled rather than left ambiguous
- 4199 web tests, biome and `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt6But7wNmMpRx4C7ykdnV