### PR TITLE
docs(projects): document social account connections

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,6 +76,40 @@ _Avoid_: Coworker developer (when meaning this)
 The in-repo command-line client for Coworker developers and Agent developers. Complements web `/developer`; does not replace it.
 _Avoid_: Treating `/developer` as deprecated, a second CLI per persona
 
+### Social publishing
+
+**Social account**:
+An external publishing identity on a social provider, such as an X account. It may be connected to more than one Project.
+_Avoid_: Integration, Project account
+
+**Project social connection**:
+A Project's authorization to publish through one Social account. A Project may have multiple connections, including to different accounts on the same provider.
+_Avoid_: Social account (when meaning the Project authorization), integration account
+
+**Social accounts**:
+The Project Settings section where Social connection managers view and manage a Project's Social connections. It is not a Calendar surface.
+_Avoid_: Social account (when meaning the external publishing identity), integrations page
+
+**Social connection manager**:
+An interactive human user who belongs to a Project's Workspace and may view, connect, reconnect, or disconnect that Project's Social connections. Coworkers, orchestrators, and API keys are not Social connection managers.
+_Avoid_: Connector (the person who completed OAuth), automation
+
+**Reconnect social connection**:
+Reauthorizing a Project social connection with the same Social account after it needs authentication again. It cannot change the external publishing identity.
+_Avoid_: Replace, connect another account
+
+**Replace social connection**:
+Disconnecting a Project's current Social account and connecting a different one. It is a deliberate identity change, not reconnecting.
+_Avoid_: Reconnect, edit connection
+
+**Social connection audit record**:
+A non-executable record of a Project social connection lifecycle event, including the Project, Social account identity, action, actor or scheduler, timestamp, and provider outcome. It never contains OAuth values.
+_Avoid_: Active connection, credential log
+
+**Social scheduling authorization**:
+The consent granted when a Social account is connected that lets the Project's scheduler publish through that Project social connection until it is disconnected.
+_Avoid_: Per-post approval, connector approval
+
 ### Task payments
 
 **Task payment claim**:

--- a/docs/adr/0018-core-owned-project-social-connections.md
+++ b/docs/adr/0018-core-owned-project-social-connections.md
@@ -1,0 +1,3 @@
+# Core owns project social connections through Composio
+
+Sokosumi Core owns Project authorization, scheduling authorization, connection lifecycle, and audit records for Social connections. Composio is the server-side broker for provider OAuth credentials and restricted X execution only, so neither the browser nor an automation actor can hold or authorize use of an external publishing credential.

--- a/docs/plans/2026-09-03-project-social-connections-spec.md
+++ b/docs/plans/2026-09-03-project-social-connections-spec.md
@@ -1,0 +1,88 @@
+# Project social connections for X
+
+Glossary: `CONTEXT.md`. Decision: `docs/adr/0018-core-owned-project-social-connections.md`. Research: `docs/research/composio-x-project-connections.md`.
+
+## Requirement
+
+Sokosumi Projects can connect multiple X accounts through `Project settings > Social accounts`. A Social account may be deliberately connected to more than one Project, but each Project social connection is independently authorized, managed, disconnected, and audited. The connection grants the Project's future scheduler permission to publish through that account until disconnected.
+
+## Problem Statement
+
+Sokosumi has no native, Project-scoped way to connect an external publishing identity. Users cannot prepare a Project for native social scheduling, and provider OAuth connections in the existing product serve Hermes rather than the Project. Credentials, authorization, lifecycle, and audit records need one secure owner before posting or scheduling can be added.
+
+## Solution
+
+Add a provider-agnostic Project social connection resource in Core, exposing X as the first and only supported provider. Core validates the interactive human's Workspace access, brokers X OAuth with Composio, records the Project association and non-executable audit history, and never exposes provider credentials to Web. Web adds a Social accounts section to Project settings where Workspace humans can connect, view, reconnect, replace, or disconnect X accounts.
+
+The initial release creates the foundation only. It does not compose, post, upload media, schedule, or display social history. Connecting explicitly grants the Project's future scheduler authority to publish as that account; future scheduling will be a Core capability rather than an X or Composio delayed-post feature.
+
+## User Stories
+
+1. As a human in a Project's Workspace, I want to open Social accounts in Project settings, so that I can prepare the Project for social publishing.
+2. As a Social connection manager, I want to connect an X account from a specific Project, so that the Project gains only an explicitly granted publishing authorization.
+3. As a Social connection manager, I want the X OAuth flow to open only after Core has authorized my Workspace access, so that a copied Project ID cannot start a connection.
+4. As a Social connection manager, I want to return from X OAuth to the same Project and see the connection result, so that I know whether the account is ready.
+5. As a Social connection manager, I want to see the connected X account's identity and status, so that I can distinguish ready accounts from accounts that need attention.
+6. As a Social connection manager, I want a Project to hold several distinct X accounts, so that brand, campaign, or regional identities can be prepared independently.
+7. As a Social connection manager, I want the same X account to be connectable to another Project through another explicit OAuth flow, so that account reuse does not expose cross-Project account inventory.
+8. As a Social connection manager, I want the Project to reject a duplicate active connection to the same X account, so that a future scheduler cannot have ambiguous credentials.
+9. As a Social connection manager, I want to reconnect an X account that needs reauthorization, so that the original publishing identity can become usable again.
+10. As a Social connection manager, I want reconnecting to reject a different X identity, so that an authorization refresh cannot silently change where a future post is published.
+11. As a Social connection manager, I want to replace an X account deliberately, so that an identity change is explicit and auditable.
+12. As a Social connection manager, I want to disconnect one Project's X account without affecting another Project that uses the same account, so that Project authorization remains isolated.
+13. As a Workspace human who did not complete the original OAuth flow, I want to manage an existing Project social connection, so that the connection belongs to the Project rather than one employee.
+14. As a Project scheduler in a future release, I want a valid Social scheduling authorization, so that due social work can publish without requiring the original connector to be online.
+15. As a person who leaves a Workspace, I want my departure not to silently disable the Project's approved publishing authorization, so that the remaining Workspace can continue its work or disconnect it deliberately.
+16. As a coworker, orchestrator, or API-key caller, I cannot initiate, inspect, reconnect, replace, or disconnect a Project social connection, so that external publishing credentials remain human-managed.
+17. As a human outside the Project's Workspace, I cannot learn whether or which X accounts that Project uses, so that Project social identity remains private.
+18. As a support engineer, I can investigate a connection lifecycle from non-secret audit records, so that failed or revoked connections are diagnosable without exposing OAuth values.
+19. As a Project owner, I expect a future Project close to disable and disconnect its Social connections while retaining non-executable audit records, so that a terminal Project keeps no publishing authority.
+20. As a security reviewer, I want Composio and X secrets to remain server-side, so that browser clients and automation actors never receive reusable publishing credentials.
+
+## Implementation Decisions
+
+- **Single seam: Project social connections.** A Core Project resource owns Project authorization, connection intents, Composio calls, state transitions, provider references, and audit records. Web's Project settings service/action layer is its only product client. The existing OAuth popup transport is reusable, but the Project lifecycle is independent from Hermes connections.
+- **Provider-agnostic persistence, X-only behavior.** Persist a provider discriminator and a normalized external Social account identity so other providers can be added without a schema redesign. The API, UI, and Composio configuration accept only X in this release. Do not build a plugin framework or generic provider catalogue.
+- **Cardinality.** A Project has multiple Project social connections. One external Social account can be associated with multiple Projects only by a new OAuth flow begun from each Project. Do not surface an account picker or connection inventory outside the current Project. Only one active X connection for the same external account may exist within a Project.
+- **Human management policy.** A Social connection manager is an interactive, logged-in human in the Project's Workspace. User API keys, coworkers, orchestrators, and other automation actors are rejected. This is intentionally broader than owner-only Project editing: every eligible Workspace human can view and manage these connections.
+- **Connection state.** Model a short-lived, single-use connection intent separately from the durable Project social connection. The durable resource maps provider lifecycle responses into pending, active, reauthorization-required, and disconnected product states. After Composio reports `ACTIVE`, Core opens a transient session pinned to that account and permits only `TWITTER_USER_LOOKUP_ME` to retrieve the stable X id and handle. Persist that non-secret identity with the provider account reference; never store OAuth access or refresh tokens in Sokosumi.
+- **Identity-safe OAuth.** Core authorizes the Project and creates the intent before returning a Composio-hosted link. The intent binds the Project, initiating human, provider, custom X auth configuration, expected connection, and callback completion. Callback identity verification must prove the same human identity that initiated the flow. Core validates the completed account against the intent before persisting it.
+- **Reconnect and replace.** Reconnect authorizes the same external X identity only. Replace first removes the old Project authorization and then initiates a distinct connection flow; it may not mutate an existing connection into a different identity.
+- **Disconnect and provider revocation.** Disconnect immediately makes the Project social connection non-executable and writes an audit record. It must not affect another Project's valid authorization. Provider-side revocation runs only when no remaining Project social connection references that underlying Composio connection. A failed provider revocation remains visible in the audit record while local use stays blocked.
+- **Project lifecycle.** A future Project-close command must use the same disconnect lifecycle for every active Project social connection. Creating a Project-close feature is not part of this release because no such product command exists today.
+- **Composio boundary.** Core uses Composio's current API for a customer-owned X OAuth application and custom X auth configuration. Composio stores and refreshes provider tokens; Core remains the authority for all Project checks, scheduler permission, state transitions, and audit data. Use a stable user-scoped connector identity for callback verification and a Core-only Project executor identity for later restricted posting sessions.
+- **Least privilege.** Use X's post-related OAuth scopes plus renewable access, but do not request media scope until media publishing exists. The initial identity session pins one connected account and enables only `TWITTER_USER_LOOKUP_ME`; future publishing sessions enable only the post-creation tool. No session may expose broad toolkit discovery, proxy execution, sandbox, triggers, or browser-exposed Composio keys.
+- **Audit.** Record connect, reconnect, replace, disconnect, provider-revocation outcome, and future Project-close actions with the Project, connection, external identity, actor or scheduler, timestamps, and non-secret provider outcome. The release writes this data but does not add a history UI.
+- **Web to Core boundary.** Add documented Core endpoints and regenerate the Web Core client. Web coordinates popup state and Project-settings feedback through its service/action layer; it does not access Prisma, Composio, X, or OAuth values directly.
+- **Operational configuration.** Each environment needs its own customer-owned X developer application and Composio custom X auth configuration. Core receives only the scoped Composio project API key and X auth-config identifier. X app setup, billing plan, callback registration, scoped Composio permissions, IP policy, and Composio data-retention configuration are deployment prerequisites.
+
+## Testing Decisions
+
+- Test observable lifecycle behavior and authorization boundaries, not internal helper calls or Prisma query shapes.
+- Core route and service tests cover Workspace membership, interactive-session-only management, no cross-Workspace visibility, missing Project, and rejection of coworkers, orchestrators, and user API keys.
+- Test connection intents as one-use and short-lived: a mismatched user, Project, provider, callback, or completed connected-account identity must fail without creating a Project social connection.
+- Test active connection creation, the restricted X identity lookup and response parsing, status refresh, expired/failed provider status, reauthorization, same-identity reconnect, explicit replacement, duplicate-in-Project rejection, and several distinct accounts per Project.
+- Test that another Project can establish its own authorization for the same X account without discovering the first Project's connection and without being affected by the first Project's disconnect.
+- Test disconnect as an immediate local block, provider revocation only after the last reference, and an upstream revoke failure that remains auditable but cannot restore local use.
+- Test audit-record contents for every state change and assert that OAuth values, Composio API keys, hosted connection links, and raw provider credentials never appear in API responses, logs, or audit records.
+- Web tests cover the Social accounts empty state, connected and reauthorization-required states, connect/reconnect/replace/disconnect controls, popup success/failure/abandon behavior, and inaccessible controls for non-human actors where relevant to the client contract.
+- Add OpenAPI contract coverage for the new Project social-connection endpoints, regenerate the Web client, and typecheck Web against the generated DTOs.
+- Prior art: the existing Project route tests, Composio client tests, Hermes OAuth callback tests, Web OAuth popup-protocol tests, Project service/action tests, and Project form/component tests.
+
+## Out of Scope
+
+- Creating, editing, previewing, approving, or immediately publishing X posts.
+- Uploading or processing X media, polls, replies, quotes, analytics, direct messages, or other X toolkit actions.
+- Creating social schedules, changing the Calendar, or invoking the Core scheduler to publish.
+- Supporting providers other than X or exposing a generic provider marketplace.
+- Showing cross-Project or cross-Workspace account inventory.
+- A Project social-connection history UI or end-user audit-log page.
+- Building the missing Project-close command itself.
+- Automating X developer-account approval, X API plan purchase, Composio custom auth-config setup, provider callback registration, or production secrets provisioning.
+
+## Further Notes
+
+- X does not provide a future-publish parameter through the relevant post API. Native social scheduling must persist schedule state and dispatch from Core when due.
+- Composio's X toolkit has no managed credentials. The deployment prerequisite is a customer-owned X OAuth application per environment and an explicit custom auth configuration.
+- Verify provider revocation behavior with one X identity deliberately connected to multiple Projects before treating an upstream revoke as isolated. Local Project authorization must always be blocked first.
+- This spec is intentionally local and unfiled. It is ready to become a requirement issue only when explicitly requested.

--- a/docs/research/composio-x-project-connections.md
+++ b/docs/research/composio-x-project-connections.md
@@ -1,0 +1,139 @@
+# Composio X connections at Sokosumi project scope
+
+Researched 2026-09-03 against official Composio and X Developer Platform documentation only. Repository observations are explicitly marked and are not external-source claims.
+
+## Recommendation
+
+Use Composio as the server-side OAuth credential broker and X tool executor, but keep Sokosumi Core as the authorization, project-association, scheduling, and audit authority.
+
+Create one customer-owned X OAuth 2.0 app and one custom Twitter auth config per deployment environment. At connection time, make the connecting human's stable Sokosumi user ID the Composio `userId`, create a **SHARED** connected account, and grant only an opaque per-project Core executor ID access to it. Store the resulting connected-account ID against the Sokosumi project. Every publish, schedule, disconnect, and connection-status operation must first authorize the caller against that project in Core.
+
+Do not model a Sokosumi project directly as the Composio `userId`. Composio's callback identity verifier requires the authenticated caller to prove the same `userId` that began the connection. A project ID cannot prove which human completed the OAuth flow. The user-owned, shared-to-project-executor model preserves that protection while keeping use project-scoped.
+
+## Current capability and prerequisites
+
+Composio's current Twitter toolkit is OAuth 2.0, has no Composio-managed app, exposes 79 tools, and has zero Composio triggers. Its documentation says that managed Twitter credentials were removed in February 2026, so a customer-owned X app and custom Composio auth config are mandatory. [C1] [C2]
+
+For a production publishing integration:
+
+1. Create and approve an X developer account, then create a Project and App in the X Developer Console. X identifies these as prerequisites for creating posts. [X1] [X2]
+2. Enable OAuth 2.0 user authentication in the X app. Use a confidential **Web App** or **Automated App / Bot** type because Core, not the browser, can protect the client secret. Register the exact current Composio callback URL shown by the auth-config flow. X requires an exact callback-URL match; Composio's Twitter guide specifically warns not to reuse a legacy callback URL. [X3] [X4] [C2]
+3. Create a custom Composio Twitter auth config with the X OAuth client ID, client secret, and application bearer token. The bearer token is needed for toolkit actions that use app-only X authentication; user OAuth scopes do not repair an app-only bearer-token failure. [C2]
+4. Request only the scopes needed. X's create-post endpoint requires `tweet.read`, `users.read`, and `tweet.write`; add `offline.access` for a renewable connection and `media.write` only when the product supports uploads. [X5] [X4]
+5. Select and fund an X API product/plan that allows every endpoint enabled in Sokosumi. X access is plan-based, and Composio documents X `UsageCapExceeded`, rate-limit, and developer-project/app-link failures as external-account conditions rather than OAuth-scope problems. [X1] [C1] [C2]
+
+X access tokens from the OAuth 2.0 authorization-code-with-PKCE flow last two hours by default. Requesting `offline.access` yields a refresh token, allowing Composio to renew access without another prompt; X describes that scope as keeping access until the user revokes it. [X4]
+
+## Scope mapping
+
+Composio's **Organization / Project** is its own tenancy boundary: a Composio project scopes API keys, auth configs, connected accounts, and webhooks. It is appropriate for Sokosumi production versus staging isolation, but it is not a Sokosumi customer project. [C3]
+
+Within a Composio project, a connected account belongs to the supplied stable `userId`. It is PRIVATE by default, so only that owner can use it. A SHARED connection is available only when explicitly pinned into a session and its per-connection ACL permits the requesting `userId`; it defaults to deny. [C4] [C5]
+
+Use the following identifiers and records:
+
+| Concern | Recommended representation | Reason |
+| --- | --- | --- |
+| OAuth connector | `sokosumi:user:${userId}` | A stable human identity that can complete Composio callback identity verification. |
+| Project executor | `sokosumi:project-executor:${projectId}` | An opaque Core-only identity that can use the shared connection for both immediate and scheduled publishing. It is never returned to the browser or an agent runtime. |
+| Composio account type | `SHARED`, ACL `allowedUserIds: [projectExecutorId]` | Gives Core one explicitly scoped executor. Do not use `allowAllUsers`; Core is still the source of truth for project membership and roles. [C5] |
+| Sokosumi persistence | A project integration row containing the Composio connected-account ID, auth-config ID, connector user ID, X account identity where available, status, and audit timestamps | Associates the opaque Composio credential with the project without storing OAuth tokens locally. |
+
+This avoids syncing every project member into Composio's ACL, including its 1,000-entry ACL-list limit. It also means that an ex-member cannot use the X account: Core simply does not create an executor session for unauthorized callers. The connector remains a Composio-level creator, so Core must continue to reject use by that person after removal from the project. Composio ACLs are a defense in depth layer, not Sokosumi's authorization model. [C5]
+
+## Connection and execution flow
+
+1. A real interactive user with an explicit project-integration management permission initiates the flow through Core. Do not let a coworker, orchestrator, or unauthenticated callback initiate it.
+2. Core validates project access, writes a short-lived, one-use local connection intent, and asks Composio to create a Twitter connection for `sokosumi:user:${userId}` using the pre-created custom auth-config ID. Create it as `SHARED` with only that project's executor ID in its allow list. Composio's TypeScript session `authorize()` and `connectedAccounts.link()` both support this experimental account type and ACL shape. [C5] [C6]
+3. Send only Composio's hosted redirect URL to the browser. The X client secret, bearer token, Composio project API key, and connected-account token values never cross the Core-to-browser boundary. Composio's Connect Link handles the provider sign-in and stores/refreshes the resulting tokens. [C4] [C7]
+4. Enable Composio's project-level callback identity verification. Core receives the single-use `session_uri`, authenticates the returning Sokosumi user, and completes the connection with the same `sokosumi:user:${userId}` used at initiation. A mismatch fails the connection rather than binding a victim's X account to an attacker's identifier. [C7]
+5. Persist the `ca_...` ID only after Composio reports `ACTIVE`. Do not trust a browser-supplied connected-account ID without checking it against the local intent, expected toolkit/auth config, and connector identity. Composio states that an abandoned link stays `INITIATED` until it expires. [C6] [C7]
+6. For a publish, Core re-checks project authorization and creates a short-lived session as `sokosumi:project-executor:${projectId}`, pinning that project's exact connected account. Limit the session to Twitter's `TWITTER_CREATION_OF_A_POST`, disable connection management and the sandbox, execute the tool, record the returned X post ID, then delete the session. Sessions otherwise start with broad toolkit discovery and sandbox capabilities enabled. [C6] [C8] [C9]
+
+Illustrative server-only TypeScript pattern, not a drop-in implementation:
+
+```ts
+const session = await composio.sessions.create(projectExecutorId, {
+  toolkits: ["twitter"],
+  tools: {
+    twitter: { enable: ["TWITTER_CREATION_OF_A_POST"] },
+  },
+  authConfigs: { twitter: twitterAuthConfigId },
+  connectedAccounts: { twitter: [connectedAccountId] },
+  manageConnections: false,
+  sandbox: { enable: false },
+});
+
+const result = await session.execute("TWITTER_CREATION_OF_A_POST", { text });
+await session.delete();
+```
+
+The SDK documents `sessions.create(...)` as the preferred replacement for the top-level alias, `connectedAccounts` as the way to pin a selected account, and `session.execute()` as provider-independent execution. For a deterministic direct-execution implementation instead, pin the toolkit's dated version: Composio intentionally rejects a bare/latest version for manual execution to avoid unreviewed toolkit changes. [C6] [C8] [C9]
+
+## Token lifecycle and disconnect
+
+| Event | Required behavior |
+| --- | --- |
+| Normal use | Let Composio store and refresh tokens. Treat a non-`ACTIVE` connection or tool authentication failure as unavailable; ask the connector to reconnect rather than exposing a token. [C7] [X4] |
+| X credentials/scopes changed | Reconnect. X says changing permissions requires re-authorization, and regenerating credentials invalidates the old values. [X3] [X1] |
+| Project disconnect | First atomically disable future local publishes/schedules, then call Composio's v3.1 revoke endpoint. It makes a best-effort provider revocation, returns exactly which token subjects were revoked, and moves the connection to `REVOKED` on success. Then delete or retain only a non-executable audit record locally. [C10] |
+| Revocation unavailable or failed | Block the local integration immediately. Composio can return 400 when a toolkit lacks programmatic revocation or 500 when upstream dispatch fails, so the UI must report that upstream revocation was not confirmed and provide the X deauthorization/reconnect path. [C10] |
+| Temporary suspension | Disable the connected account rather than deleting it only when a later re-enable is intended. Composio distinguishes disable/enable from permanent delete; delete removes the platform connection and its associated access. [C11] |
+
+Test the upstream behavior with one X account connected to more than one Sokosumi project before promising that a project disconnect is isolated from other X grants. Composio describes revocation as provider-side and best-effort, not as a project-local token revocation guarantee. [C10]
+
+## Core-service integration fit
+
+**Repository observation:** Core already has a server-only REST client at `apps/core/src/clients/composio.client.ts`, reads `COMPOSIO_API_KEY` from Core environment validation, and calls Composio with `x-api-key`. It also has an ownership-safe schedule sync mechanism in `apps/core/src/routes/sync/task-schedules/get.ts` and `apps/core/src/services/task-schedules-sync.ts`.
+
+Extend that Core client for new project-connection behavior rather than putting a Composio key in Web or adding browser-side OAuth logic. For new endpoints, use Composio REST v3.1: it is the current API; v3 remains supported but is the prior version. If adopting `@composio/core` for the restricted execution-session pattern above, pin an exact package version because the SHARED-account ACL surface is documented as experimental. [C3] [C5] [C8]
+
+**Repository observation:** the existing `ensureAuthConfig()` helper creates `use_composio_managed_auth` configs (`apps/core/src/clients/composio.client.ts:684-751`). It cannot provision Twitter now. X must use an explicitly provisioned custom auth-config ID, and the existing Twitter MCP write allow list already identifies `TWITTER_CREATION_OF_A_POST` (`apps/core/src/clients/composio.client.ts:450-469`).
+
+Use a scoped Composio project API key with only the required permissions: connected-account read/write for link/status/revoke, sessions write when using sessions, and tool-execution write for posting. Do not grant Proxy Execute, triggers, or auth-config write to the runtime key unless a confirmed use requires it. Composio supports immutable scoped-key permissions and IP allowlisting. [C12] [C13]
+
+## Security and authorization controls
+
+- Keep the Composio project API key and X client secret in Core-only secret storage. A Composio project key can create/revoke connections and execute tools; X classifies Web App and Automated App clients as confidential specifically because they can protect the client secret. [C12] [X3]
+- Authorize on the Sokosumi project for every Core endpoint and every background publish. Never accept `projectId`, Composio `userId`, connected-account ID, callback URL, or tool arguments from the browser as authority.
+- Enable Composio callback identity verification and retain a server-side one-time intent for project, connector, and requested capability. This mitigates OAuth session fixation, which Composio explicitly identifies for unauthenticated Connect-Link completion. [C7]
+- Use a dedicated custom X auth config per environment and an X app per environment. X recommends distinct apps for development, staging, and production. [X3]
+- Limit OAuth scopes and session tools to the publishing feature. Do not expose the full 79-tool Twitter catalog, direct proxy execution, raw MCP URL, or sandbox to a publish flow. [C1] [C8]
+- Configure Composio project log storage deliberately. By default it retains tool request/response payloads for up to one year; "Don't store data" keeps audit metadata but not those payloads for new calls. [C14]
+- Log the Sokosumi project, authorized actor or scheduler, connector, connected-account ID, requested publish time, tool version, result, and X post ID. Do not log OAuth values, Composio keys, or a Connect Link.
+
+## Publishing and scheduling limits
+
+Composio can immediately publish with `TWITTER_CREATION_OF_A_POST`; X's API publishes through `POST /2/tweets` using a user access token. The documented Composio tool and X request schema have post-content, media, reply, quote, poll, and disclosure fields but no future publish-time field. Therefore, scheduled posting must be a Sokosumi Core responsibility: persist a scheduled post, have the existing protected Core scheduler claim it when due, then run the restricted publish session. This is an inference from the cited request schemas, not a Composio scheduling feature. [C1] [X5] [X2]
+
+Relevant product limits:
+
+- Composio reports zero Twitter triggers, so it is not a scheduling or X-event trigger solution. [C1]
+- X's create-post endpoint requires user-context authorization. App-only bearer authentication is for public reads, not posting. [X2] [X4]
+- Media must be uploaded before post creation. A post supports at most four photos, one animated GIF, or one video, and post-time media caps depend on the posting account's X status. [X5]
+- Quote-posting through `quote_tweet_id` requires an X Enterprise plan; self-serve API posts are limited to one cashtag, and self-serve replies have additional mention/quote constraints. [X5] [X2]
+- If scheduled media processing or the Composio connection is not ready at dispatch time, leave the schedule in a retryable/failed state and require an explicit retry policy. Do not silently post a changed payload.
+
+## Sources
+
+| ID | Official source |
+| --- | --- |
+| C1 | [Composio Twitter toolkit](https://docs.composio.dev/toolkits/twitter) |
+| C2 | [Composio Twitter/X configuration guide](https://docs.composio.dev/kb/guide/toolkits-twitter) |
+| C3 | [Composio projects](https://docs.composio.dev/reference/api-reference/projects) |
+| C4 | [Composio authentication model](https://docs.composio.dev/docs/authentication) |
+| C5 | [Composio shared connections](https://docs.composio.dev/docs/extending-sessions/shared-connections) |
+| C6 | [Composio TypeScript Session reference](https://docs.composio.dev/reference/sdk-reference/typescript/session) |
+| C7 | [Composio connected accounts and callback identity verification](https://docs.composio.dev/reference/api-reference/connected-accounts) |
+| C8 | [Composio session configuration](https://docs.composio.dev/docs/configuring-sessions) |
+| C9 | [Composio TypeScript tool execution reference](https://docs.composio.dev/reference/sdk-reference/typescript/tools) |
+| C10 | [Composio connected-account provider revocation](https://docs.composio.dev/reference/api-reference/connected-accounts/postConnectedAccountsByNanoidRevoke) |
+| C11 | [Composio TypeScript connected-account lifecycle methods](https://docs.composio.dev/reference/sdk-reference/typescript/connected-accounts) |
+| C12 | [Composio scoped project API-key permissions](https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions) |
+| C13 | [Composio security overview](https://docs.composio.dev/docs/security/overview) |
+| C14 | [Composio data retention](https://docs.composio.dev/docs/security/data-retention) |
+| X1 | [X API: getting access](https://docs.x.com/x-api/getting-started/getting-access) |
+| X2 | [X API: manage posts](https://docs.x.com/x-api/posts/manage-tweets/introduction) |
+| X3 | [X developer apps](https://docs.x.com/resources/fundamentals/developer-apps) |
+| X4 | [X OAuth 2.0 authorization code flow with PKCE](https://docs.x.com/resources/fundamentals/authentication/oauth-2-0/authorization-code) |
+| X5 | [X API: create posts](https://docs.x.com/x-api/posts/create-post) |

--- a/docs/superpowers/plans/2026-09-03-project-social-connections.md
+++ b/docs/superpowers/plans/2026-09-03-project-social-connections.md
@@ -1,0 +1,417 @@
+# Project Social Connections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let interactive humans in a Project's Workspace connect, inspect, reconnect, replace, and disconnect X accounts from `Project settings > Social accounts` without exposing provider credentials.
+
+**Architecture:** Core owns one Project social-connections resource, including the durable connection, short-lived OAuth intent, Composio operations, and non-executable audit records. Web consumes only generated Core DTOs through its Project service and server actions, and extends the existing Composio popup transport without using the Hermes connection lifecycle.
+
+**Tech Stack:** Prisma/PostgreSQL, Hono and Zod OpenAPI, Composio REST v3.1, X OAuth 2.0, Next.js App Router, React, next-intl, Vitest, Testing Library.
+
+**Spec:** `docs/plans/2026-09-03-project-social-connections-spec.md`
+
+## Global Constraints
+
+- Core is the authorization, scheduling-authorization, lifecycle, and audit authority; Composio holds provider credentials.
+- Only a real interactive session user in the Project's Workspace may manage a Social connection. User API keys, coworkers, and orchestrators are rejected.
+- X is the only provider in this release. The persistence model remains provider-agnostic without adding a provider plugin system.
+- Never return, persist in Sokosumi, or log OAuth access tokens, refresh tokens, Composio API keys, or hosted OAuth URLs after initiation.
+- Each OAuth completion must be bound to a single-use, 15-minute server-side intent containing the Project, initiating user, provider, action, and expected connection id.
+- The initial UI is `Project settings > Social accounts`. It has no composer, post action, media flow, Calendar change, scheduler invocation, or audit-history UI.
+- X identity resolution uses a session pinned to the new account and only `TWITTER_USER_LOOKUP_ME`; future posting must use a distinct restricted session.
+- Update `messages/en.json`, `messages/de.json`, and `messages/es.json` with identical Social account key paths. Regenerate the Web Core client after every Core OpenAPI change.
+- Do not commit unless the user explicitly requests a commit.
+
+---
+
+### Task 1: Persist Project social-connection lifecycle state
+
+**Files:**
+- Modify: `packages/database/prisma/schema.prisma`
+- Create: `packages/database/prisma/migrations/<timestamp>_add_project_social_connections/migration.sql`
+- Modify: `apps/core/src/test/setup.ts`
+- Modify: `apps/core/src/config/env.ts`
+- Test: `packages/database/src/helpers/migration-prefix-uniqueness.test.ts` if the migration-prefix guard requires an updated expected list
+
+**Interfaces:**
+- Produces `ProjectSocialConnection`, `ProjectSocialConnectionIntent`, and `ProjectSocialConnectionAudit` Prisma models owned by `Project`.
+- Produces connection states `pending`, `active`, `reauthorization_required`, and `disconnected`, represented as strings so adding future providers or states does not require an enum migration.
+- Produces `COMPOSIO_X_AUTH_CONFIG_ID`, required by Core only and defaulted in Core Vitest setup.
+
+- [ ] **Step 1: Add the failing Prisma-schema expectations to the nearest schema/migration test seam.**
+
+```typescript
+expect(prisma.projectSocialConnection).toBeDefined();
+expect(prisma.projectSocialConnectionIntent).toBeDefined();
+expect(prisma.projectSocialConnectionAudit).toBeDefined();
+```
+
+- [ ] **Step 2: Run the focused schema or migration guard.**
+
+Run: `pnpm --filter @sokosumi/database test src/helpers/migration-prefix-uniqueness.test.ts`
+
+Expected: the new social-connection model API is absent or the migration guard reports the missing migration prefix.
+
+- [ ] **Step 3: Add the three models and Project relations, then generate a migration.**
+
+```prisma
+model ProjectSocialConnection {
+  id                       String   @id @default(uuid(7)) @db.Uuid
+  projectId                String   @db.Uuid
+  provider                 String
+  externalAccountId        String
+  externalHandle           String?
+  composioConnectedAccountId String
+  status                   String
+  activeExternalAccountKey String?
+  connectorUserId          String
+  connectedAt              DateTime?
+  disconnectedAt           DateTime?
+  createdAt                DateTime @default(now())
+  updatedAt                DateTime @updatedAt
+}
+```
+
+Add the `Project` relation, a nullable active key constrained with `projectId` to prevent two active rows for one provider/account identity, a one-to-many audit relation, and an intent keyed by Composio's connection id. Generate the SQL with `pnpm prisma:migrate:dev --name add-project-social-connections`; do not hand-write generated migration SQL.
+
+- [ ] **Step 4: Add Core-only configuration.**
+
+```typescript
+COMPOSIO_X_AUTH_CONFIG_ID: z.string().min(1).optional(),
+```
+
+Use the production value as a required precondition when beginning an X connection, and set a non-secret test value in `envDefaults` so Core tests do not require a local `.env` edit.
+
+- [ ] **Step 5: Generate Prisma and run the focused guard again.**
+
+Run: `pnpm prisma:generate && pnpm --filter @sokosumi/database test src/helpers/migration-prefix-uniqueness.test.ts`
+
+Expected: generated Prisma types recognize all three models and the migration prefix is unique.
+
+### Task 2: Build the Core Composio adapter and Project social-connection service
+
+**Files:**
+- Modify: `apps/core/src/clients/composio.client.ts`
+- Test: `apps/core/src/clients/composio.client.test.ts`
+- Create: `apps/core/src/services/project-social-connections.service.ts`
+- Create: `apps/core/src/services/project-social-connections.service.test.ts`
+
+**Interfaces:**
+- Consumes Task 1's Prisma models and `COMPOSIO_X_AUTH_CONFIG_ID`.
+- Produces `initiateProjectSocialConnection`, `finalizeProjectSocialConnection`, `listProjectSocialConnections`, and `disconnectProjectSocialConnection` service functions.
+- Produces adapter functions that link a custom X auth config, query a connected account, create a least-privilege identity session, execute `TWITTER_USER_LOOKUP_ME`, and request provider revocation.
+
+- [ ] **Step 1: Write failing adapter tests using mocked Composio responses.**
+
+```typescript
+it("returns the hosted link and connected-account id for custom X auth", async () => {
+  await expect(initiateProjectXConnection(input)).resolves.toEqual({
+    connectionId: "ca_123",
+    redirectUrl: "https://connect.composio.dev/...",
+  });
+});
+
+it("parses the authenticated X id and handle from lookup-me", async () => {
+  await expect(getConnectedXIdentity(input)).resolves.toEqual({
+    id: "123",
+    handle: "sokosumi",
+  });
+});
+```
+
+- [ ] **Step 2: Run the Composio client test file.**
+
+Run: `pnpm --filter core test src/clients/composio.client.test.ts`
+
+Expected: imports or functions for project-scoped X connection operations are missing.
+
+- [ ] **Step 3: Extend the adapter without changing Hermes behavior.**
+
+```typescript
+export interface ConnectedXIdentity {
+  id: string;
+  handle: string | null;
+}
+
+export async function getConnectedXIdentity(input: {
+  connectedAccountId: string;
+  executorUserId: string;
+}): Promise<ConnectedXIdentity>;
+```
+
+Use the existing Core-only `composioFetch` boundary. Pin every Composio session to the one connected account, enable only `TWITTER_USER_LOOKUP_ME`, disable connection management and sandbox behavior, parse the tool result, and delete the session in `finally`. Keep the X auth-config id, Composio API key, hosted URL, and raw tool payload out of errors and return values.
+
+- [ ] **Step 4: Write failing service tests for the lifecycle state machine.**
+
+```typescript
+it("rejects a callback from a different user or project", async () => {
+  await expect(finalizeProjectSocialConnection(mismatchedInput)).rejects.toThrow(
+    "Unknown or expired connection",
+  );
+});
+
+it("blocks a duplicate active provider/account in one project", async () => {
+  await expect(finalizeProjectSocialConnection(duplicateInput)).rejects.toThrow(
+    "already connected",
+  );
+});
+```
+
+- [ ] **Step 5: Implement the service around one durable intent and audit seam.**
+
+```typescript
+export interface InitiateProjectSocialConnectionInput {
+  projectId: string;
+  userId: string;
+  provider: "x";
+  action: "connect" | "reconnect" | "replace";
+  socialConnectionId?: string;
+}
+
+export async function initiateProjectSocialConnection(
+  input: InitiateProjectSocialConnectionInput,
+): Promise<{ connectionId: string; redirectUrl: string }>;
+```
+
+Validate the scoped Project before all reads or mutations. Persist the one-use intent before returning the redirect URL. On finalize, verify the user, Project, provider, requested action, expiry, and Composio account; wait only for active Composio state; resolve X identity; enforce the active Project/provider/account uniqueness rule; write one durable row and one audit record atomically; remove the intent only after success. Reconnect rejects a different X id. Replace marks the prior row disconnected before activating the new one. Disconnect blocks local execution and records the result before best-effort provider revocation; revoke only when no other active Project connection references that Composio account.
+
+- [ ] **Step 6: Run the focused Core service and adapter tests.**
+
+Run: `pnpm --filter core test src/clients/composio.client.test.ts src/services/project-social-connections.service.test.ts`
+
+Expected: all lifecycle paths pass, including Composio failures that leave the Project connection locally blocked and audited.
+
+### Task 3: Expose the Project social-connections OpenAPI resource
+
+**Files:**
+- Create: `apps/core/src/schemas/project-social-connection.schema.ts`
+- Modify: `apps/core/src/routes/v1/projects/index.ts`
+- Create: `apps/core/src/routes/v1/projects/[id]/social-connections/get.ts`
+- Create: `apps/core/src/routes/v1/projects/[id]/social-connections/initiate/post.ts`
+- Create: `apps/core/src/routes/v1/projects/[id]/social-connections/finalize/post.ts`
+- Create: `apps/core/src/routes/v1/projects/[id]/social-connections/[connectionId]/delete.ts`
+- Create: `apps/core/src/routes/v1/projects/[id]/social-connections/project-social-connections.routes.test.ts`
+
+**Interfaces:**
+- Consumes Task 2 service functions.
+- Produces `GET /projects/{id}/social-connections`, `POST /projects/{id}/social-connections/initiate`, `POST /projects/{id}/social-connections/finalize`, and `DELETE /projects/{id}/social-connections/{connectionId}`.
+- Produces OpenAPI DTOs containing only id, provider, external handle, status, connection timestamps, and initiation redirect data.
+
+- [ ] **Step 1: Define failing route tests before mounting routes.**
+
+```typescript
+it("allows an interactive workspace user to list connections", async () => {
+  const response = await app.request(`http://localhost/${PROJECT_ID}/social-connections`);
+  expect(response.status).toBe(200);
+});
+
+it.each([COWORKER_CONTEXT_AUTH, ORCHESTRATOR_CONTEXT_AUTH, USER_API_KEY_AUTH])(
+  "rejects a non-interactive actor",
+  async (authContext) => {
+    const response = await createApp(authContext).request(url);
+    expect(response.status).toBe(403);
+  },
+);
+```
+
+- [ ] **Step 2: Run the new route test.**
+
+Run: `pnpm --filter core test src/routes/v1/projects/[id]/social-connections/project-social-connections.routes.test.ts`
+
+Expected: route modules and schemas do not exist.
+
+- [ ] **Step 3: Add schemas and mount routes as one Project resource.**
+
+```typescript
+const initiateRequestSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("connect"), provider: z.literal("x") }),
+  z.object({ action: z.literal("reconnect"), socialConnectionId: z.string().uuid() }),
+  z.object({ action: z.literal("replace"), socialConnectionId: z.string().uuid() }),
+]);
+```
+
+Use `requireUserAuthContext` and `requireWorkspaceContext` in every handler, then require that the Project belongs to the current Workspace. Return standard `ok`, `created`, and error helpers. The list never includes disconnected audit history. The finalize endpoint takes the opaque Composio connection id only and looks up every other authority value server-side.
+
+- [ ] **Step 4: Cover the full HTTP boundary.**
+
+```typescript
+expect(body.data).toEqual([
+  expect.objectContaining({ provider: "x", externalHandle: "sokosumi", status: "active" }),
+]);
+expect(JSON.stringify(body)).not.toContain("access_token");
+```
+
+Add cases for missing or out-of-workspace Projects, malformed IDs, expired/mismatched intent, duplicate X id, same-id reconnect, different-id reconnect, replacement, disconnect, and provider revoke failure.
+
+- [ ] **Step 5: Run Core checks and create the Web snapshot.**
+
+Run: `pnpm --filter core test src/routes/v1/projects/[id]/social-connections/project-social-connections.routes.test.ts && pnpm --filter core typecheck && pnpm --filter core write-openapi-snapshot-for-web`
+
+Expected: all endpoints appear in the Core OpenAPI snapshot with no credential fields.
+
+### Task 4: Regenerate the Web client and add Project service/actions
+
+**Files:**
+- Modify: `apps/web/src/lib/services/project.service.ts`
+- Modify: `apps/web/src/lib/actions/project/action.ts`
+- Modify: `apps/web/src/lib/services/__tests__/project.service.test.ts`
+- Modify: `apps/web/src/lib/actions/project/__tests__/action.test.ts`
+- Regenerate: `apps/web/src/lib/clients/generated/core/*`
+
+**Interfaces:**
+- Consumes Task 3 generated DTOs.
+- Produces `projectService.listSocialConnections`, `initiateSocialConnection`, `finalizeSocialConnection`, and `disconnectSocialConnection`.
+- Produces session-bound server actions that revalidate the Project detail and edit paths after terminal mutations.
+
+- [ ] **Step 1: Regenerate the generated Core client instead of editing it.**
+
+Run: `pnpm --filter web generate:core:snapshot`
+
+Expected: generated operation and DTO names for the four Project social-connection endpoints are available under `src/lib/clients/generated/core`.
+
+- [ ] **Step 2: Add failing service tests against generated-client calls.**
+
+```typescript
+it("lists a project's active social connections", async () => {
+  await expect(projectService.listSocialConnections(PROJECT_ID)).resolves.toEqual([
+    expect.objectContaining({ provider: "x", status: "active" }),
+  ]);
+});
+
+it("does not turn a Core request error into a success", async () => {
+  await expect(projectService.initiateSocialConnection(PROJECT_ID, input)).rejects.toThrow();
+});
+```
+
+- [ ] **Step 3: Run the focused service tests.**
+
+Run: `pnpm --filter web test src/lib/services/__tests__/project.service.test.ts`
+
+Expected: the Project service does not expose social-connection operations.
+
+- [ ] **Step 4: Implement the service and server actions with plain action DTOs.**
+
+```typescript
+export const initiateProjectSocialConnection = withSession<
+  { projectId: string; action: "connect" | "reconnect" | "replace"; socialConnectionId?: string },
+  ActionResultDto<{ connectionId: string; redirectUrl: string }, ActionError>
+>(async (input) => { /* Core call, then toActionResult */ });
+```
+
+Use `toActionResult` for expected Core errors, preserve generated DTOs instead of creating Prisma-shaped mirrors, and revalidate `/projects`, `/projects/${projectId}`, and `/projects/${projectId}/edit` after finalize or disconnect. Do not add Web environment variables or any direct Composio request.
+
+- [ ] **Step 5: Add action tests and typecheck Web.**
+
+Run: `pnpm --filter web test src/lib/actions/project/__tests__/action.test.ts && pnpm --filter web typecheck`
+
+Expected: server actions return Flight-safe success/error DTOs and generated-client types match the Core contract.
+
+### Task 5: Add the Project Settings Social accounts UI and OAuth flow
+
+**Files:**
+- Modify: `apps/web/src/app/(app)/projects/[projectId]/edit/page.tsx`
+- Modify: `apps/web/src/app/(app)/projects/components/project-edit-modal.tsx`
+- Create: `apps/web/src/app/(app)/projects/components/project-social-accounts.tsx`
+- Create: `apps/web/src/app/(app)/projects/components/__tests__/project-social-accounts.test.tsx`
+- Modify: `apps/web/messages/en.json`
+- Modify: `apps/web/messages/de.json`
+- Modify: `apps/web/messages/es.json`
+- Modify if needed: `apps/web/src/i18n/message-namespaces.ts`
+
+**Interfaces:**
+- Consumes Task 4 Project service/action contracts and the existing `ComposioOAuthCallbackPayload` BroadcastChannel protocol.
+- Produces a Project Settings section with active-account rows and connect, reconnect, replace, and disconnect controls.
+- Produces translated labels in all supported locales with matching key paths.
+
+- [ ] **Step 1: Add failing component tests for visible lifecycle states.**
+
+```tsx
+render(<ProjectSocialAccounts projectId={PROJECT_ID} connections={connections} />);
+expect(screen.getByText("@sokosumi")).toBeVisible();
+expect(screen.getByRole("button", { name: "Reconnect" })).toBeVisible();
+expect(screen.getByRole("button", { name: "Disconnect" })).toBeVisible();
+```
+
+- [ ] **Step 2: Run the focused component test.**
+
+Run: `pnpm --filter web test src/app/(app)/projects/components/__tests__/project-social-accounts.test.tsx`
+
+Expected: the component and translated controls do not exist.
+
+- [ ] **Step 3: Load active connections in the edit server component and render a focused client section.**
+
+```tsx
+const [project, socialConnections] = await Promise.all([
+  projectService.getProjectById(projectId),
+  projectService.listSocialConnections(projectId),
+]);
+```
+
+Pass the generated DTOs to `ProjectEditModal`, then render `ProjectSocialAccounts` below the existing Project details form. Keep the page server-rendered; make only the interaction/popup section a client component.
+
+- [ ] **Step 4: Implement popup handling with the existing BroadcastChannel protocol.**
+
+```typescript
+const result = await initiateProjectSocialConnection({ projectId, action, socialConnectionId });
+const popup = window.open(result.value.redirectUrl, "_blank", "popup,width=520,height=720");
+// On a successful ComposioOAuthCallbackPayload, call finalizeProjectSocialConnection.
+```
+
+Validate that the callback connection id equals the initiation result before finalizing. Show an actionable error for blocked popup, cancelled OAuth, provider error, expired intent, different-account reconnect, duplicate account, and failed disconnect. Never put the redirect URL into component state, route state, analytics, or a message catalog. Use a deliberate confirmation dialog before disconnect and replace.
+
+- [ ] **Step 5: Add all locale keys and run translation parity.**
+
+Run: `pnpm --filter web messages:parity && pnpm --filter web test src/app/(app)/projects/components/__tests__/project-social-accounts.test.tsx`
+
+Expected: all locales contain the same Project Social accounts keys and lifecycle controls render without a Hermes dependency.
+
+### Task 6: Run the cross-layer regression suite and review the change
+
+**Files:**
+- Modify only files required to fix failures from the commands below.
+- Review: `CONTEXT.md`, `docs/adr/0018-core-owned-project-social-connections.md`, `docs/plans/2026-09-03-project-social-connections-spec.md`, and this plan if implementation changed an agreed decision.
+
+**Interfaces:**
+- Consumes the completed Core API, generated Web client, and Project Settings UI.
+- Produces verified behavior and a reviewed working tree ready for the user to decide whether to commit.
+
+- [ ] **Step 1: Run focused Core and Web tests.**
+
+Run: `pnpm --filter core test src/clients/composio.client.test.ts src/services/project-social-connections.service.test.ts src/routes/v1/projects/[id]/social-connections/project-social-connections.routes.test.ts && pnpm --filter web test src/lib/services/__tests__/project.service.test.ts src/lib/actions/project/__tests__/action.test.ts src/app/(app)/projects/components/__tests__/project-social-accounts.test.tsx`
+
+Expected: every selected lifecycle, authorization, and UI test passes.
+
+- [ ] **Step 2: Run static validation after the generated client is current.**
+
+Run: `pnpm --filter core typecheck && pnpm --filter web typecheck && pnpm --filter core lint && pnpm --filter web check`
+
+Expected: no Core or Web diagnostics and no generated-client DTO drift.
+
+- [ ] **Step 3: Inspect the diff for boundary violations.**
+
+```text
+Confirm Web has no @sokosumi/database, Composio, X, OAuth token, or Core secret imports.
+Confirm no API response or audit DTO contains token, key, hosted OAuth URL, or raw provider payload.
+Confirm every social-connection route requires an interactive Workspace human.
+```
+
+- [ ] **Step 4: Run the required review pass.**
+
+Run: invoke `/code-review` against the working-tree diff.
+
+Expected: standards and spec review find no unresolved correctness, security, or behavior regressions.
+
+- [ ] **Step 5: Report operational prerequisites separately from application verification.**
+
+```text
+Production still requires a customer-owned X app, the exact Composio callback URL,
+COMPOSIO_X_AUTH_CONFIG_ID, a scoped COMPOSIO_API_KEY, and a Composio data-retention choice.
+```
+
+Do not claim a live X OAuth flow passed until those credentials exist in a non-production environment and an interactive browser check completes.
+
+## Self-Review
+
+- **Spec coverage:** Tasks 1-3 cover persistence, Core authorization, custom Composio OAuth, lifecycle, audit, and OpenAPI. Tasks 4-5 cover generated client, server actions, Project settings, popup handling, and translations. Task 6 covers regression, boundary, and review gates. Posting, media, Calendar, scheduler execution, other providers, and history UI remain excluded.
+- **Placeholder scan:** The task descriptions contain no deferred implementation instructions. Deployment prerequisites are intentional out-of-code operational work, not incomplete implementation tasks.
+- **Type consistency:** The Project service and Web actions consume Task 3 DTOs. Core routes consume Task 2 service functions. Task 1 persistence owns the fields Task 2 needs for status, provider reference, identity, intent, and audit.


### PR DESCRIPTION
## Summary
- define Project social connections and their lifecycle vocabulary
- record Core ownership of authorization, auditing, and Composio boundaries
- capture the product specification, implementation plan, and provider research

## Verification
- pnpm check
- pnpm typecheck

Pairs with #4127.