### PR TITLE
feat(web): move Files into desktop main nav

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx
@@ -171,6 +171,8 @@ describe("SidebarAccountChip", () => {
     renderChip();
     openChip();
 
+    expect(screen.queryByRole("button", { name: "drive" })).toBeNull();
+
     const admin = screen.getByRole("button", { name: "admin" });
     const settings = screen.getByRole("button", { name: "settings" });
     const logout = screen.getByRole("button", { name: "logout" });

--- a/apps/web/src/app/(app)/components/sidebar/components/account-summary-menu.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/account-summary-menu.client.tsx
@@ -2,7 +2,7 @@
 
 import { resolveAccountDisplayName, type SessionUser } from "@sokosumi/utils";
 import gravatarUrl from "gravatar-url";
-import { Coins, HardDrive, LogOut, Settings, ShieldCheck } from "lucide-react";
+import { Coins, LogOut, Settings, ShieldCheck } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type ReactElement, useRef, useState } from "react";
@@ -107,11 +107,6 @@ export function AccountSummaryMenu({
   function handleLogout() {
     onRequestClose();
     showLogoutModal({ id: sessionUser.id, email: sessionUser.email });
-  }
-
-  function handleDrive() {
-    onRequestClose();
-    router.push("/drive");
   }
 
   function handleAdmin() {
@@ -264,16 +259,6 @@ export function AccountSummaryMenu({
               {buyCreditsLabel}
             </Button>
             <div className="divide-border divide-y">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={handleDrive}
-                className="text-muted-foreground hover:text-foreground h-10 w-full justify-start gap-2 rounded-none font-normal"
-              >
-                <HardDrive className="size-4 shrink-0" aria-hidden />
-                {tMenu("drive")}
-              </Button>
               {adminSettingsChrome.adminMenuEnabled ? (
                 <Button
                   type="button"

--- a/apps/web/src/app/(app)/components/sidebar/components/menu-items.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/menu-items.test.tsx
@@ -54,7 +54,7 @@ vi.mock("@/components/ui/sidebar", () => ({
     <li>{children}</li>
   ),
   useSidebar: () => ({
-    isMobile: true,
+    isMobile: sidebarIsMobile,
     setOpenMobile: setOpenMobileMock,
   }),
 }));
@@ -72,7 +72,14 @@ vi.mock("next/link", () => ({
 import MenuItems from "@/app/components/sidebar/components/menu-items";
 import { OrganizationSeatProvider } from "@/contexts/organization-seat-context";
 
-function renderMenu(hasAssignedSeat = true, calendarMenuEnabled = false) {
+let sidebarIsMobile = true;
+
+function renderMenu(
+  hasAssignedSeat = true,
+  calendarMenuEnabled = false,
+  isMobile = true,
+) {
+  sidebarIsMobile = isMobile;
   return render(
     <OrganizationSeatProvider hasAssignedSeat={hasAssignedSeat}>
       <MenuItems calendarMenuEnabled={calendarMenuEnabled} />
@@ -83,6 +90,7 @@ function renderMenu(hasAssignedSeat = true, calendarMenuEnabled = false) {
 describe("MenuItems search action", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sidebarIsMobile = true;
     historySearchValue = {
       openHistorySearch: openHistorySearchMock,
       searchShortcutLabel: "Ctrl+K",
@@ -147,6 +155,7 @@ describe("MenuItems search action", () => {
 
     expect(screen.queryByRole("link", { name: /calendar/i })).toBeNull();
 
+    sidebarIsMobile = true;
     rerender(
       <OrganizationSeatProvider hasAssignedSeat>
         <MenuItems calendarMenuEnabled />
@@ -156,6 +165,39 @@ describe("MenuItems search action", () => {
     expect(screen.getByRole("link", { name: /calendar/i })).toHaveAttribute(
       "href",
       "/calendar",
+    );
+  });
+
+  it("hides Files from the main menu on mobile", () => {
+    renderMenu(true, true, true);
+
+    expect(screen.queryByRole("link", { name: /drive/i })).toBeNull();
+  });
+
+  it("shows Files after Schedules on desktop", () => {
+    const { container } = renderMenu(true, true, false);
+    const menuLabels = Array.from(container.querySelectorAll("button, a")).map(
+      (element) => element.textContent ?? "",
+    );
+
+    const primaryOrder = [
+      "search",
+      "exploreAgents",
+      "projects",
+      "taskManager",
+      "calendar",
+      "drive",
+      "history",
+    ];
+    const positions = primaryOrder.map((label) =>
+      menuLabels.findIndex((text) => text.includes(label)),
+    );
+
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+    expect(screen.getByRole("link", { name: /drive/i })).toHaveAttribute(
+      "href",
+      "/drive",
     );
   });
 

--- a/apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
@@ -4,6 +4,7 @@ import {
   Bot,
   CalendarDays,
   FolderKanban,
+  HardDrive,
   History,
   ListTodo,
   Plus,
@@ -106,6 +107,17 @@ export default function MenuItems({ calendarMenuEnabled }: MenuItemsProps) {
             href: "/calendar",
             label: t("calendar"),
             Icon: CalendarDays,
+          },
+        ]
+      : []),
+    // Desktop only: mobile keeps Files on the You page account surface.
+    ...(!isMobile
+      ? [
+          {
+            key: "drive",
+            href: "/drive",
+            label: t("drive"),
+            Icon: HardDrive,
           },
         ]
       : []),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Desktop sidebar main menu now shows **Files** after **Schedules** (when Schedules is enabled). The user account popover no longer lists Files. Mobile is unchanged: Files stays on the You page.

## Changes

- Add `/drive` to `MenuItems` when `!isMobile`, immediately after Schedules
- Remove Files from `AccountSummaryMenu` (desktop account chip only)
- Unit coverage for desktop order, mobile omission, and account popover absence

## Verification

- `pnpm --filter web test` on `menu-items.test.tsx` and `sidebar-account-chip.test.tsx` (30 passed)
- Desktop UI (alice@sokosumi.test): Files visible in sidebar main nav; account popover lists Settings / Log out only (no Files)

[Desktop sidebar with Files in main menu](https://cursor.com/agents/bc-1da94783-25ff-4a1c-8e59-e447bafe88cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdesktop_main_menu_files.png)

[Desktop account popover without Files](https://cursor.com/agents/bc-1da94783-25ff-4a1c-8e59-e447bafe88cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdesktop_account_popover_no_files_v2.png)

[desktop_files_main_menu_demo.mp4](https://cursor.com/agents/bc-1da94783-25ff-4a1c-8e59-e447bafe88cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_files_main_menu_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1da94783-25ff-4a1c-8e59-e447bafe88cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1da94783-25ff-4a1c-8e59-e447bafe88cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated **Drive** entry to the desktop sidebar for quicker access to Files.
  - Drive is positioned after Calendar in the desktop navigation.

- **Updates**
  - Removed the deprecated Drive button from the account summary menu.
  - On mobile, Files remains accessible through the account surface rather than the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->