### PR TITLE
fix(core): await the in-app job notification on sync

### DIFF
--- a/apps/core/src/services/job-sync-state.service.ts
+++ b/apps/core/src/services/job-sync-state.service.ts
@@ -95,16 +95,19 @@ function buildFailureNotificationData(
   };
 }
 
-function dispatchJobInAppNotification(
+async function dispatchJobInAppNotification(
   job: JobWithSokosumiStatus,
   jobStatus: SokosumiJobStatus,
-): void {
+): Promise<void> {
   const eventId = job.events.at(0)?.id;
   if (!eventId) {
     return;
   }
 
-  void dispatchJobNotification(job, jobStatus, eventId);
+  // Awaited so the sync run's waitUntil covers the notification write and its
+  // Ably publish. A detached promise is not covered, so both can be cut off
+  // when the isolate freezes.
+  await dispatchJobNotification(job, jobStatus, eventId);
 }
 
 async function dispatchFinalStatusNotification(
@@ -116,7 +119,7 @@ async function dispatchFinalStatusNotification(
     return;
   }
 
-  dispatchJobInAppNotification(job, jobStatus);
+  await dispatchJobInAppNotification(job, jobStatus);
 
   try {
     const agentName = getAgentName(job.agent);
@@ -154,7 +157,7 @@ async function dispatchInputRequiredNotification(
     return;
   }
 
-  dispatchJobInAppNotification(job, SokosumiJobStatus.INPUT_REQUIRED);
+  await dispatchJobInAppNotification(job, SokosumiJobStatus.INPUT_REQUIRED);
 
   try {
     const agentName = getAgentName(job.agent);
@@ -187,7 +190,7 @@ async function dispatchJobFailureNotification(
   job: JobWithSokosumiStatus,
   enqueueEmail: (input: SendEmailInput) => void,
 ): Promise<void> {
-  dispatchJobInAppNotification(job, job.status);
+  await dispatchJobInAppNotification(job, job.status);
 
   try {
     const notificationData = buildFailureNotificationData(job);

--- a/apps/core/src/services/job-sync.service.test.ts
+++ b/apps/core/src/services/job-sync.service.test.ts
@@ -2672,6 +2672,68 @@ describe("jobSyncService.syncUnfinishedJobs", () => {
     );
   });
 
+  it("awaits the in-app notification so sync waitUntil covers it", async () => {
+    const notificationGate = Promise.withResolvers<void>();
+    const notificationStarted = Promise.withResolvers<void>();
+
+    const completedJob = createJob({
+      status: SokosumiJobStatus.COMPLETED,
+      jobStatusSettled: true,
+      events: [
+        createJobEvent({
+          id: "event_2",
+          status: AgentJobStatus.COMPLETED,
+          result: "done",
+          statusHash: "new-hash",
+        }),
+      ],
+    });
+
+    mockInitialJobQueries({ unfinished: [createJob()] });
+    fetchAgentJobStatusMock.mockReturnValue(
+      ok({
+        status: "completed",
+        result: "done",
+        input_schema: null,
+        statusHash: "new-hash",
+      }),
+    );
+    getJobByIdMock.mockResolvedValueOnce(completedJob);
+    createNotificationMock.mockImplementation(async () => {
+      notificationStarted.resolve();
+      await notificationGate.promise;
+      return { notification: { id: "notification_1" }, created: true };
+    });
+
+    const syncPromise = jobSyncService.syncUnfinishedJobs(
+      createExecutionOptions(),
+    );
+    let syncSettled = false;
+    // Both handlers: a rejection is still a settle, and a bare `.then` here
+    // would float the very kind of promise this test exists to forbid.
+    void syncPromise.then(
+      () => {
+        syncSettled = true;
+      },
+      () => {
+        syncSettled = true;
+      },
+    );
+
+    await notificationStarted.promise;
+    // A detached notification lets the rest of the run settle while the write
+    // is still in flight. Flush that work before asserting coverage.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(syncSettled).toBe(false);
+
+    notificationGate.resolve();
+    await expect(syncPromise).resolves.toEqual(
+      expect.objectContaining({ processed: 1 }),
+    );
+    expect(syncSettled).toBe(true);
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
   it("flushes pending status emails in one sendEmails batch call", async () => {
     const completedById = new Map([
       [


### PR DESCRIPTION
## Summary

`dispatchJobInAppNotification` detached `dispatchJobNotification` with `void`, so the `notification.create` write and its Ably publish escaped the promise `handleSyncRequest` hands to `waitUntil`. A detached promise is not covered by that wrapper, so a frozen isolate can cut both off.

This is a mechanism argument, not an incident report. NOT DETERMINED whether any such loss is recorded in Sentry: this work had no Sentry access, so its absence was never checked and must not be read as evidence either way. INFERRED, not measured: such a loss would not be — the `try`/`catch` that would report it lives inside the promise that never resumes.

Found while reviewing #4117, which fixed the same defect class in the same function chain (`finalizeJobSyncResult`). Different failure mode: `link.upsert` uses `event: { connect }`, so it is a nested write and Sentry saw it as `25P03`. `notification.create` is flat, so it leaves no trace.

## Change

Await the dispatch. One source file, `apps/core/src/services/job-sync-state.service.ts`, plus the new test in `apps/core/src/services/job-sync.service.test.ts`.

- `dispatchJobInAppNotification` becomes `async`.
- The three callers (`dispatchFinalStatusNotification`, `dispatchInputRequiredNotification`, `dispatchJobFailureNotification`) await it. All three are already awaited by `finalizeJobSyncResult`.

`dispatchJobNotification` wraps its whole body in `try`/`catch` with `Sentry.captureException`. Its only statement outside the `try` is the `notificationsOptIn` guard, so awaiting it cannot make the sync fail. It also aligns this call site with every other `createNotification` caller in Core, all of which already await.

The new `await` does not hold a Prisma transaction open. Two of the three `finalizeJobSyncResult` call sites, `job-sync-state.service.ts:432` and `:501`, run after an awaited `prisma.$transaction` has resolved into a local. The third, `job-sync.service.ts:294`, sits in `backfillJobPurchase` (`:195-303`), which opens no transaction. So the awaited publish is never inside one.

Two corrections to earlier revisions of this paragraph. It cited `:429` and `:498`, which are those call sites' positions on `main`, before the three-line comment this PR adds shifts them. It then said `job-sync.service.ts` "contains no `$transaction` at all", which is false: `:440` opens one, inside `syncRefundReconciliationJob` (`:426-445`), a different function from the one holding `:294`.

## Verification

Local, Node 24.14.0, `pnpm --filter @sokosumi/core test src/services/job-sync.service.test.ts`, rerun after rebasing onto `main` post-#4117:

- Green with the fix: `Tests 63 passed (63)`, exit 0.
- Red without it: restored `void dispatchJobNotification(...)`, kept the test, reran. `Tests 1 failed | 62 passed (63)`, exit 1, `AssertionError: expected true to be false`. Non-zero collected count, so this is a real red.
- `pnpm check`: exit 0. `pnpm typecheck`: `19 successful, 19 total`, exit 0. The task count belongs to the turbo `typecheck` run; `biome check` reports a file count instead.

## Reviewed, and what was accepted rather than fixed

Six adversarial review passes ran on this branch. The items below were raised across them and are recorded rather than silently dropped.

1. **Ably latency now sits on the sync's critical path (accepted).** `createNotification` awaits `publishNotificationCreated`. For a `JOB` notification that is an Ably REST publish and nothing else: `publishNotificationCreated` first calls `shouldPushNotification`, which returns `false` before its `prisma.user.findUnique` for any kind other than `CHAT` (`helpers/notifications.ts:44-49`), so this path adds no database round trip. `apps/core/src/lib/ably/client.ts` passes only `key`, so `ably@2.28.0` defaults apply: `httpRequestTimeout: 1e4` and `httpMaxRetryDuration: 15e3`, giving ~10s per request and ~25s across fallback hosts. `runSyncPhase` only checks `shouldStopSync` at slot entry, so nothing cancels work already in flight. On a degraded Ably this roughly doubles the worst-case publish time for notification-eligible jobs, making a run more likely to overshoot its deadline and lose its lock. Amplification of an existing shape, not a new one: `publishJobStatusData` is already awaited per job. For scale, the run deadline is 275s by schema default and 95s under `.env.example`. Bounding it needs either an Ably client timeout or the run's `abortSignal` threaded through, both outside this diff. Raised separately.
2. **Everything after the dispatch is serialized behind it (accepted).** In all three dispatchers the email render and `enqueueEmail` now run after the notification, and in `dispatchJobFailureNotification` so does `void postWebhook(...)`. No data is affected: `syncUnfinishedJobs` flushes `pendingEmails` in a `finally`, so a delayed enqueue still ships in the same run. The outbound failure alert is delayed by the notification's latency.
3. **Only the `COMPLETED` call site is gated by the new test (accepted).** `INPUT_REQUIRED` and `FAILED`/`PAYMENT_FAILED` route through the same `dispatchJobInAppNotification` funnel and are not separately gated. The new test is 61 lines (`job-sync.service.test.ts:2675-2735`); two more near-identical copies of it would be copy-paste, and the funnel is one function with one `await`.
4. **The `setTimeout(0)` flush is a repo-wide pattern with a latent edge (accepted).** It gates the invariant only while every step after the dispatch stays microtask-only, which was verified to hold today. A correction to an earlier revision of this description, which claimed both sibling `waitUntil`-coverage tests use this shape: only one does. `awaits source import enqueue so sync waitUntil covers link upserts` flushes with `setTimeout(resolve, 0)` (`job-sync.service.test.ts:2661`); `awaits Resend batch flush so sync waitUntil covers delivery` flushes with `await Promise.resolve()` (`:2607`), a microtask. An earlier revision also miscounted the precedent. Within `apps/core` the macrotask shape appears 6 times across 4 test files, and one of those is this PR's own new test, so the pre-existing Core precedent is 5 across 4 files (`lib/auth.test.ts:2703` and `:2810`, `routes/sync/index.test.ts:145`, `services/job-sync.service.test.ts:2661`, `services/source-import-sync.service.test.ts:116`). The 8-across-6 figure was repo-wide, counting one file in `apps/web` and one in `packages/ai-provider`. It is still an established pattern, but it has one precedent in this file, not two.
5. **`void postWebhook(...)` at `job-sync-state.service.ts:201` is the same escape and is left alone.** A frozen isolate drops a job-failure webhook and the `Sentry.captureMessage` reporter attached to its `.then` never runs. An earlier revision of this item went on to discuss whether an unhandled rejection there would be fatal, and what `SENTRY_DSN` changes about that. None of it applies: the chain ends in `.catch(() => {})` at `:218-220`, so nothing escapes it. The only loss is the dropped webhook and its missing report. Out of scope here; raised separately.
6. **`dispatchJobInAppNotification` is now a pure pass-through (accepted).** With `void` gone, its only work is the `job.events.at(0)?.id` guard, which `dispatchJobNotification` could absorb. Folding it would widen this diff past the fix.

Fixed in response to review, in the code: the comment no longer states the isolate freeze as an observed incident, the test's floating `.then` handles both settle paths, and its seeding matches its sibling.

Fixed in this description, each corrected in place above rather than overwritten: the `:429`/`:498` line numbers; the claim that `job-sync.service.ts` holds no `$transaction`; the claim that both sibling tests use the `setTimeout(0)` flush; the macrotask precedent count; the unhandled-rejection discussion on `void postWebhook`; and `publishNotificationCreated` described as an unconditional Ably publish. Every one of those was a description defect, not a code defect. The code has been unchanged since the third pass.

The new test is a real gate, proved with three separate mutations (full source revert; dropping only the three call-site `await`s; detaching only the inner call), each red at `Tests 1 failed | 62 passed (63)` with `AssertionError: expected true to be false`.




