### PR TITLE
fix(web): flush mobile search query after history navigation

### DIFF
--- a/apps/web/src/app/(app)/components/header/header-mobile-search.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/header-mobile-search.client.test.tsx
@@ -186,6 +186,49 @@ describe("HeaderMobileSearchControl", () => {
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
   });
 
+  it("applies a query typed before /history navigation finishes", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+
+    const { rerender } = render(<HeaderMobileSearchControl />);
+
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    expect(pushMock).toHaveBeenCalledWith("/history");
+
+    await user.type(screen.getByPlaceholderText("Search..."), "brief");
+
+    // Debounce may fire while still off /history and no-op.
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(replaceMock).not.toHaveBeenCalled();
+
+    mockPathname = "/history";
+    window.history.replaceState({}, "", "/history");
+    rerender(<HeaderMobileSearchControl />);
+
+    expect(replaceMock).toHaveBeenCalledWith("/history?q=brief");
+    expect(screen.getByPlaceholderText("Search...")).toHaveValue("brief");
+  });
+
+  it("flushes a still-pending query when /history navigation completes", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+
+    const { rerender } = render(<HeaderMobileSearchControl />);
+
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.type(screen.getByPlaceholderText("Search..."), "brief");
+
+    mockPathname = "/history";
+    window.history.replaceState({}, "", "/history");
+    rerender(<HeaderMobileSearchControl />);
+
+    expect(replaceMock).toHaveBeenCalledWith("/history?q=brief");
+  });
+
   it("cancels pending history query updates after navigating away", async () => {
     mockPathname = "/history";
     window.history.replaceState({}, "", "/history");

--- a/apps/web/src/app/(app)/components/header/header-mobile-search.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-mobile-search.client.tsx
@@ -52,6 +52,8 @@ export function HeaderMobileSearchControl() {
   const pathname = usePathname();
   const previousPathnameRef = useRef(pathname);
   const navigatedToHistoryRef = useRef(false);
+  const queryRef = useRef(query);
+  queryRef.current = query;
 
   function replaceHistoryQuery(nextQuery: string | null) {
     const currentPath =
@@ -82,16 +84,32 @@ export function HeaderMobileSearchControl() {
   useEffect(() => {
     const previousPathname = previousPathnameRef.current;
     previousPathnameRef.current = pathname;
-    debouncedReplaceHistoryQuery.cancel();
 
     if (
       expanded &&
       isHistoryPath(previousPathname) &&
       !isHistoryPath(pathname)
     ) {
+      debouncedReplaceHistoryQuery.cancel();
       navigatedToHistoryRef.current = false;
       setExpanded(false);
       setQuery("");
+      return;
+    }
+
+    // Opened search from a non-history route: typing can race `router.push`.
+    // Debounced replaces no-op off /history and used to be cancelled on arrival.
+    // Flush the local query once navigation lands so `?q=` reaches the URL.
+    if (
+      expanded &&
+      !isHistoryPath(previousPathname) &&
+      isHistoryPath(pathname)
+    ) {
+      debouncedReplaceHistoryQuery.cancel();
+      const trimmedQuery = queryRef.current.trim();
+      if (trimmedQuery) {
+        replaceHistoryQuery(trimmedQuery);
+      }
     }
   }, [pathname, expanded, debouncedReplaceHistoryQuery]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Bugbot finding: opening mobile header search from a non-`/history` route and typing could leave the input filled while the history list stayed unfiltered, because pending `?q=` updates were cancelled on navigation and/or no-op'd while still off `/history`.

## Change

- Only cancel the debounced URL update when leaving `/history` (or unmounting/collapsing).
- When search was opened off-history and navigation lands on `/history`, flush the current local query into `?q=` immediately.

## Test plan

- [x] Unit tests: typing before `/history` settles applies `?q=` once the route lands (including after an early debounce no-op).
- [x] Existing cases still pass (filter on history, cancel when navigating away, dismiss clears `q`).
- [ ] Manual: from a non-history mobile page, open header search, type before/while `/history` loads, confirm URL and list filter update.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5aa6a94d-c215-468e-a06d-8207bbf7c711?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5aa6a94d-c215-468e-a06d-8207bbf7c711&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

