### PR TITLE
fix(core): stop capping soko-bot judge output tokens

### DIFF
--- a/apps/core/src/routes/v1/soko-bots/index.ts
+++ b/apps/core/src/routes/v1/soko-bots/index.ts
@@ -115,8 +115,7 @@ import {
 } from "@/services/soko-bot-lab.service";
 import {
   judgeSokoBotLabTurn,
-  SokoBotJudgeFailure,
-  SokoBotLabJudgeError,
+  sokoBotLabJudgeErrorKind,
 } from "@/services/soko-bot-lab-judge.service";
 import { retimeSystemSchedules } from "@/services/soko-bot-proactive.service";
 import {
@@ -1726,8 +1725,15 @@ app.openapi(judgeLabTurnRoute, async (c) => {
     });
     return ok(c, sokoBotLabVerdictSchema.parse({ model, ...verdict }));
   } catch (error) {
-    if (error instanceof SokoBotJudgeFailure) throw badGateway(error.message);
-    if (error instanceof SokoBotLabJudgeError) throw notFound(error.message);
+    const kind = sokoBotLabJudgeErrorKind(error);
+    if (kind === "miss") {
+      throw badGateway(
+        error instanceof Error ? error.message : "Judge produced no verdict",
+      );
+    }
+    if (kind === "not_found") {
+      throw notFound(error instanceof Error ? error.message : "Not Found");
+    }
     throw error;
   }
 });

--- a/apps/core/src/routes/v1/soko-bots/index.ts
+++ b/apps/core/src/routes/v1/soko-bots/index.ts
@@ -6,6 +6,7 @@ import { waitUntil } from "@vercel/functions";
 
 import { getEnv } from "@/config/env";
 import {
+  badGateway,
   badRequest,
   conflict,
   forbidden,
@@ -114,6 +115,7 @@ import {
 } from "@/services/soko-bot-lab.service";
 import {
   judgeSokoBotLabTurn,
+  SokoBotJudgeFailure,
   SokoBotLabJudgeError,
 } from "@/services/soko-bot-lab-judge.service";
 import { retimeSystemSchedules } from "@/services/soko-bot-proactive.service";
@@ -1711,6 +1713,7 @@ const judgeLabTurnRoute = createRoute({
     401: jsonErrorResponse("Unauthorized"),
     404: jsonErrorResponse("Not Found"),
     422: jsonErrorResponse("Unprocessable Entity"),
+    502: jsonErrorResponse("Bad Gateway"),
   },
 });
 
@@ -1723,6 +1726,7 @@ app.openapi(judgeLabTurnRoute, async (c) => {
     });
     return ok(c, sokoBotLabVerdictSchema.parse({ model, ...verdict }));
   } catch (error) {
+    if (error instanceof SokoBotJudgeFailure) throw badGateway(error.message);
     if (error instanceof SokoBotLabJudgeError) throw notFound(error.message);
     throw error;
   }

--- a/apps/core/src/services/soko-bot-control-plane.service.ts
+++ b/apps/core/src/services/soko-bot-control-plane.service.ts
@@ -1490,16 +1490,10 @@ export class SokoBotControlPlane {
           void (
             judgeAllowed ? judgeTurnQuality(input.turnId) : Promise.resolve()
           ).catch(async (error) => {
-            console.error("Soko Bot turn judge failed", {
-              turnId: input.turnId,
-              error: error instanceof Error ? error.message : "unknown",
-            });
-            // A judge that produced nothing usable still spent the tokens it
-            // spent, and it fails most often on the turns that cost the most.
-            const { recordFailedJudgeUsage } = await import(
+            const { reportFailedTurnJudge } = await import(
               "@/services/soko-bot-lab-judge.service"
             );
-            await recordFailedJudgeUsage(input.turnId, error);
+            await reportFailedTurnJudge(input.turnId, error);
           });
         }
         return settled;

--- a/apps/core/src/services/soko-bot-lab-judge.service.test.ts
+++ b/apps/core/src/services/soko-bot-lab-judge.service.test.ts
@@ -1,0 +1,92 @@
+import { sokoBotJudgeVerdictSchema } from "@sokosumi/soko-bot";
+import { generateText, NoOutputGeneratedError, Output } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    sokoBotTurn: { findFirst: vi.fn(), update: vi.fn() },
+    sokoBotLabRun: { upsert: vi.fn() },
+  },
+}));
+
+import { SOKO_BOT_JUDGE_MAX_OUTPUT_TOKENS } from "./soko-bot-lab-judge.service";
+
+const VALID_VERDICT = {
+  scores: { delegation: 4, followThrough: 4, judgment: 4, honesty: 5 },
+  verdict: "pass" as const,
+  rationale: "Tasks were clear and claims matched tool results.",
+  issues: [] as string[],
+};
+
+function usage(outputTotal: number, reasoning: number, text: number) {
+  return {
+    inputTokens: {
+      total: 20,
+      noCache: 20,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    },
+    outputTokens: { total: outputTotal, text, reasoning },
+  };
+}
+
+/**
+ * gpt-5.5-style: reasoning consumes the whole cap, so the JSON never arrives
+ * unless maxOutputTokens is larger than production's original 800.
+ */
+function budgetSensitiveJudgeModel() {
+  return new MockLanguageModelV3({
+    doGenerate: async (options) => {
+      if ((options.maxOutputTokens ?? 0) <= 800) {
+        return {
+          content: [
+            {
+              type: "reasoning",
+              text: "scoring the turn against the rubric...",
+            },
+          ],
+          finishReason: { unified: "length" as const, raw: "length" },
+          usage: usage(800, 800, 0),
+          warnings: [],
+        };
+      }
+      return {
+        content: [{ type: "text", text: JSON.stringify(VALID_VERDICT) }],
+        finishReason: { unified: "stop" as const, raw: "stop" },
+        usage: usage(400, 100, 300),
+        warnings: [],
+      };
+    },
+  });
+}
+
+describe("soko-bot lab judge generateText", () => {
+  it("throws AI_NoOutputGeneratedError when reasoning fills an 800-token cap", async () => {
+    const resultPromise = generateText({
+      model: budgetSensitiveJudgeModel(),
+      output: Output.object({ schema: sokoBotJudgeVerdictSchema }),
+      maxOutputTokens: 800,
+      prompt: "{}",
+    });
+
+    await expect(
+      resultPromise.then((result) => result.output),
+    ).rejects.toSatisfy((error: unknown) =>
+      NoOutputGeneratedError.isInstance(error),
+    );
+  });
+
+  it("parses a verdict when the production judge budget leaves room for JSON", async () => {
+    const result = await generateText({
+      model: budgetSensitiveJudgeModel(),
+      output: Output.object({ schema: sokoBotJudgeVerdictSchema }),
+      maxOutputTokens: SOKO_BOT_JUDGE_MAX_OUTPUT_TOKENS,
+      prompt: "{}",
+    });
+
+    expect(sokoBotJudgeVerdictSchema.parse(result.output)).toEqual(
+      VALID_VERDICT,
+    );
+  });
+});

--- a/apps/core/src/services/soko-bot-lab-judge.service.test.ts
+++ b/apps/core/src/services/soko-bot-lab-judge.service.test.ts
@@ -1,7 +1,16 @@
+import { readFileSync } from "node:fs";
 import { sokoBotJudgeVerdictSchema } from "@sokosumi/soko-bot";
 import { generateText, NoOutputGeneratedError, Output } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 import { describe, expect, it, vi } from "vitest";
+
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: captureExceptionMock,
+}));
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
@@ -10,7 +19,10 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-import { generateSokoBotJudgeText } from "./soko-bot-lab-judge.service";
+import {
+  generateSokoBotJudgeText,
+  reportFailedTurnJudge,
+} from "./soko-bot-lab-judge.service";
 
 const VALID_VERDICT = {
   scores: { delegation: 4, followThrough: 4, judgment: 4, honesty: 5 },
@@ -88,6 +100,37 @@ describe("soko-bot lab judge generateText", () => {
 
     expect(sokoBotJudgeVerdictSchema.parse(result.output)).toEqual(
       VALID_VERDICT,
+    );
+  });
+});
+
+describe("soko-bot judge failure reporting", () => {
+  it("pages Sentry when a background turn judge fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const error = new Error("No output generated.");
+    await reportFailedTurnJudge("turn_1", error);
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        tags: { error_type: "soko_bot_turn_judge_failed" },
+        extra: { turnId: "turn_1" },
+      }),
+    );
+  });
+
+  it("maps a lab judge miss to 502, not 404", () => {
+    const route = readFileSync(
+      new URL("../routes/v1/soko-bots/index.ts", import.meta.url),
+      "utf8",
+    );
+    const handler = route.slice(
+      route.indexOf("judgeLabTurnRoute"),
+      route.indexOf("export default app"),
+    );
+    expect(handler).toContain("SokoBotJudgeFailure");
+    expect(handler).toContain("badGateway");
+    expect(handler).toMatch(
+      /SokoBotJudgeFailure[\s\S]*badGateway[\s\S]*SokoBotLabJudgeError[\s\S]*notFound/,
     );
   });
 });

--- a/apps/core/src/services/soko-bot-lab-judge.service.test.ts
+++ b/apps/core/src/services/soko-bot-lab-judge.service.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { sokoBotJudgeVerdictSchema } from "@sokosumi/soko-bot";
 import { generateText, NoOutputGeneratedError, Output } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
@@ -22,6 +21,9 @@ vi.mock("@/lib/db/prisma", () => ({
 import {
   generateSokoBotJudgeText,
   reportFailedTurnJudge,
+  SokoBotJudgeFailure,
+  SokoBotLabJudgeError,
+  sokoBotLabJudgeErrorKind,
 } from "./soko-bot-lab-judge.service";
 
 const VALID_VERDICT = {
@@ -44,13 +46,13 @@ function usage(outputTotal: number, reasoning: number, text: number) {
 }
 
 /**
- * gpt-5.5-style: reasoning consumes a small maxOutputTokens cap, so the JSON
- * never arrives. No cap (production) leaves room for the verdict.
+ * gpt-5.5-style: reasoning consumes maxOutputTokens, so the JSON never
+ * arrives whenever a cap is set. No cap (production) leaves room for JSON.
  */
 function budgetSensitiveJudgeModel() {
   return new MockLanguageModelV3({
     doGenerate: async (options) => {
-      if (options.maxOutputTokens != null && options.maxOutputTokens <= 800) {
+      if (options.maxOutputTokens != null) {
         return {
           content: [
             {
@@ -74,20 +76,23 @@ function budgetSensitiveJudgeModel() {
 }
 
 describe("soko-bot lab judge generateText", () => {
-  it("throws AI_NoOutputGeneratedError when reasoning fills an 800-token cap", async () => {
-    const resultPromise = generateText({
-      model: budgetSensitiveJudgeModel(),
-      output: Output.object({ schema: sokoBotJudgeVerdictSchema }),
-      maxOutputTokens: 800,
-      prompt: "{}",
-    });
+  it.each([800, 8_000])(
+    "throws AI_NoOutputGeneratedError when a %s-token cap is set",
+    async (maxOutputTokens) => {
+      const resultPromise = generateText({
+        model: budgetSensitiveJudgeModel(),
+        output: Output.object({ schema: sokoBotJudgeVerdictSchema }),
+        maxOutputTokens,
+        prompt: "{}",
+      });
 
-    await expect(
-      resultPromise.then((result) => result.output),
-    ).rejects.toSatisfy((error: unknown) =>
-      NoOutputGeneratedError.isInstance(error),
-    );
-  });
+      await expect(
+        resultPromise.then((result) => result.output),
+      ).rejects.toSatisfy((error: unknown) =>
+        NoOutputGeneratedError.isInstance(error),
+      );
+    },
+  );
 
   it("parses a verdict when the production judge call does not cap output tokens", async () => {
     const result = await generateSokoBotJudgeText({
@@ -118,19 +123,17 @@ describe("soko-bot judge failure reporting", () => {
     );
   });
 
-  it("maps a lab judge miss to 502, not 404", () => {
-    const route = readFileSync(
-      new URL("../routes/v1/soko-bots/index.ts", import.meta.url),
-      "utf8",
-    );
-    const handler = route.slice(
-      route.indexOf("judgeLabTurnRoute"),
-      route.indexOf("export default app"),
-    );
-    expect(handler).toContain("SokoBotJudgeFailure");
-    expect(handler).toContain("badGateway");
-    expect(handler).toMatch(
-      /SokoBotJudgeFailure[\s\S]*badGateway[\s\S]*SokoBotLabJudgeError[\s\S]*notFound/,
-    );
+  it("treats a judge miss as miss even though it is also a lab-judge error", () => {
+    const miss = new SokoBotJudgeFailure("No output generated.", {
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    expect(miss).toBeInstanceOf(SokoBotLabJudgeError);
+    expect(sokoBotLabJudgeErrorKind(miss)).toBe("miss");
+    expect(
+      sokoBotLabJudgeErrorKind(new SokoBotLabJudgeError("Turn not found")),
+    ).toBe("not_found");
+    expect(sokoBotLabJudgeErrorKind(new Error("boom"))).toBeUndefined();
   });
 });

--- a/apps/core/src/services/soko-bot-lab-judge.service.test.ts
+++ b/apps/core/src/services/soko-bot-lab-judge.service.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-import { SOKO_BOT_JUDGE_MAX_OUTPUT_TOKENS } from "./soko-bot-lab-judge.service";
+import { generateSokoBotJudgeText } from "./soko-bot-lab-judge.service";
 
 const VALID_VERDICT = {
   scores: { delegation: 4, followThrough: 4, judgment: 4, honesty: 5 },
@@ -32,13 +32,13 @@ function usage(outputTotal: number, reasoning: number, text: number) {
 }
 
 /**
- * gpt-5.5-style: reasoning consumes the whole cap, so the JSON never arrives
- * unless maxOutputTokens is larger than production's original 800.
+ * gpt-5.5-style: reasoning consumes a small maxOutputTokens cap, so the JSON
+ * never arrives. No cap (production) leaves room for the verdict.
  */
 function budgetSensitiveJudgeModel() {
   return new MockLanguageModelV3({
     doGenerate: async (options) => {
-      if ((options.maxOutputTokens ?? 0) <= 800) {
+      if (options.maxOutputTokens != null && options.maxOutputTokens <= 800) {
         return {
           content: [
             {
@@ -77,12 +77,13 @@ describe("soko-bot lab judge generateText", () => {
     );
   });
 
-  it("parses a verdict when the production judge budget leaves room for JSON", async () => {
-    const result = await generateText({
+  it("parses a verdict when the production judge call does not cap output tokens", async () => {
+    const result = await generateSokoBotJudgeText({
       model: budgetSensitiveJudgeModel(),
-      output: Output.object({ schema: sokoBotJudgeVerdictSchema }),
-      maxOutputTokens: SOKO_BOT_JUDGE_MAX_OUTPUT_TOKENS,
-      prompt: "{}",
+      payload: {
+        scenario: { id: "lab" },
+        turn: { finalAnswer: "done" },
+      },
     });
 
     expect(sokoBotJudgeVerdictSchema.parse(result.output)).toEqual(

--- a/apps/core/src/services/soko-bot-lab-judge.service.ts
+++ b/apps/core/src/services/soko-bot-lab-judge.service.ts
@@ -226,6 +226,14 @@ export class SokoBotJudgeFailure extends SokoBotLabJudgeError {
   }
 }
 
+/** Lab HTTP: a miss is upstream (502); missing turn/scenario is 404. */
+export function sokoBotLabJudgeErrorKind(
+  error: unknown,
+): "miss" | "not_found" | undefined {
+  if (error instanceof SokoBotJudgeFailure) return "miss";
+  if (error instanceof SokoBotLabJudgeError) return "not_found";
+}
+
 /**
  * Adds one model call's spend to a turn.
  *

--- a/apps/core/src/services/soko-bot-lab-judge.service.ts
+++ b/apps/core/src/services/soko-bot-lab-judge.service.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/node";
 import type { Prisma } from "@sokosumi/database";
 import {
   type ScenarioCheck,
@@ -415,4 +416,20 @@ export async function recordFailedJudgeUsage(
   if (!(error instanceof SokoBotJudgeFailure)) return;
   if (error.usage.costUsd === 0 && error.usage.inputTokens === 0) return;
   await addTurnOverheadUsage(turnId, error.usage).catch(() => undefined);
+}
+
+/** Background quality scoring: page Sentry, then keep the spend. */
+export async function reportFailedTurnJudge(
+  turnId: string,
+  error: unknown,
+): Promise<void> {
+  console.error("Soko Bot turn judge failed", {
+    turnId,
+    error: error instanceof Error ? error.message : "unknown",
+  });
+  Sentry.captureException(error, {
+    tags: { error_type: "soko_bot_turn_judge_failed" },
+    extra: { turnId },
+  });
+  await recordFailedJudgeUsage(turnId, error);
 }

--- a/apps/core/src/services/soko-bot-lab-judge.service.ts
+++ b/apps/core/src/services/soko-bot-lab-judge.service.ts
@@ -7,15 +7,13 @@ import {
   type SokoBotJudgeVerdict,
   sokoBotJudgeVerdictSchema,
 } from "@sokosumi/soko-bot";
-import { generateText, Output } from "ai";
+import { generateText, type LanguageModel, Output } from "ai";
 import { getEnv } from "@/config/env";
 import prisma from "@/lib/db/prisma";
 import { serializableTransaction } from "@/lib/db/transaction";
 import { gatewayCostUsd } from "@/lib/soko-bot/gateway-cost";
 
 const JUDGE_TIMEOUT_MS = 90_000;
-/** Reasoning tokens count against this cap. 800 left gpt-5.5 with empty JSON (SOKOSUMI-CORE-3D). */
-export const SOKO_BOT_JUDGE_MAX_OUTPUT_TOKENS = 8_000;
 // Tool results are the judge's evidence. At 2,000 a `search_inbox` result of
 // 3,091 lost its last message, and the judge called the bot a fabricator for
 // reporting an email the clipping had hidden. The limit exists to bound the
@@ -157,6 +155,25 @@ export interface JudgeCall {
   usage: { inputTokens: number; outputTokens: number; costUsd: number };
 }
 
+/**
+ * No maxOutputTokens: that cap includes reasoning, so gpt-5.5 can finish
+ * `length` with empty JSON (SOKOSUMI-CORE-3D). The schema bounds the verdict;
+ * JUDGE_TIMEOUT_MS bounds the call.
+ */
+export async function generateSokoBotJudgeText(options: {
+  model: LanguageModel | string;
+  payload: unknown;
+  abortSignal?: AbortSignal;
+}) {
+  return generateText({
+    model: options.model,
+    output: Output.object({ schema: sokoBotJudgeVerdictSchema }),
+    abortSignal: options.abortSignal,
+    instructions: SOKO_BOT_JUDGE_RUBRIC,
+    prompt: JSON.stringify(options.payload),
+  });
+}
+
 async function askJudge(
   payload: unknown,
   modelOverride?: string,
@@ -166,13 +183,10 @@ async function askJudge(
   const usage = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
-      const result = await generateText({
+      const result = await generateSokoBotJudgeText({
         model: modelOverride ?? sokoBotJudgeModel(),
-        output: Output.object({ schema: sokoBotJudgeVerdictSchema }),
-        maxOutputTokens: SOKO_BOT_JUDGE_MAX_OUTPUT_TOKENS,
+        payload,
         abortSignal: AbortSignal.timeout(JUDGE_TIMEOUT_MS),
-        instructions: SOKO_BOT_JUDGE_RUBRIC,
-        prompt: JSON.stringify(payload),
       });
       // Counted before the parse: a verdict this call cannot read still cost
       // what it cost, and the retry below spends again on top.

--- a/apps/core/src/services/soko-bot-lab-judge.service.ts
+++ b/apps/core/src/services/soko-bot-lab-judge.service.ts
@@ -14,6 +14,8 @@ import { serializableTransaction } from "@/lib/db/transaction";
 import { gatewayCostUsd } from "@/lib/soko-bot/gateway-cost";
 
 const JUDGE_TIMEOUT_MS = 90_000;
+/** Reasoning tokens count against this cap. 800 left gpt-5.5 with empty JSON (SOKOSUMI-CORE-3D). */
+export const SOKO_BOT_JUDGE_MAX_OUTPUT_TOKENS = 8_000;
 // Tool results are the judge's evidence. At 2,000 a `search_inbox` result of
 // 3,091 lost its last message, and the judge called the bot a fabricator for
 // reporting an email the clipping had hidden. The limit exists to bound the
@@ -167,7 +169,7 @@ async function askJudge(
       const result = await generateText({
         model: modelOverride ?? sokoBotJudgeModel(),
         output: Output.object({ schema: sokoBotJudgeVerdictSchema }),
-        maxOutputTokens: 800,
+        maxOutputTokens: SOKO_BOT_JUDGE_MAX_OUTPUT_TOKENS,
         abortSignal: AbortSignal.timeout(JUDGE_TIMEOUT_MS),
         instructions: SOKO_BOT_JUDGE_RUBRIC,
         prompt: JSON.stringify(payload),

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -34302,6 +34302,20 @@ export type JudgeMySokoBotLabTurnErrors = {
             method: string;
         };
     };
+    /**
+     * Bad Gateway
+     */
+    502: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
 };
 
 export type JudgeMySokoBotLabTurnError = JudgeMySokoBotLabTurnErrors[keyof JudgeMySokoBotLabTurnErrors];


### PR DESCRIPTION
Fixes SOKOSUMI-CORE-3D.

Supersedes #4022. The orchestrator refactor did not touch this path.

`askJudge` called `generateText` with `Output.object` and `maxOutputTokens: 800`. Reasoning tokens count against that cap, so gpt-5.5 can finish `length` with empty JSON. Accessing `result.output` then throws `AI_NoOutputGeneratedError`. Retry used the same cap, so it could not recover. Any finite cap has the same failure mode.

We only noticed because that error escaped as a 500. After wrapping as `SokoBotJudgeFailure`, the same miss became a 404 (not reported) or a swallowed `console.error` on per-turn quality.

## Change

- Drop `maxOutputTokens` on the judge call. The verdict schema bounds the JSON; `JUDGE_TIMEOUT_MS` (90s) bounds the call.
- Lab: `SokoBotJudgeFailure` is 502 (Sentry reports ≥500). Turn not found / unknown scenario stay 404.
- Background `judgeTurnQuality`: `Sentry.captureException` with `soko_bot_turn_judge_failed`, then record spend.

## Verification

```
pnpm --filter core test src/services/soko-bot-lab-judge.service.test.ts
```

Did not live-call the judge model.