### PR TITLE
fix(core): warn instead of page on a stale readiness check

### DIFF
--- a/apps/core/src/helpers/agent.ts
+++ b/apps/core/src/helpers/agent.ts
@@ -240,8 +240,10 @@ const CARDANO_POLICY_ID_PATTERN = /^[0-9a-f]{56}$/;
 
 /**
  * Exact Cardano V2 policy/contract sources the payment node last reported
- * purchase-ready. Returns an empty list only when readiness has never been
- * recorded, or the recorded payload is unusable.
+ * purchase-ready. Returns an empty list when readiness has never been
+ * recorded, when the recorded payload is unusable, and when the node last
+ * reported nothing purchase-ready. Callers cannot tell those apart from the
+ * result, and all three hide the entire V2 catalogue.
  *
  * Deliberately NOT expired on age. Readiness is static configuration — the
  * node derives it from config presence (an active source, a current contract,

--- a/apps/core/src/services/agent-sync.readiness.ts
+++ b/apps/core/src/services/agent-sync.readiness.ts
@@ -14,9 +14,11 @@ import prisma from "@/lib/db/prisma";
  *
  * On check failure the last known value is kept and a marker is written, so
  * readers keep serving it rather than losing the V2 catalog to an outage of
- * our own polling. That graceful degradation only exists once a value HAS been
- * recorded — before then there is nothing to fall back on and the whole V2
- * catalogue is hidden, which is why the two cases alert differently.
+ * our own polling. That degradation is only graceful while the last known
+ * value is a USABLE one. A recorded empty set hides the whole V2 catalogue as
+ * completely as no recording at all, which is why the alert below takes its
+ * SEVERITY from what readers are served. How OFTEN it may fire is a separate
+ * question, and that one still turns on whether a row exists at all.
  *
  * Returns whether the purchase-ready source set CHANGED, which is what makes
  * the caller replay the registry — and, since a change from "nothing recorded"
@@ -36,11 +38,11 @@ export async function syncCardanoV2RailReadiness(
       readinessResult.error,
     );
     try {
-      // Is a usable fallback actually being served? The two cases degrade
-      // completely differently and must not share one alert.
+      // HOW BAD is it? Is a usable fallback actually being served? The two
+      // cases degrade completely differently and must not share one alert.
       //
-      // Ask the question readers ask. Row EXISTENCE is a different question
-      // and answering that one gets it wrong: the success path upserts
+      // Ask the question readers ask. Row EXISTENCE answers a different
+      // question and answers this one wrong: the success path upserts
       // whatever it got, so a tick where the node reported nothing ready
       // leaves a row holding "[]". That row hides the catalogue exactly as
       // completely as no row at all, and calling it "warm" would downgrade a
@@ -56,6 +58,18 @@ export async function syncCardanoV2RailReadiness(
       const isCatalogueHidden =
         (await getCardanoV2ReadySources(prisma)).length === 0;
 
+      // HOW OFTEN may it page is a separate question, and row existence is
+      // the right answer to THIS one. A catalogue that was recorded and then
+      // went empty already paged when it went empty, on the success path
+      // below. Bypassing the latch for it as well would page every five
+      // minutes for the length of an outage, which is the noise this change
+      // exists to cut, not add to.
+      const recordedReadiness = await prisma.syncMetadata.findUnique({
+        where: { key: CARDANO_V2_RAIL_READINESS_KEY },
+        select: { key: true },
+      });
+      const hasNeverBeenRecorded = !recordedReadiness;
+
       // createMany + skipDuplicates is an atomic cross-instance latch:
       // exactly one serverless worker creates the marker and reports the
       // failure; later workers see count=0 until a successful check clears it.
@@ -69,12 +83,12 @@ export async function syncCardanoV2RailReadiness(
         ],
         skipDuplicates: true,
       });
-      // The latch is deliberately bypassed while the catalogue is hidden:
-      // silence would otherwise be indistinguishable from a healthy deployment
-      // that simply has no V2 agents, and the single page that the latch does
-      // allow is spent on the first tick — minutes after deploy, long before
-      // anyone looks.
-      if (marker.count > 0 || isCatalogueHidden) {
+      // The latch is deliberately bypassed while readiness has never been
+      // recorded: silence would otherwise be indistinguishable from a healthy
+      // deployment that simply has no V2 agents, and the single page that the
+      // latch does allow is spent on the first tick — minutes after deploy,
+      // long before anyone looks.
+      if (marker.count > 0 || hasNeverBeenRecorded) {
         Sentry.captureException(
           new Error(
             isCatalogueHidden

--- a/apps/core/src/services/agent-sync.readiness.ts
+++ b/apps/core/src/services/agent-sync.readiness.ts
@@ -9,6 +9,32 @@ import {
 import prisma from "@/lib/db/prisma";
 
 /**
+ * Marker states. The row exists for the length of one failure streak and a
+ * successful check deletes it, so these are the streak's own states, not the
+ * rail's. "failed" is what a fresh streak writes; the escalation flips it so
+ * exactly one worker can report the streak outliving the threshold below.
+ */
+const READINESS_FAILURE_NEW = "failed";
+const READINESS_FAILURE_ESCALATED = "escalated";
+
+/**
+ * How long a failure streak may run before it stops being a blip.
+ *
+ * The first tick of a streak alerts and the latch then goes quiet, so a
+ * lasting outage does not page every five minutes. That silence is right for
+ * minutes and wrong for hours. Readiness has no age expiry on purpose, so a
+ * V2 catalogue that is already enabled STAYS enabled through the whole
+ * outage: agents keep being listed and priced from the last recorded sources
+ * while every purchase against them fails at the node. Six ticks is where
+ * that stops looking like a blip.
+ *
+ * Deliberately not shorter. The point of this branch is to stop paging for a
+ * single timed-out attempt, and a threshold inside one or two ticks would put
+ * that page straight back.
+ */
+const READINESS_FAILURE_ESCALATION_MS = 30 * 60 * 1000;
+
+/**
  * Refreshes the recorded Cardano V2 rail readiness of the payment node (read
  * by getCardanoV2ReadySources).
  *
@@ -77,23 +103,55 @@ export async function syncCardanoV2RailReadiness(
         data: [
           {
             key: CARDANO_V2_RAIL_READINESS_FAILURE_KEY,
-            cursorId: "failed",
+            cursorId: READINESS_FAILURE_NEW,
             lastSyncedAt: new Date(),
           },
         ],
         skipDuplicates: true,
       });
+      // HOW LONG has it been failing is the third question, and the marker
+      // row already answers it: skipDuplicates never touches an existing row,
+      // so lastSyncedAt still holds the moment the streak started.
+      //
+      // The latch's silence is right for a blip and wrong for an outage.
+      // Nothing expires the recorded readiness, so an enabled V2 catalogue
+      // stays enabled for the whole outage and keeps selling agents that
+      // cannot be paid for. A streak that outlives the threshold earns one
+      // more alert, and that one is an error whatever the catalogue looks
+      // like, because purchases have been failing for half an hour.
+      //
+      // Same atomic latch trick as the insert above: exactly one worker wins
+      // the conditional update and reports; the rest see count=0. The state
+      // lives in the row, so the escalation fires once per streak rather than
+      // once per tick, and a successful check deletes the row and re-arms it.
+      const escalation =
+        marker.count > 0
+          ? { count: 0 }
+          : await prisma.syncMetadata.updateMany({
+              where: {
+                key: CARDANO_V2_RAIL_READINESS_FAILURE_KEY,
+                cursorId: READINESS_FAILURE_NEW,
+                lastSyncedAt: {
+                  lt: new Date(Date.now() - READINESS_FAILURE_ESCALATION_MS),
+                },
+              },
+              data: { cursorId: READINESS_FAILURE_ESCALATED },
+            });
+      const isStreakSustained = escalation.count > 0;
+
       // The latch is deliberately bypassed while readiness has never been
       // recorded: silence would otherwise be indistinguishable from a healthy
       // deployment that simply has no V2 agents, and the single page that the
       // latch does allow is spent on the first tick — minutes after deploy,
       // long before anyone looks.
-      if (marker.count > 0 || hasNeverBeenRecorded) {
+      if (marker.count > 0 || hasNeverBeenRecorded || isStreakSustained) {
         Sentry.captureException(
           new Error(
             isCatalogueHidden
               ? `Cardano V2 rail readiness has no usable value; the entire V2 catalogue is hidden. Last error: ${readinessResult.error}`
-              : `Cardano V2 rail readiness check failed: ${readinessResult.error}`,
+              : isStreakSustained
+                ? `Cardano V2 rail readiness has failed for over ${READINESS_FAILURE_ESCALATION_MS / 60_000}m; V2 agents are still listed from the last recorded sources, so purchases against them keep failing. Last error: ${readinessResult.error}`
+                : `Cardano V2 rail readiness check failed: ${readinessResult.error}`,
           ),
           {
             // Severity follows the user-visible impact, not the check result.
@@ -102,11 +160,17 @@ export async function syncCardanoV2RailReadiness(
             // sources, the next cron tick is five minutes out, and the usual
             // cause is one timed-out attempt that costs nothing anybody can
             // see. Paging for that teaches people to skip the alert, which is
-            // how the hidden case gets missed too. It stays reported, so a
-            // lasting outage is still visible in the same place.
-            level: isCatalogueHidden ? "error" : "warning",
+            // how the hidden case gets missed too. A stale streak that has
+            // outlived the threshold is no longer that case: it is an outage
+            // that has been running for half an hour, so it takes the error
+            // level back.
+            level: isCatalogueHidden || isStreakSustained ? "error" : "warning",
             tags: {
-              cardano_v2_readiness: isCatalogueHidden ? "hidden" : "stale",
+              cardano_v2_readiness: isCatalogueHidden
+                ? "hidden"
+                : isStreakSustained
+                  ? "stale_sustained"
+                  : "stale",
             },
           },
         );

--- a/apps/core/src/services/agent-sync.readiness.ts
+++ b/apps/core/src/services/agent-sync.readiness.ts
@@ -79,6 +79,15 @@ export async function syncCardanoV2RailReadiness(
               : `Cardano V2 rail readiness check failed: ${readinessResult.error}`,
           ),
           {
+            // Severity follows the user-visible impact, not the check result.
+            // Cold IS the outage: the whole V2 catalogue is hidden right now.
+            // Warm is not. Readers keep serving the last recorded value, the
+            // next cron tick is five minutes out, and the usual cause is one
+            // 10s timeout that costs nothing anybody can see. Paging for that
+            // teaches people to skip the alert, which is how the cold case
+            // gets missed too. It stays reported, so a lasting outage is
+            // still visible in the same place.
+            level: hasNeverBeenRecorded ? "error" : "warning",
             tags: {
               cardano_v2_readiness: hasNeverBeenRecorded
                 ? "never_recorded"

--- a/apps/core/src/services/agent-sync.readiness.ts
+++ b/apps/core/src/services/agent-sync.readiness.ts
@@ -4,6 +4,7 @@ import { paymentClient } from "@/clients/masumi-payment.client";
 import {
   CARDANO_V2_RAIL_READINESS_FAILURE_KEY,
   CARDANO_V2_RAIL_READINESS_KEY,
+  getCardanoV2ReadySources,
 } from "@/helpers/agent";
 import prisma from "@/lib/db/prisma";
 
@@ -35,23 +36,25 @@ export async function syncCardanoV2RailReadiness(
       readinessResult.error,
     );
     try {
-      // Has readiness EVER been recorded? The two cases degrade completely
-      // differently and must not share one alert.
+      // Is a usable fallback actually being served? The two cases degrade
+      // completely differently and must not share one alert.
       //
-      // Warm (a row exists): readers keep serving the last known value, so a
-      // failed check costs nothing user-visible. One page is right — repeating
-      // it for the length of an outage would be noise.
+      // Ask the question readers ask. Row EXISTENCE is a different question
+      // and answering that one gets it wrong: the success path upserts
+      // whatever it got, so a tick where the node reported nothing ready
+      // leaves a row holding "[]". That row hides the catalogue exactly as
+      // completely as no row at all, and calling it "warm" would downgrade a
+      // live outage to a warning and then latch it into silence.
       //
-      // Cold (no row): getCardanoV2ReadySources cannot tell "never recorded"
-      // from "nothing ready" and returns [], which hides the ENTIRE V2
-      // catalogue and 422s every V2 task payment. That is an outage, and it is
-      // the state a fresh environment or a deploy landing before the node
-      // serves /rail-readiness starts in.
-      const recordedReadiness = await prisma.syncMetadata.findUnique({
-        where: { key: CARDANO_V2_RAIL_READINESS_KEY },
-        select: { key: true },
-      });
-      const hasNeverBeenRecorded = !recordedReadiness;
+      // Hidden (no usable source): every V2 agent is unlistable and every V2
+      // task payment 422s. That is an outage, and it is the state a fresh
+      // environment, a deploy landing before the node serves /rail-readiness,
+      // and a node reporting nothing purchase-ready all share.
+      //
+      // Stale (sources are being served): readers keep serving the last known
+      // value, so a failed check costs nothing user-visible.
+      const isCatalogueHidden =
+        (await getCardanoV2ReadySources(prisma)).length === 0;
 
       // createMany + skipDuplicates is an atomic cross-instance latch:
       // exactly one serverless worker creates the marker and reports the
@@ -66,32 +69,30 @@ export async function syncCardanoV2RailReadiness(
         ],
         skipDuplicates: true,
       });
-      // The latch is deliberately bypassed while readiness has never been
-      // recorded: silence would otherwise be indistinguishable from a healthy
-      // deployment that simply has no V2 agents, and the single page that the
-      // latch does allow is spent on the first tick — minutes after deploy,
-      // long before anyone looks.
-      if (marker.count > 0 || hasNeverBeenRecorded) {
+      // The latch is deliberately bypassed while the catalogue is hidden:
+      // silence would otherwise be indistinguishable from a healthy deployment
+      // that simply has no V2 agents, and the single page that the latch does
+      // allow is spent on the first tick — minutes after deploy, long before
+      // anyone looks.
+      if (marker.count > 0 || isCatalogueHidden) {
         Sentry.captureException(
           new Error(
-            hasNeverBeenRecorded
-              ? `Cardano V2 rail readiness has never been recorded; the entire V2 catalogue is hidden. Last error: ${readinessResult.error}`
+            isCatalogueHidden
+              ? `Cardano V2 rail readiness has no usable value; the entire V2 catalogue is hidden. Last error: ${readinessResult.error}`
               : `Cardano V2 rail readiness check failed: ${readinessResult.error}`,
           ),
           {
             // Severity follows the user-visible impact, not the check result.
-            // Cold IS the outage: the whole V2 catalogue is hidden right now.
-            // Warm is not. Readers keep serving the last recorded value, the
-            // next cron tick is five minutes out, and the usual cause is one
-            // 10s timeout that costs nothing anybody can see. Paging for that
-            // teaches people to skip the alert, which is how the cold case
-            // gets missed too. It stays reported, so a lasting outage is
-            // still visible in the same place.
-            level: hasNeverBeenRecorded ? "error" : "warning",
+            // Hidden IS the outage: no V2 agent can be listed or paid right
+            // now. Stale is not. Readers keep serving the last recorded
+            // sources, the next cron tick is five minutes out, and the usual
+            // cause is one timed-out attempt that costs nothing anybody can
+            // see. Paging for that teaches people to skip the alert, which is
+            // how the hidden case gets missed too. It stays reported, so a
+            // lasting outage is still visible in the same place.
+            level: isCatalogueHidden ? "error" : "warning",
             tags: {
-              cardano_v2_readiness: hasNeverBeenRecorded
-                ? "never_recorded"
-                : "stale",
+              cardano_v2_readiness: isCatalogueHidden ? "hidden" : "stale",
             },
           },
         );

--- a/apps/core/src/services/agent-sync.service.test.ts
+++ b/apps/core/src/services/agent-sync.service.test.ts
@@ -40,6 +40,7 @@ const {
   syncMetadataDeleteManyMock,
   syncMetadataCreateManyMock,
   syncMetadataFindUniqueMock,
+  syncMetadataUpdateManyMock,
   syncMetadataUpsertMock,
   tagUpsertMock,
   transactionMock,
@@ -75,6 +76,7 @@ const {
   syncMetadataDeleteManyMock: vi.fn(),
   syncMetadataCreateManyMock: vi.fn(),
   syncMetadataFindUniqueMock: vi.fn(),
+  syncMetadataUpdateManyMock: vi.fn(),
   syncMetadataUpsertMock: vi.fn(),
   tagUpsertMock: vi.fn(),
   transactionMock: vi.fn(),
@@ -147,6 +149,7 @@ vi.mock("@/lib/db/prisma", () => ({
       createMany: syncMetadataCreateManyMock,
       deleteMany: syncMetadataDeleteManyMock,
       findUnique: syncMetadataFindUniqueMock,
+      updateMany: syncMetadataUpdateManyMock,
       upsert: syncMetadataUpsertMock,
     },
     $transaction: transactionMock,
@@ -3119,6 +3122,7 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
     syncMetadataCreateManyMock.mockResolvedValue({ count: 1 });
     syncMetadataDeleteManyMock.mockResolvedValue({ count: 0 });
     syncMetadataFindUniqueMock.mockResolvedValue(null);
+    syncMetadataUpdateManyMock.mockResolvedValue({ count: 0 });
     syncMetadataUpsertMock.mockResolvedValue(undefined);
   });
 
@@ -3418,6 +3422,157 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
       expect.objectContaining({
         level: "error",
         tags: { cardano_v2_readiness: "hidden" },
+      }),
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("escalates a stale streak to an error once it outlives the threshold", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const agentSyncService = await getAgentSyncService();
+
+    // Sources are recorded and still served, so every tick of this streak is
+    // a "stale" warning and the latch silences all but the first. Nothing
+    // expires the recorded value, so V2 agents stay listed and priced the
+    // whole time while every purchase against them fails at the node. Half an
+    // hour of that is an outage, not a blip.
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      key: CARDANO_V2_RAIL_READINESS_KEY,
+      cursorId: JSON.stringify(readySources),
+      lastSyncedAt: new Date("2026-02-24T00:00:00.000Z"),
+    });
+    getCardanoV2RailReadinessMock.mockResolvedValue(
+      err("payment node unavailable"),
+    );
+    // The latch is held by an earlier tick, and the conditional update wins.
+    syncMetadataCreateManyMock.mockResolvedValue({ count: 0 });
+    syncMetadataUpdateManyMock.mockResolvedValue({ count: 1 });
+
+    await agentSyncService.syncCardanoV2RailReadiness();
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("has failed for over 30m"),
+      }),
+      expect.objectContaining({
+        level: "error",
+        tags: { cardano_v2_readiness: "stale_sustained" },
+      }),
+    );
+
+    // Only a streak that has actually run long may escalate, and only from
+    // the un-escalated state. Without both, the first tick of every streak
+    // would escalate itself and the threshold would mean nothing.
+    expect(syncMetadataUpdateManyMock).toHaveBeenCalledWith({
+      where: {
+        key: "cardano-v2-rail-readiness-failure",
+        cursorId: "failed",
+        lastSyncedAt: { lt: expect.any(Date) },
+      },
+      data: { cursorId: "escalated" },
+    });
+    const where = syncMetadataUpdateManyMock.mock.calls[0]?.[0]?.where as {
+      lastSyncedAt: { lt: Date };
+    };
+    expect(Date.now() - where.lastSyncedAt.lt.getTime()).toBeGreaterThanOrEqual(
+      30 * 60 * 1000,
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("stays quiet while a stale streak is still short", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const agentSyncService = await getAgentSyncService();
+
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      key: CARDANO_V2_RAIL_READINESS_KEY,
+      cursorId: JSON.stringify(readySources),
+      lastSyncedAt: new Date("2026-02-24T00:00:00.000Z"),
+    });
+    getCardanoV2RailReadinessMock.mockResolvedValue(
+      err("payment node unavailable"),
+    );
+    // Latch held, and the marker is younger than the threshold, so the
+    // conditional update matches nothing.
+    syncMetadataCreateManyMock.mockResolvedValue({ count: 0 });
+    syncMetadataUpdateManyMock.mockResolvedValue({ count: 0 });
+
+    await agentSyncService.syncCardanoV2RailReadiness();
+
+    // One timed-out attempt inside a five-minute cron must stay silent. That
+    // silence is the whole point of this branch, and the escalation above
+    // must not undo it.
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("escalates once per streak, not once per tick", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const agentSyncService = await getAgentSyncService();
+
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      key: CARDANO_V2_RAIL_READINESS_KEY,
+      cursorId: JSON.stringify(readySources),
+      lastSyncedAt: new Date("2026-02-24T00:00:00.000Z"),
+    });
+    getCardanoV2RailReadinessMock.mockResolvedValue(
+      err("payment node unavailable"),
+    );
+    syncMetadataCreateManyMock.mockResolvedValue({ count: 0 });
+    syncMetadataUpdateManyMock.mockResolvedValue({ count: 1 });
+
+    await agentSyncService.syncCardanoV2RailReadiness();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+
+    // The row now reads "escalated", so the same conditional update matches
+    // nothing on every later tick. Without that state in the row this would
+    // page every five minutes for the rest of the outage, which is exactly
+    // the alarm flood the latch exists to prevent.
+    syncMetadataUpdateManyMock.mockResolvedValue({ count: 0 });
+    await agentSyncService.syncCardanoV2RailReadiness();
+    await agentSyncService.syncCardanoV2RailReadiness();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("does not try to escalate on the tick that starts the streak", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const agentSyncService = await getAgentSyncService();
+
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      key: CARDANO_V2_RAIL_READINESS_KEY,
+      cursorId: JSON.stringify(readySources),
+      lastSyncedAt: new Date("2026-02-24T00:00:00.000Z"),
+    });
+    getCardanoV2RailReadinessMock.mockResolvedValue(
+      err("payment node unavailable"),
+    );
+    // count > 0 means this worker just wrote the marker, so the streak is
+    // seconds old. Reading it back to ask whether it is half an hour old is
+    // a wasted round trip on a path that already alerts.
+    syncMetadataCreateManyMock.mockResolvedValue({ count: 1 });
+
+    await agentSyncService.syncCardanoV2RailReadiness();
+
+    expect(syncMetadataUpdateManyMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        level: "warning",
+        tags: { cardano_v2_readiness: "stale" },
       }),
     );
 

--- a/apps/core/src/services/agent-sync.service.test.ts
+++ b/apps/core/src/services/agent-sync.service.test.ts
@@ -3193,6 +3193,24 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
         update: expect.objectContaining({ cursorId: "[]" }),
       }),
     );
+    // This page is load-bearing for the failure path's latch: a recorded "[]"
+    // is left latched there precisely BECAUSE going empty already paged here.
+    // Delete this and the two together go silent for a whole outage.
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      "Cardano V2 rail reports no purchase-ready source; all V2 agents are hidden",
+      "error",
+    );
+
+    // On the transition only. A catalogue that was already empty must not
+    // page again every five minutes for as long as it stays empty.
+    captureMessageMock.mockClear();
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      key: CARDANO_V2_RAIL_READINESS_KEY,
+      cursorId: "[]",
+      lastSyncedAt: new Date("2026-02-24T00:00:00.000Z"),
+    });
+    await agentSyncService.syncCardanoV2RailReadiness();
+    expect(captureMessageMock).not.toHaveBeenCalled();
 
     consoleWarnSpy.mockRestore();
   });
@@ -3386,11 +3404,22 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
       }),
     );
 
-    // The latch is now held by the earlier insert, so a stale failure would go
-    // quiet here. A hidden catalogue must page anyway.
+    // The latch is now held by the earlier insert, so any other failure would
+    // go quiet here. A catalogue that has never been recorded must page
+    // anyway: it produced no page of its own to fall back on, and silence is
+    // indistinguishable from a healthy deployment with no V2 agents.
     syncMetadataCreateManyMock.mockResolvedValue({ count: 0 });
     await agentSyncService.syncCardanoV2RailReadiness();
     expect(captureExceptionMock).toHaveBeenCalledTimes(2);
+    // Sustained error-level paging IS the bypass. A repeat that quietly
+    // dropped to a warning would satisfy the count above and defeat it.
+    expect(captureExceptionMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        level: "error",
+        tags: { cardano_v2_readiness: "hidden" },
+      }),
+    );
 
     consoleWarnSpy.mockRestore();
   });
@@ -3404,9 +3433,9 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
     // A tick where the node reported nothing purchase-ready still upserts a
     // row, holding "[]". Row EXISTENCE therefore says "warm" while readers
     // see exactly the cold outage: getCardanoV2ReadySources returns [], no V2
-    // agent is listable, every V2 payment 422s. Gating on row existence would
-    // downgrade this to a warning and then latch it into silence for the
-    // whole outage, which is strictly worse than what it replaced.
+    // agent is listable, every V2 payment 422s. Gating the SEVERITY on row
+    // existence would call that "warm" and downgrade a live outage to a
+    // warning.
     syncMetadataFindUniqueMock.mockResolvedValue({
       key: CARDANO_V2_RAIL_READINESS_KEY,
       cursorId: "[]",
@@ -3428,10 +3457,14 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
       }),
     );
 
-    // And it must keep paging through the streak, exactly like a missing row.
+    // The severity is where this case differs, and only the severity. The
+    // latch still holds it to one page per streak, because the catalogue
+    // going empty already paged on the success path that recorded it.
+    // Bypassing the latch here too would page every five minutes for the
+    // length of the outage, which is noise this change exists to cut.
     syncMetadataCreateManyMock.mockResolvedValue({ count: 0 });
     await agentSyncService.syncCardanoV2RailReadiness();
-    expect(captureExceptionMock).toHaveBeenCalledTimes(2);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
 
     consoleWarnSpy.mockRestore();
   });

--- a/apps/core/src/services/agent-sync.service.test.ts
+++ b/apps/core/src/services/agent-sync.service.test.ts
@@ -3340,7 +3340,12 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
         message:
           "Cardano V2 rail readiness check failed: payment node unavailable",
       }),
-      expect.objectContaining({ tags: { cardano_v2_readiness: "stale" } }),
+      expect.objectContaining({
+        // Warm failures are a warning, not a page: the last recorded value is
+        // still being served, so nothing user-visible has degraded.
+        level: "warning",
+        tags: { cardano_v2_readiness: "stale" },
+      }),
     );
 
     // A different process loses the atomic insert race and also dedupes.
@@ -3375,6 +3380,8 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
         message: expect.stringContaining("has never been recorded"),
       }),
       expect.objectContaining({
+        // Cold IS the outage, so it keeps the error level.
+        level: "error",
         tags: { cardano_v2_readiness: "never_recorded" },
       }),
     );

--- a/apps/core/src/services/agent-sync.service.test.ts
+++ b/apps/core/src/services/agent-sync.service.test.ts
@@ -3356,7 +3356,7 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it("keeps paging while readiness has never been recorded", async () => {
+  it("keeps paging while no readiness row has ever been written", async () => {
     const consoleWarnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
@@ -3365,7 +3365,7 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
     // Cold start: no readiness row has ever been written, so
     // getCardanoV2ReadySources returns [] and the ENTIRE V2 catalogue is
     // hidden — every V2 agent unlistable, every V2 task payment 422. The
-    // one-shot latch is right for the warm case but would spend its single
+    // one-shot latch is right for the stale case but would spend its single
     // page minutes after deploy and then go quiet through the whole outage,
     // leaving silence indistinguishable from "no V2 agents configured".
     syncMetadataFindUniqueMock.mockResolvedValue(null);
@@ -3377,17 +3377,58 @@ describe("agentSyncService.syncCardanoV2RailReadiness", () => {
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     expect(captureExceptionMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining("has never been recorded"),
+        message: expect.stringContaining("the entire V2 catalogue is hidden"),
       }),
       expect.objectContaining({
-        // Cold IS the outage, so it keeps the error level.
+        // A hidden catalogue IS the outage, so it keeps the error level.
         level: "error",
-        tags: { cardano_v2_readiness: "never_recorded" },
+        tags: { cardano_v2_readiness: "hidden" },
       }),
     );
 
-    // The latch is now held by the earlier insert, so a warm failure would go
-    // quiet here. Never-recorded must page anyway.
+    // The latch is now held by the earlier insert, so a stale failure would go
+    // quiet here. A hidden catalogue must page anyway.
+    syncMetadataCreateManyMock.mockResolvedValue({ count: 0 });
+    await agentSyncService.syncCardanoV2RailReadiness();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(2);
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("treats a recorded empty source set as hidden, not stale", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const agentSyncService = await getAgentSyncService();
+
+    // A tick where the node reported nothing purchase-ready still upserts a
+    // row, holding "[]". Row EXISTENCE therefore says "warm" while readers
+    // see exactly the cold outage: getCardanoV2ReadySources returns [], no V2
+    // agent is listable, every V2 payment 422s. Gating on row existence would
+    // downgrade this to a warning and then latch it into silence for the
+    // whole outage, which is strictly worse than what it replaced.
+    syncMetadataFindUniqueMock.mockResolvedValue({
+      key: CARDANO_V2_RAIL_READINESS_KEY,
+      cursorId: "[]",
+      lastSyncedAt: new Date("2026-02-24T00:00:00.000Z"),
+    });
+    getCardanoV2RailReadinessMock.mockResolvedValue(
+      err("payment node unavailable"),
+    );
+
+    await agentSyncService.syncCardanoV2RailReadiness();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("the entire V2 catalogue is hidden"),
+      }),
+      expect.objectContaining({
+        level: "error",
+        tags: { cardano_v2_readiness: "hidden" },
+      }),
+    );
+
+    // And it must keep paging through the streak, exactly like a missing row.
     syncMetadataCreateManyMock.mockResolvedValue({ count: 0 });
     await agentSyncService.syncCardanoV2RailReadiness();
     expect(captureExceptionMock).toHaveBeenCalledTimes(2);

--- a/apps/core/src/services/agent-sync.x402-readiness.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.ts
@@ -135,7 +135,12 @@ function summarizeEmptyX402Readiness(
 
 /**
  * Refreshes the recorded x402 buy-side readiness of the payment node (read
- * by getX402ReadySources). Mirrors syncCardanoV2RailReadiness exactly:
+ * by getX402ReadySources). Same shape as syncCardanoV2RailReadiness, with one
+ * deliberate difference: this rail still reports a failed check at Sentry's
+ * default `error` level, while the Cardano rail drops a check that is still
+ * serving a usable value to `warning`. Aligning the two is a follow-up, not
+ * an oversight — the x402 path also carries its own preview-deploy muting,
+ * which has to be reasoned about in the same change.
  *
  * On check failure the last known value is kept and a marker is written, so
  * readers keep serving it rather than losing the x402 listing to an outage

--- a/apps/core/src/services/agent-sync.x402-readiness.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.ts
@@ -135,12 +135,21 @@ function summarizeEmptyX402Readiness(
 
 /**
  * Refreshes the recorded x402 buy-side readiness of the payment node (read
- * by getX402ReadySources). Same shape as syncCardanoV2RailReadiness, with one
- * deliberate difference: this rail still reports a failed check at Sentry's
- * default `error` level, while the Cardano rail drops a check that is still
- * serving a usable value to `warning`. Aligning the two is a follow-up, not
- * an oversight — the x402 path also carries its own preview-deploy muting,
- * which has to be reasoned about in the same change.
+ * by getX402ReadySources). Same shape as syncCardanoV2RailReadiness, and no
+ * longer the same behaviour. Three differences, none of them an oversight:
+ *
+ * 1. This rail reports every failed check at Sentry's default `error` level.
+ *    The Cardano rail drops a check that is still serving a usable value to
+ *    `warning`.
+ * 2. This rail still classifies by ROW EXISTENCE (`hasNeverBeenRecorded`
+ *    below). The Cardano rail stopped, because it is wrong: the success path
+ *    upserts whatever the node reported, so a row can exist and still hide
+ *    the whole listing. That defect is live here, in this file.
+ * 3. This rail mutes its own preview deployments. The Cardano rail does not.
+ *
+ * 3 is why 1 and 2 are not fixed here: the muting decides which environments
+ * an alert change is even observable in, so it has to be reasoned about in
+ * the same change, and that is a bigger change than this one.
  *
  * On check failure the last known value is kept and a marker is written, so
  * readers keep serving it rather than losing the x402 listing to an outage


### PR DESCRIPTION
## Summary

`/sync/agents` runs every five minutes and checks Cardano V2 rail readiness inside it. A failed check raised a Sentry **error**, even when nothing user-visible had degraded.

Severity now follows what readers are served. How often the alert may fire stays exactly where `main` had it.

**How bad is it** reads `getCardanoV2ReadySources`:

- **`hidden`** is an error. No usable source is served, so every V2 agent is unlistable and every V2 task payment 422s. That is an outage.
- **`stale`** is a warning. Sources are still served and the next tick is five minutes away. The usual cause is one timed-out attempt that costs nothing anybody can see.

**How often may it page** reads row existence. The once-per-streak latch is bypassed only when readiness has never been recorded, because that state produces no page of its own.

The two are separate on purpose, and an earlier revision of this branch got each of them wrong in turn:

- Gating the *severity* on row existence is wrong. The success path upserts whatever the node reported, so a tick reporting nothing purchase-ready leaves a row holding `"[]"`. That row hides the catalogue as completely as no row at all, and calling it warm downgrades a live outage.
- Gating the *latch* on catalogue visibility is wrong the other way. A recorded `"[]"` plus a failing node would then page at error level every five minutes, 288 times a day, which is the noise this PR exists to cut.

Precedent for `level: "warning"` is `apps/core/src/clients/webhook.client.ts:51`.

## User-facing impact

None. Alert severity only. No behaviour change, no data change, no API surface.

## Operator note: existing Sentry filters

Two things change in Sentry, so saved searches and alert rules may need an update:

- The tag value `cardano_v2_readiness: "never_recorded"` becomes `"hidden"`.
- A failing check that is still serving sources drops from `error` to `warning`.

`apps/core/src/lib/sentry.ts:28` has no level filter, so warnings are still delivered. Nothing in the repo references the old tag value. Anything that does lives in Sentry and cannot be checked from here.

## Tradeoff worth knowing: readiness never expires

`getCardanoV2ReadySources` has no age gate, and nothing anywhere reads `lastSyncedAt` for readiness freshness. That is deliberate (see its JSDoc): expiring on age would mean our own cron falling behind takes the whole V2 catalogue down.

The consequence is that **a V2 catalogue that is enabled never disables itself from an outage.** Only the node *answering* with an empty set disables it, because that is the one case the success path records. While the node is unreachable, the last recorded sources keep being served, so V2 agents stay listed and priced while every purchase against them fails at the node.

That state used to produce one alert per streak, which this PR would have made one *warning* per streak. So a streak that outlives **30 minutes** now earns one more alert, at `error` level whatever the catalogue looks like. The marker row already holds the answer: `createMany` with `skipDuplicates` never touches an existing row, so `lastSyncedAt` still carries the streak start. A conditional update from `"failed"` to `"escalated"` is the same atomic cross-instance latch as the insert, so exactly one worker reports it, it fires once per streak rather than once per tick, and a successful check deletes the row and re-arms it.

Six ticks rather than one or two, on purpose. Cutting the page for a single timed-out attempt is the point of this PR, and a shorter threshold would put that page straight back.

### Correction to an earlier version of this description

An earlier revision of this body claimed that an unreachable payment node "breaks purchases through paths that have their own alerts". That is only partly true, and the part that is false is the part that mattered:

| Node fails as | Readiness alert | `/sync/jobs` purchase-diff |
| --- | --- | --- |
| Timeout, abort, `ECONNRESET`, socket hang up | stale streak | **suppressed to a console line** |
| Proxy 502/503/504/520-524 | stale streak | **suppressed to a console line** |
| `ECONNREFUSED`, `ENOTFOUND` | stale streak | pages |
| Node answers with an error envelope | stale streak | pages |

`job-purchase-diff.service.ts:531` calls `Sentry.captureException` only when the node supplied its own error envelope. Otherwise it goes to `captureExternalServiceError`, and `shouldSuppressSentryForExternalError` (`apps/core/src/lib/external-service-errors.ts:138`) drops the first two rows on purpose, because a one-minute cron would otherwise page once a minute for the whole outage.

Those are the same failure shapes that reach the stale branch here. Without the escalation, a hanging node or one behind a restarting proxy would have produced one warning and nothing else, for hours.

## Verification

VERIFIED, run locally on Node 24.

```
pnpm --filter core test src/services/agent-sync.service.test.ts
#      Tests  83 passed (83)

pnpm --filter core test
#  Test Files  471 passed | 2 skipped (473)
#       Tests  4784 passed | 6 skipped (4790)

pnpm --filter core typecheck   # exit 0
```

Mutation check. Source reverted, tests kept, non-zero collected count each time:

```
severity back on row existence        Tests  1 failed | 78 passed (79)
latch back on catalogue visibility    Tests  1 failed | 78 passed (79)
full revert to origin/main            Tests  3 failed | 76 passed (79)
success-path page never fires         Tests  1 failed | 78 passed (79)
success-path page fires every tick    Tests  1 failed | 78 passed (79)
emptiness check inverted              Tests  1 failed | 78 passed (79)
bypassed repeat downgraded to warn    Tests  1 failed | 78 passed (79)
bypassed repeat tagged stale          Tests  1 failed | 78 passed (79)
```

Escalation, same method:

```
escalation never alerts               Tests  2 failed | 81 passed (83)
escalated alert stays a warning       Tests  1 failed | 82 passed (83)
drop the age guard                    Tests  1 failed | 82 passed (83)
drop the un-escalated guard           Tests  1 failed | 82 passed (83)
threshold 30min -> 1min               Tests  1 failed | 82 passed (83)
escalate on the streak's first tick   Tests  1 failed | 82 passed (83)
```

The success-path page is asserted in both directions because the latch decision leans on it: leaving a recorded `"[]"` latched is only safe because going empty pages once when it happens.

## Follow-ups, not in this PR

- The x402 rail has neither the severity split nor the escalation. `apps/core/src/services/agent-sync.x402-readiness.ts:250` carries the identical row-existence misclassification. Separate rail, separate tests, and its own preview-deploy muting decides which environments an alert change is observable in. Documented in that file.
- Cardano's marker-cleanup failure only `console.warn`s where its x402 twin pages. Pre-existing.
- `docs/adr/0001-x402-evm-payment-rail.md:220` and `docs/wayfinder/x402-evm/build-log.md:295` describe the old severity. Both are dated records, so I left them alone.
