### PR TITLE
fix(web): use shared back control in mobile search

### DIFF
--- a/apps/web/src/app/(app)/components/header/header-mobile-search.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/header-mobile-search.client.test.tsx
@@ -2,9 +2,10 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { pushMock, replaceMock } = vi.hoisted(() => ({
+const { pushMock, replaceMock, backMock } = vi.hoisted(() => ({
   pushMock: vi.fn(),
   replaceMock: vi.fn(),
+  backMock: vi.fn(),
 }));
 
 let mockPathname = "/chat";
@@ -13,6 +14,7 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: pushMock,
     replace: replaceMock,
+    back: backMock,
   }),
   usePathname: () => mockPathname,
 }));
@@ -36,6 +38,9 @@ vi.mock("next-intl", () => ({
         loading: "Loading...",
         error: "Failed to load results",
         resultsHeading: "Search",
+      },
+      "App.Channels.MobileNav": {
+        back: "Back",
       },
       "Components.NotificationCenter": {
         notifications: "Notifications",
@@ -120,7 +125,7 @@ describe("HeaderMobileSearchControl", () => {
     ).toBeInTheDocument();
   });
 
-  it("dismisses expanded search and restores the trigger", async () => {
+  it("uses the shared mobile back control and navigates back after opening from another page", async () => {
     const user = userEvent.setup({
       advanceTimers: vi.advanceTimersByTime.bind(vi),
     });
@@ -128,12 +133,37 @@ describe("HeaderMobileSearchControl", () => {
     render(<HeaderMobileSearchControl />);
 
     await user.click(screen.getByRole("button", { name: "Search" }));
-    await user.click(screen.getByTestId("header-mobile-search-dismiss"));
+    const back = screen.getByRole("button", { name: "Back" });
+    expect(back).toHaveAttribute("data-testid", "header-mobile-search-dismiss");
+    expect(back.className).toMatch(/hover:bg-accent/);
+    expect(back.className).toMatch(/rounded-md/);
+
+    await user.click(back);
 
     expect(
       screen.queryByTestId("header-mobile-search-expanded"),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    expect(backMock).toHaveBeenCalledTimes(1);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("collapses search on /history without router.back", async () => {
+    mockPathname = "/history";
+    window.history.replaceState({}, "", "/history");
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+
+    render(<HeaderMobileSearchControl />);
+
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(
+      screen.queryByTestId("header-mobile-search-expanded"),
+    ).not.toBeInTheDocument();
+    expect(backMock).not.toHaveBeenCalled();
   });
 
   it("filters the history page via URL q instead of opening a results popup", async () => {

--- a/apps/web/src/app/(app)/components/header/header-mobile-search.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-mobile-search.client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, Search } from "lucide-react";
+import { ChevronLeft, Search } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
@@ -19,6 +19,10 @@ import { getEnvPublicConfig } from "@/config/env.public";
 import { cn } from "@/lib/utils";
 
 const HISTORY_PATH = "/history";
+
+/** Same chrome as `HeaderLeadingControl` mobile back. */
+const MOBILE_HEADER_BACK_BUTTON_CLASS =
+  "text-foreground hover:bg-accent inline-flex size-8 shrink-0 items-center justify-center rounded-md";
 
 function isHistoryPath(pathname: string): boolean {
   return pathname === HISTORY_PATH || pathname.endsWith(HISTORY_PATH);
@@ -41,11 +45,13 @@ function readHistoryQueryFromLocation(): string {
 
 export function HeaderMobileSearchControl() {
   const t = useTranslations("App.Header.Search");
+  const tNav = useTranslations("App.Channels.MobileNav");
   const [expanded, setExpanded] = useState(false);
   const [query, setQuery] = useState("");
   const router = useRouter();
   const pathname = usePathname();
   const previousPathnameRef = useRef(pathname);
+  const navigatedToHistoryRef = useRef(false);
 
   function replaceHistoryQuery(nextQuery: string | null) {
     const currentPath =
@@ -83,6 +89,7 @@ export function HeaderMobileSearchControl() {
       isHistoryPath(previousPathname) &&
       !isHistoryPath(pathname)
     ) {
+      navigatedToHistoryRef.current = false;
       setExpanded(false);
       setQuery("");
     }
@@ -98,19 +105,27 @@ export function HeaderMobileSearchControl() {
     setExpanded(true);
     if (!isHistoryPath(pathname)) {
       setQuery("");
+      navigatedToHistoryRef.current = true;
       router.push(HISTORY_PATH);
       return;
     }
+    navigatedToHistoryRef.current = false;
     setQuery(readHistoryQueryFromLocation());
   }
 
   function collapse() {
     debouncedReplaceHistoryQuery.cancel();
+    const shouldNavigateBack = navigatedToHistoryRef.current;
     const hadQuery =
       query.trim().length > 0 ||
       (isHistoryPath(pathname) && readHistoryQueryFromLocation().length > 0);
+    navigatedToHistoryRef.current = false;
     setQuery("");
     setExpanded(false);
+    if (shouldNavigateBack) {
+      router.back();
+      return;
+    }
     if (isHistoryPath(pathname) && hadQuery) {
       replaceHistoryQuery(null);
     }
@@ -151,12 +166,12 @@ export function HeaderMobileSearchControl() {
               <div className="relative z-10 flex h-16 w-full items-center gap-2 px-2">
                 <button
                   type="button"
-                  className="hover:bg-muted flex size-8 shrink-0 items-center justify-center rounded-full transition-colors"
-                  aria-label={t("dismiss")}
+                  className={MOBILE_HEADER_BACK_BUTTON_CLASS}
+                  aria-label={tNav("back")}
                   data-testid="header-mobile-search-dismiss"
                   onClick={collapse}
                 >
-                  <ArrowLeft className="text-foreground size-4" aria-hidden />
+                  <ChevronLeft className="size-5" aria-hidden />
                 </button>
                 <Input
                   autoFocus


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mobile header search used a different dismiss control (`ArrowLeft`, round ghost) than the rest of the app chrome. It also stayed on `/history` after closing when search had navigated there from another page.

This matches the shared `HeaderLeadingControl` back chrome (`ChevronLeft`, accent hover, `rounded-md`) and calls `router.back()` when search pushed `/history`. Opening search while already on `/history` still only collapses (and clears `q` when needed).

## Verification

- `pnpm --filter web test src/app/(app)/components/header/header-mobile-search.client.test.tsx` (10 passed)
- Manual mobile viewport: open Search from home → ChevronLeft Back with shared classes → click returns to home

[Search open with shared back control](https://cursor.com/agents/bc-4589ddff-990a-4a05-b02a-42ea6661099a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch-open-with-back.png)
[Notifications page back control for comparison](https://cursor.com/agents/bc-4589ddff-990a-4a05-b02a-42ea6661099a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnotifications-back-control.png)
[search-open-back-button-demo.mp4](https://cursor.com/agents/bc-4589ddff-990a-4a05-b02a-42ea6661099a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch-open-back-button-demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4589ddff-990a-4a05-b02a-42ea6661099a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4589ddff-990a-4a05-b02a-42ea6661099a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

