### PR TITLE
feat(web): flatten You settings into main menu sections

### DIFF
--- a/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
@@ -22,6 +22,10 @@ vi.mock("@/hooks/use-self-presence", () => ({
   useSelfPresence: () => "online",
 }));
 
+vi.mock("@/components/analytics/cookie-banner", () => ({
+  openConsentPreferences: vi.fn(),
+}));
+
 import { YouPageClient } from "@/app/you/components/you-page.client";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
 
@@ -135,78 +139,102 @@ describe("YouPageClient", () => {
     expect(screen.getByTestId("you-files")).toHaveAttribute("href", "/drive");
   });
 
-  it("groups Admin and Settings before Log out when admin is enabled", () => {
+  it("shows Admin alone before account links when admin is enabled", () => {
     renderYouPage();
 
     const admin = screen.getByTestId("you-admin");
-    const settings = screen.getByTestId("you-settings");
+    const account = screen.getByTestId("you-account");
     const logout = screen.getByTestId("you-logout");
 
     expect(admin).toHaveAttribute("href", "/admin");
-    expect(settings).not.toHaveAttribute("href");
+    expect(account).toHaveAttribute("href", "/account");
+    expect(screen.queryByTestId("you-settings")).toBeNull();
     expect(
-      admin.compareDocumentPosition(settings) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+      admin.compareDocumentPosition(account) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      settings.compareDocumentPosition(logout) &
+      account.compareDocumentPosition(logout) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 
-  it("opens an in-page settings drill instead of navigating to /account", () => {
+  it("flattens account and drill triggers onto the root menu", () => {
     renderYouPage();
 
-    fireEvent.click(screen.getByTestId("you-settings"));
-
-    expect(pushMock).not.toHaveBeenCalled();
-    expect(screen.getByTestId("you-settings-panel")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "account" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "developer" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "help" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "legal" })).toBeInTheDocument();
-    expect(screen.queryByTestId("you-logout")).toBeNull();
-    expect(screen.queryByTestId("you-buy-credits")).toBeNull();
-  });
-
-  it("navigates to an account destination from the settings drill", () => {
-    renderYouPage();
-
-    fireEvent.click(screen.getByTestId("you-settings"));
-    fireEvent.click(screen.getByRole("button", { name: "account" }));
-
-    expect(pushMock).toHaveBeenCalledWith("/account");
-  });
-
-  it("returns to the You root from the settings drill back control", () => {
-    renderYouPage();
-
-    fireEvent.click(screen.getByTestId("you-settings"));
-    expect(screen.getByTestId("you-settings-panel")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "back" }));
-
-    expect(screen.queryByTestId("you-settings-panel")).toBeNull();
-    expect(screen.getByTestId("you-settings")).toBeInTheDocument();
+    expect(screen.queryByTestId("you-settings")).toBeNull();
+    expect(screen.getByTestId("you-account")).toHaveAttribute(
+      "href",
+      "/account",
+    );
+    expect(screen.getByTestId("you-billing")).toHaveAttribute(
+      "href",
+      "/billing",
+    );
+    expect(screen.getByTestId("you-connections")).toHaveAttribute(
+      "href",
+      "/connections",
+    );
+    expect(screen.getByTestId("you-developer")).toBeInTheDocument();
+    expect(screen.getByTestId("you-help")).toBeInTheDocument();
+    expect(screen.getByTestId("you-legal")).toBeInTheDocument();
+    expect(screen.getByTestId("you-buy-credits")).toBeInTheDocument();
     expect(screen.getByTestId("you-logout")).toBeInTheDocument();
   });
 
-  it("drills into nested settings panels on the You page", () => {
+  it("navigates to an account destination from the flattened account link", () => {
     renderYouPage();
 
-    fireEvent.click(screen.getByTestId("you-settings"));
-    fireEvent.click(screen.getByRole("button", { name: "help" }));
+    fireEvent.click(screen.getByTestId("you-account"));
 
-    expect(
-      screen.getByRole("button", { name: "documentation" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "support" })).toBeInTheDocument();
+    expect(screen.getByTestId("you-account")).toHaveAttribute(
+      "href",
+      "/account",
+    );
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: "back" }));
+  it("drills Developer inside the section while keeping credits and logout", () => {
+    renderYouPage();
 
-    expect(screen.getByRole("button", { name: "account" })).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("you-developer"));
+
+    expect(screen.getByTestId("you-drill-section")).toBeInTheDocument();
+    expect(screen.getByTestId("you-drill-back")).toBeInTheDocument();
+    expect(screen.getByTestId("you-developer-docs")).toHaveAttribute(
+      "href",
+      "/developer/docs",
+    );
+    expect(screen.getByTestId("you-buy-credits")).toBeInTheDocument();
+    expect(screen.getByTestId("you-logout")).toBeInTheDocument();
+    expect(screen.getByTestId("you-files")).toBeInTheDocument();
+    expect(screen.queryByTestId("you-developer")).toBeNull();
+    expect(screen.queryByTestId("you-settings")).toBeNull();
+  });
+
+  it("returns to root drill triggers from a nested back control", () => {
+    renderYouPage();
+
+    fireEvent.click(screen.getByTestId("you-help"));
+    expect(screen.getByTestId("you-help-documentation")).toBeInTheDocument();
+    expect(screen.getByTestId("you-buy-credits")).toBeInTheDocument();
+    expect(screen.getByTestId("you-logout")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("you-drill-back"));
+
+    expect(screen.getByTestId("you-developer")).toBeInTheDocument();
+    expect(screen.getByTestId("you-help")).toBeInTheDocument();
+    expect(screen.getByTestId("you-legal")).toBeInTheDocument();
+    expect(screen.queryByTestId("you-help-documentation")).toBeNull();
+  });
+
+  it("drills Legal nested rows including cookie consent", () => {
+    renderYouPage();
+
+    fireEvent.click(screen.getByTestId("you-legal"));
+
+    expect(screen.getByTestId("you-legal-termsOfService")).toBeInTheDocument();
+    expect(screen.getByTestId("you-cookie-consent")).toBeInTheDocument();
+    expect(screen.getByTestId("you-buy-credits")).toBeInTheDocument();
+    expect(screen.getByTestId("you-logout")).toBeInTheDocument();
   });
 
   it("hides Admin when adminMenuEnabled is false", () => {
@@ -218,7 +246,8 @@ describe("YouPageClient", () => {
     });
 
     expect(screen.queryByTestId("you-admin")).toBeNull();
-    expect(screen.getByTestId("you-settings")).toBeInTheDocument();
+    expect(screen.queryByTestId("you-settings")).toBeNull();
+    expect(screen.getByTestId("you-account")).toBeInTheDocument();
     expect(screen.getByTestId("you-logout")).toBeInTheDocument();
   });
 

--- a/apps/web/src/app/(app)/you/components/you-page.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.tsx
@@ -4,18 +4,28 @@ import type { SessionUser } from "@sokosumi/utils";
 import gravatarUrl from "gravatar-url";
 import {
   Calendar,
+  ChevronLeft,
   ChevronRight,
+  Code2,
   Coins,
+  Cookie,
   HardDrive,
+  LifeBuoy,
   LogOut,
-  Settings,
+  Scale,
   ShieldCheck,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type ReactElement, useState } from "react";
-import { AccountPopoverDrill } from "@/app/components/sidebar/components/account-popover-drill.client";
+import {
+  getAccountNavItems,
+  HELP_LINKS,
+  type HelpLinkItem,
+  LEGAL_LINKS,
+  type LegalLinkItem,
+} from "@/app/components/sidebar/components/account-menu-config";
 import {
   isLowCreditsBalance,
   resolveAccountCreditsLabel,
@@ -23,9 +33,9 @@ import {
 } from "@/app/components/sidebar/components/account-summary-labels";
 import type {
   AccountAdminSettingsChrome,
-  AccountPopoverPanel,
   AccountSummaryCreditProps,
 } from "@/app/components/sidebar/components/account-summary-types";
+import { getDeveloperNavItems } from "@/app/components/sidebar/components/developer-menu-config";
 import { openConsentPreferences } from "@/components/analytics/cookie-banner";
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { useGlobalModalsContext } from "@/components/modals/global-modals-context";
@@ -42,6 +52,12 @@ const GRAVATAR_SIZE = 160;
 const ADMIN_HREF = "/admin";
 const DRIVE_HREF = "/drive";
 const CALENDAR_HREF = "/calendar";
+
+type YouNavPanel =
+  | { kind: "root" }
+  | { kind: "developer" }
+  | { kind: "help" }
+  | { kind: "legal" };
 
 export interface YouPageClientProps extends AccountSummaryCreditProps {
   sessionUser: SessionUser;
@@ -68,10 +84,13 @@ export function YouPageClient({
   const tBilling = useTranslations("App.Billing");
   const tPresence = useTranslations("App.Channels.Presence");
   const tMenu = useTranslations("App.Sidebar.Content.MenuItems");
+  const tYou = useTranslations("App.You.Metadata");
+  const tDeveloper = useTranslations("App.Developer.tabs");
+  const tConsent = useTranslations("CookieConsent");
   const { showLogoutModal } = useGlobalModalsContext();
   const router = useRouter();
   const presence = useSelfPresence();
-  const [panel, setPanel] = useState<AccountPopoverPanel>({ kind: "root" });
+  const [panel, setPanel] = useState<YouNavPanel>({ kind: "root" });
   const [slideFrom, setSlideFrom] = useState<"right" | "left" | null>(null);
 
   const displayName = resolveAccountDisplayName(
@@ -89,6 +108,11 @@ export function YouPageClient({
     extraCredits === null ? null : formatCreditsForDisplay(extraCredits);
   const showExtraCredits =
     usage !== null && displayExtraCredits !== null && displayExtraCredits > 0;
+
+  const accountNavItems = getAccountNavItems({
+    activeOrganizationId: adminSettingsChrome.activeOrganizationId,
+    members: adminSettingsChrome.members,
+  });
 
   function resolveRenewalLabel(): string | null {
     if (subscriptionPeriodEndMs === null || currentTimestampMs <= 0) {
@@ -114,16 +138,9 @@ export function YouPageClient({
     showLogoutModal({ id: sessionUser.id, email: sessionUser.email });
   }
 
-  function handleNavigatePanel(next: AccountPopoverPanel) {
-    const goingDeeper =
-      panel.kind === "root" ||
-      (panel.kind === "settings" && next.kind !== "root");
-    setSlideFrom(goingDeeper ? "right" : "left");
+  function handleNavigatePanel(next: YouNavPanel) {
+    setSlideFrom(next.kind === "root" ? "left" : "right");
     setPanel(next);
-  }
-
-  function handleNavigateRoute(href: string) {
-    router.push(href);
   }
 
   function handleOpenExternal(url: string) {
@@ -134,49 +151,27 @@ export function YouPageClient({
     window.open(url, "_blank", "noopener,noreferrer");
   }
 
-  if (panel.kind !== "root") {
-    return (
-      <div
-        className="mx-auto w-full py-6 md:max-w-4xl md:py-8"
-        data-testid="you-page"
-      >
-        <div
-          key={panel.kind}
-          data-testid="you-settings-panel"
-          className={cn(
-            slideFrom !== null && "animate-in fade-in duration-200",
-            slideFrom === "right" && "slide-in-from-right-4",
-            slideFrom === "left" && "slide-in-from-left-4",
-          )}
-        >
-          <AccountPopoverDrill
-            panel={panel}
-            members={adminSettingsChrome.members}
-            activeOrganizationId={adminSettingsChrome.activeOrganizationId}
-            showDeveloperVendors={adminSettingsChrome.showDeveloperVendors}
-            onNavigatePanel={handleNavigatePanel}
-            onNavigateRoute={handleNavigateRoute}
-            onOpenExternal={handleOpenExternal}
-            onOpenConsent={openConsentPreferences}
-          />
-        </div>
-      </div>
+  function getAccountItemLabel(translationKey: string): string {
+    return tCredit(
+      translationKey as "account" | "billing" | "connections" | "organization",
     );
   }
+
+  const drillTitle =
+    panel.kind === "developer"
+      ? tCredit("developer")
+      : panel.kind === "help"
+        ? tCredit("help")
+        : panel.kind === "legal"
+          ? tCredit("legal")
+          : null;
 
   return (
     <div
       className="mx-auto w-full py-6 md:max-w-4xl md:py-8"
       data-testid="you-page"
     >
-      <div
-        key="root"
-        className={cn(
-          "space-y-6",
-          slideFrom === "left" &&
-            "animate-in fade-in slide-in-from-left-4 duration-200",
-        )}
-      >
+      <div className="space-y-6">
         <header className="flex items-start gap-4">
           <YouPageAvatar sessionUser={sessionUser} displayName={displayName} />
           <div className="min-w-0 flex-1 space-y-1">
@@ -274,7 +269,7 @@ export function YouPageClient({
           </Button>
         </section>
 
-        <nav aria-label={tMenu("settings")} className="space-y-6">
+        <nav aria-label={tYou("title")} className="space-y-6">
           <YouMenuGroup>
             {calendarMenuEnabled ? (
               <YouMenuLink
@@ -292,22 +287,140 @@ export function YouPageClient({
             />
           </YouMenuGroup>
 
-          <YouMenuGroup>
-            {adminSettingsChrome.adminMenuEnabled ? (
+          {adminSettingsChrome.adminMenuEnabled ? (
+            <YouMenuGroup>
               <YouMenuLink
                 href={ADMIN_HREF}
                 icon={<ShieldCheck className="size-4 shrink-0" aria-hidden />}
                 label={tMenu("admin")}
                 testId="you-admin"
               />
-            ) : null}
-            <YouMenuAction
-              icon={<Settings className="size-4 shrink-0" aria-hidden />}
-              label={tMenu("settings")}
-              testId="you-settings"
-              onClick={() => handleNavigatePanel({ kind: "settings" })}
-            />
+            </YouMenuGroup>
+          ) : null}
+
+          <YouMenuGroup>
+            {accountNavItems.map(({ key, href, translationKey, Icon }) => (
+              <YouMenuLink
+                key={key}
+                href={href}
+                icon={<Icon className="size-4 shrink-0" aria-hidden />}
+                label={getAccountItemLabel(translationKey)}
+                testId={`you-${key}`}
+              />
+            ))}
           </YouMenuGroup>
+
+          <div
+            key={panel.kind}
+            data-testid="you-drill-section"
+            className={cn(
+              slideFrom !== null && "animate-in fade-in duration-200",
+              slideFrom === "right" && "slide-in-from-right-4",
+              slideFrom === "left" && "slide-in-from-left-4",
+            )}
+          >
+            <YouMenuGroup>
+              {panel.kind === "root" ? (
+                <>
+                  <YouMenuAction
+                    icon={<Code2 className="size-4 shrink-0" aria-hidden />}
+                    label={tCredit("developer")}
+                    testId="you-developer"
+                    onClick={() => handleNavigatePanel({ kind: "developer" })}
+                  />
+                  <YouMenuAction
+                    icon={<LifeBuoy className="size-4 shrink-0" aria-hidden />}
+                    label={tCredit("help")}
+                    testId="you-help"
+                    onClick={() => handleNavigatePanel({ kind: "help" })}
+                  />
+                  <YouMenuAction
+                    icon={<Scale className="size-4 shrink-0" aria-hidden />}
+                    label={tCredit("legal")}
+                    testId="you-legal"
+                    onClick={() => handleNavigatePanel({ kind: "legal" })}
+                  />
+                </>
+              ) : (
+                <>
+                  <YouMenuBack
+                    label={drillTitle ?? tMenu("back")}
+                    testId="you-drill-back"
+                    onClick={() => handleNavigatePanel({ kind: "root" })}
+                  />
+                  {panel.kind === "developer"
+                    ? getDeveloperNavItems({
+                        showVendors: adminSettingsChrome.showDeveloperVendors,
+                      }).map(({ key, href, translationKey, Icon }) => (
+                        <YouMenuLink
+                          key={key}
+                          href={href}
+                          icon={
+                            <Icon className="size-4 shrink-0" aria-hidden />
+                          }
+                          label={tDeveloper(translationKey)}
+                          testId={`you-developer-${key}`}
+                        />
+                      ))
+                    : null}
+                  {panel.kind === "help"
+                    ? HELP_LINKS.map((item) => {
+                        const Icon = item.icon;
+                        return (
+                          <YouMenuAction
+                            key={item.translationKey}
+                            icon={
+                              Icon ? (
+                                <Icon className="size-4 shrink-0" aria-hidden />
+                              ) : (
+                                <span className="size-4 shrink-0" aria-hidden />
+                              )
+                            }
+                            label={tCredit(
+                              item.translationKey as HelpLinkItem["translationKey"],
+                            )}
+                            testId={`you-help-${item.translationKey}`}
+                            onClick={() => handleOpenExternal(item.url)}
+                          />
+                        );
+                      })
+                    : null}
+                  {panel.kind === "legal" ? (
+                    <>
+                      {LEGAL_LINKS.map((item) => {
+                        const Icon = item.icon;
+                        return (
+                          <YouMenuAction
+                            key={item.translationKey}
+                            icon={
+                              Icon ? (
+                                <Icon className="size-4 shrink-0" aria-hidden />
+                              ) : (
+                                <span className="size-4 shrink-0" aria-hidden />
+                              )
+                            }
+                            label={tCredit(
+                              item.translationKey as LegalLinkItem["translationKey"],
+                            )}
+                            testId={`you-legal-${item.translationKey}`}
+                            onClick={() => handleOpenExternal(item.url)}
+                          />
+                        );
+                      })}
+                      <YouMenuAction
+                        icon={
+                          <Cookie className="size-4 shrink-0" aria-hidden />
+                        }
+                        label={tConsent("settings")}
+                        testId="you-cookie-consent"
+                        onClick={openConsentPreferences}
+                      />
+                    </>
+                  ) : null}
+                </>
+              )}
+            </YouMenuGroup>
+          </div>
         </nav>
 
         <Button
@@ -415,6 +528,31 @@ function YouMenuAction({
         <span className="truncate">{label}</span>
       </span>
       <ChevronRight className="size-4 shrink-0 opacity-60" aria-hidden />
+    </Button>
+  );
+}
+
+function YouMenuBack({
+  label,
+  testId,
+  onClick,
+}: {
+  label: string;
+  testId: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      className="text-muted-foreground hover:text-foreground h-11 w-full justify-start gap-2 rounded-none font-normal md:h-10"
+      data-testid={testId}
+      aria-label={label}
+    >
+      <ChevronLeft className="size-4 shrink-0" aria-hidden />
+      <span className="truncate">{label}</span>
     </Button>
   );
 }

--- a/apps/web/src/app/(app)/you/components/you-page.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.tsx
@@ -344,7 +344,8 @@ export function YouPageClient({
               ) : (
                 <>
                   <YouMenuBack
-                    label={drillTitle ?? tMenu("back")}
+                    title={drillTitle ?? tMenu("back")}
+                    backLabel={tMenu("back")}
                     testId="you-drill-back"
                     onClick={() => handleNavigatePanel({ kind: "root" })}
                   />
@@ -381,6 +382,7 @@ export function YouPageClient({
                             )}
                             testId={`you-help-${item.translationKey}`}
                             onClick={() => handleOpenExternal(item.url)}
+                            chevron={false}
                           />
                         );
                       })
@@ -404,6 +406,7 @@ export function YouPageClient({
                             )}
                             testId={`you-legal-${item.translationKey}`}
                             onClick={() => handleOpenExternal(item.url)}
+                            chevron={false}
                           />
                         );
                       })}
@@ -414,6 +417,7 @@ export function YouPageClient({
                         label={tConsent("settings")}
                         testId="you-cookie-consent"
                         onClick={openConsentPreferences}
+                        chevron={false}
                       />
                     </>
                   ) : null}
@@ -508,11 +512,13 @@ function YouMenuAction({
   label,
   testId,
   onClick,
+  chevron = true,
 }: {
   icon: ReactElement;
   label: string;
   testId: string;
   onClick: () => void;
+  chevron?: boolean;
 }) {
   return (
     <Button
@@ -527,17 +533,21 @@ function YouMenuAction({
         {icon}
         <span className="truncate">{label}</span>
       </span>
-      <ChevronRight className="size-4 shrink-0 opacity-60" aria-hidden />
+      {chevron ? (
+        <ChevronRight className="size-4 shrink-0 opacity-60" aria-hidden />
+      ) : null}
     </Button>
   );
 }
 
 function YouMenuBack({
-  label,
+  title,
+  backLabel,
   testId,
   onClick,
 }: {
-  label: string;
+  title: string;
+  backLabel: string;
   testId: string;
   onClick: () => void;
 }) {
@@ -549,10 +559,10 @@ function YouMenuBack({
       onClick={onClick}
       className="text-muted-foreground hover:text-foreground h-11 w-full justify-start gap-2 rounded-none font-normal md:h-10"
       data-testid={testId}
-      aria-label={label}
+      aria-label={backLabel}
     >
       <ChevronLeft className="size-4 shrink-0" aria-hidden />
-      <span className="truncate">{label}</span>
+      <span className="truncate">{title}</span>
     </Button>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

You page hid account destinations behind a Settings drill that replaced the whole surface. Flattening those items onto the main menu cuts a tap and keeps profile plus credits visible while Developer, Help, and Legal still slide inside one section card.

## Scope

- `you-page.client.tsx` drops Settings and the whole-page `AccountPopoverDrill` swap.
- Root menu adds account links (`getAccountNavItems`) and a drill section for Developer / Help / Legal.
- Nested panels use `YouNavPanel` (`root` | `developer` | `help` | `legal`) and animate only `you-drill-section`.
- Sidebar Settings drill stays unchanged.
- Tests cover flattened root rows, section-local drill, and back to root.

## Tradeoffs

Section-local slide over reusing `AccountPopoverDrill` on You so profile and credits stay put. Sidebar still owns the Settings intermediate panel.

## Blast Radius

Mobile You tab users see a flatter menu. Desktop sidebar account popover is untouched. No API or i18n key changes.

## Verification

- `pnpm --filter web test 'src/app/(app)/you/components/you-page.client.test.tsx'` — 13 passed
- Pre-commit `pnpm check` + `pnpm typecheck` — exit 0
- Manual: signed in as alice fixture, opened `/you` at mobile width, confirmed no Settings, flattened Account/Billing/Connections, section-local Developer/Help drills with credits and logout still visible

[You root flattened menu](https://cursor.com/agents/bc-f5460484-8fe1-4ecd-af70-66a691d83958/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-root-flattened.png)
[You Developer section drill](https://cursor.com/agents/bc-f5460484-8fe1-4ecd-af70-66a691d83958/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-developer-drill.png)
[you-flatten-settings-demo.mp4](https://cursor.com/agents/bc-f5460484-8fe1-4ecd-af70-66a691d83958/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyou-flatten-settings-demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5460484-8fe1-4ecd-af70-66a691d83958?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5460484-8fe1-4ecd-af70-66a691d83958&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

