### PR TITLE
refactor(core): batch source-import link and blob writes

### DIFF
--- a/apps/core/src/services/source-import.service.test.ts
+++ b/apps/core/src/services/source-import.service.test.ts
@@ -5,13 +5,15 @@ import { sourceImportService } from "./source-import.service";
 
 const {
   captureExceptionMock,
-  upsertLinkMock,
-  upsertOutputBlobMock,
+  captureMessageMock,
+  createLinksMock,
+  createOutputBlobsMock,
   mockTaskFileClient,
 } = vi.hoisted(() => ({
   captureExceptionMock: vi.fn(),
-  upsertLinkMock: vi.fn(),
-  upsertOutputBlobMock: vi.fn(),
+  captureMessageMock: vi.fn(),
+  createLinksMock: vi.fn(),
+  createOutputBlobsMock: vi.fn(),
   mockTaskFileClient: {
     taskFile: {
       findFirst: vi.fn(),
@@ -22,14 +24,15 @@ const {
 
 vi.mock("@sentry/node", () => ({
   captureException: captureExceptionMock,
+  captureMessage: captureMessageMock,
 }));
 
 vi.mock("@sokosumi/database/repositories", () => ({
   blobRepository: {
-    upsertOutputBlob: upsertOutputBlobMock,
+    createOutputBlobs: createOutputBlobsMock,
   },
   linkRepository: {
-    upsertLink: upsertLinkMock,
+    createLinks: createLinksMock,
   },
 }));
 
@@ -42,41 +45,54 @@ describe("sourceImportService.enqueueFromMarkdown", () => {
     vi.clearAllMocks();
   });
 
-  it("upserts unique file blobs and http links from markdown", async () => {
+  it("writes unique file blobs and http links in one batch each", async () => {
     await sourceImportService.enqueueFromMarkdown(
       "event_1",
       [
         "[file](https://example.com/result.pdf)",
         "[dup file](https://example.com/result.pdf)",
+        "[second file](https://example.com/notes.pdf)",
         "<https://example.com/page>",
         "[link](https://example.com/page)",
+        "[other](https://example.com/other)",
         "[skip](mailto:test@example.com)",
+        // `new URL()` reads this as https, `isHttpUrl` does not. The filter
+        // between them is load-bearing.
+        "[schemeless](https:example.com/nope)",
       ].join("\n"),
     );
 
-    expect(upsertOutputBlobMock).toHaveBeenCalledTimes(1);
-    expect(upsertOutputBlobMock).toHaveBeenCalledWith(
-      {
-        eventId: "event_1",
-        sourceUrl: "https://example.com/result.pdf",
-        name: "result.pdf",
-      },
+    expect(createOutputBlobsMock).toHaveBeenCalledTimes(1);
+    expect(createOutputBlobsMock).toHaveBeenCalledWith(
+      [
+        {
+          eventId: "event_1",
+          sourceUrl: "https://example.com/result.pdf",
+          name: "result.pdf",
+        },
+        {
+          eventId: "event_1",
+          sourceUrl: "https://example.com/notes.pdf",
+          name: "notes.pdf",
+        },
+      ],
       expect.anything(),
     );
-    expect(upsertLinkMock).toHaveBeenCalledTimes(1);
-    expect(upsertLinkMock).toHaveBeenCalledWith(
-      {
-        eventId: "event_1",
-        url: "https://example.com/page",
-        title: undefined,
-      },
+    expect(createLinksMock).toHaveBeenCalledTimes(1);
+    expect(createLinksMock).toHaveBeenCalledWith(
+      [
+        { eventId: "event_1", url: "https://example.com/page" },
+        { eventId: "event_1", url: "https://example.com/other" },
+      ],
       expect.anything(),
     );
   });
 
-  it("captures repository errors and continues processing other links", async () => {
-    upsertOutputBlobMock.mockRejectedValueOnce(new Error("blob failed"));
-    upsertLinkMock.mockRejectedValueOnce(new Error("link failed"));
+  it("captures a failing batch with its job event and still attempts the other", async () => {
+    const blobFailure = new Error("blob failed");
+    const linkFailure = new Error("link failed");
+    createOutputBlobsMock.mockRejectedValueOnce(blobFailure);
+    createLinksMock.mockRejectedValueOnce(linkFailure);
 
     await sourceImportService.enqueueFromMarkdown(
       "event_1",
@@ -86,16 +102,70 @@ describe("sourceImportService.enqueueFromMarkdown", () => {
       ].join("\n"),
     );
 
+    expect(createOutputBlobsMock).toHaveBeenCalledTimes(1);
+    expect(createLinksMock).toHaveBeenCalledTimes(1);
     expect(captureExceptionMock).toHaveBeenCalledTimes(2);
-    expect(upsertOutputBlobMock).toHaveBeenCalledTimes(1);
-    expect(upsertLinkMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(blobFailure, {
+      extra: { jobEventId: "event_1", blobs: 1 },
+    });
+    expect(captureExceptionMock).toHaveBeenCalledWith(linkFailure, {
+      extra: { jobEventId: "event_1", links: 1 },
+    });
   });
 
-  it("skips upserts when markdown contains no importable links", async () => {
+  it("drops URLs the unique index cannot hold and reports the count", async () => {
+    // The two batches filter separately, so each needs its own fixture. A
+    // `.pdf` URL only ever reaches the blob batch, because `extractHttpLinks`
+    // excludes file-like URLs.
+    const oversizedFile = `https://example.com/${"a".repeat(2100)}.pdf`;
+    const oversizedLink = `https://example.com/${"b".repeat(2100)}`;
+    // Exactly MAX_INDEXABLE_URL_BYTES, so it must survive. This pins the
+    // boundary itself, not just the magnitude of the constant.
+    const atTheLimit = `https://example.com/${"c".repeat(1980)}`;
+
+    await sourceImportService.enqueueFromMarkdown(
+      "event_1",
+      [
+        `[huge file](${oversizedFile})`,
+        "[file](https://example.com/result.pdf)",
+        `[huge link](${oversizedLink})`,
+        `[at the limit](${atTheLimit})`,
+        "[link](https://example.com/page)",
+      ].join("\n"),
+    );
+
+    // An oversized row would abort its whole statement, taking the good rows
+    // with it. Only the good rows are written, and every drop is reported.
+    expect(createOutputBlobsMock).toHaveBeenCalledWith(
+      [
+        {
+          eventId: "event_1",
+          sourceUrl: "https://example.com/result.pdf",
+          name: "result.pdf",
+        },
+      ],
+      expect.anything(),
+    );
+    expect(createLinksMock).toHaveBeenCalledWith(
+      [
+        { eventId: "event_1", url: atTheLimit },
+        { eventId: "event_1", url: "https://example.com/page" },
+      ],
+      expect.anything(),
+    );
+    // One report per batch, so the count says which batch lost the URL.
+    expect(captureMessageMock).toHaveBeenCalledTimes(2);
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      "Dropped source-import URLs over the index limit",
+      { level: "warning", extra: { jobEventId: "event_1", dropped: 1 } },
+    );
+  });
+
+  it("writes nothing when markdown contains no importable links", async () => {
     await sourceImportService.enqueueFromMarkdown("event_1", "No links here");
 
-    expect(upsertOutputBlobMock).not.toHaveBeenCalled();
-    expect(upsertLinkMock).not.toHaveBeenCalled();
+    expect(createOutputBlobsMock).not.toHaveBeenCalled();
+    expect(createLinksMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/core/src/services/source-import.service.ts
+++ b/apps/core/src/services/source-import.service.ts
@@ -54,53 +54,76 @@ export interface TaskFileClient {
  */
 export type TaskFileClientLike = PrismaClientOrTx | TaskFileClient;
 
+/**
+ * Longest URL the batched inserts accept. Both writes dedupe through a btree
+ * unique that includes the URL, and Postgres cannot index an entry over about
+ * 2704 bytes. One oversized row aborts the whole statement, so it would take
+ * every other link for the same job event with it. The cut is conservative:
+ * the event id and tuple header leave ample headroom below the real limit.
+ */
+const MAX_INDEXABLE_URL_BYTES = 2000;
+
+/**
+ * Drop URLs the unique index cannot hold, and report how many were dropped.
+ * Reported rather than silent: the link is lost for good, because nothing
+ * re-reads a job event's markdown.
+ */
+function keepIndexableUrls(urls: string[], jobEventId: string): string[] {
+  const kept = urls.filter(
+    (url) => Buffer.byteLength(url) <= MAX_INDEXABLE_URL_BYTES,
+  );
+
+  if (kept.length !== urls.length) {
+    Sentry.captureMessage("Dropped source-import URLs over the index limit", {
+      level: "warning",
+      extra: { jobEventId, dropped: urls.length - kept.length },
+    });
+  }
+
+  return kept;
+}
+
 export const sourceImportService = {
   async enqueueFromMarkdown(
     jobEventId: string,
     markdown: string,
   ): Promise<void> {
-    const fileLinks = extractFileLikeLinks(markdown);
-    const httpLinks = extractHttpLinks(markdown);
+    const fileLinks = keepIndexableUrls(
+      extractFileLikeLinks(markdown).filter(isHttpUrl),
+      jobEventId,
+    );
+    const httpLinks = keepIndexableUrls(
+      extractHttpLinks(markdown).filter(isHttpUrl),
+      jobEventId,
+    );
 
-    if (fileLinks.length === 0 && httpLinks.length === 0) {
-      return;
-    }
-
-    for (const url of fileLinks) {
-      if (!isHttpUrl(url)) {
-        continue;
-      }
-
+    if (fileLinks.length > 0) {
       try {
-        await blobRepository.upsertOutputBlob(
-          {
+        await blobRepository.createOutputBlobs(
+          fileLinks.map((url) => ({
             eventId: jobEventId,
             sourceUrl: url,
             name: getUrlBasename(url) ?? undefined,
-          },
+          })),
           prisma,
         );
       } catch (error) {
-        Sentry.captureException(error);
+        Sentry.captureException(error, {
+          extra: { jobEventId, blobs: fileLinks.length },
+        });
       }
     }
 
-    for (const url of httpLinks) {
-      if (!isHttpUrl(url)) {
-        continue;
-      }
-
+    if (httpLinks.length > 0) {
       try {
-        await linkRepository.upsertLink(
-          {
-            eventId: jobEventId,
-            url,
-            title: undefined,
-          },
+        await linkRepository.createLinks(
+          httpLinks.map((url) => ({ eventId: jobEventId, url })),
           prisma,
         );
       } catch (error) {
-        Sentry.captureException(error);
+        Sentry.captureException(error, {
+          extra: { jobEventId, links: httpLinks.length },
+        });
       }
     }
   },

--- a/packages/database/src/repositories/blob.repository.test.ts
+++ b/packages/database/src/repositories/blob.repository.test.ts
@@ -3,10 +3,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 
 import type { Prisma } from "../generated/prisma/client.js";
-import { linkRepository } from "./link.repository.js";
+import { BlobStatus } from "../generated/prisma/client.js";
+import { blobRepository } from "./blob.repository.js";
 
-describe("linkRepository.createLinks", () => {
-  it("inserts every link in one call and skips stored duplicates", async () => {
+describe("blobRepository.createOutputBlobs", () => {
+  it("inserts every blob as PENDING in one call and skips stored duplicates", async () => {
     // Every call, not just the last: one statement for the whole batch is the
     // point of this repository, so a second one has to fail the test.
     const createManyCalls: unknown[] = [];
@@ -14,7 +15,7 @@ describe("linkRepository.createLinks", () => {
     // awaits it. The stub records on `then` for the same reason, so dropping
     // the `await` under test fails here instead of silently writing nothing.
     const tx = {
-      link: {
+      blob: {
         createMany: (args: unknown) => ({
           then: (resolve: (value: { count: number }) => void) => {
             createManyCalls.push(args);
@@ -24,10 +25,18 @@ describe("linkRepository.createLinks", () => {
       },
     } as unknown as Prisma.TransactionClient;
 
-    await linkRepository.createLinks(
+    await blobRepository.createOutputBlobs(
       [
-        { eventId: "event-1", url: "https://example.com/page" },
-        { eventId: "event-1", url: "https://example.com/other" },
+        {
+          eventId: "event-1",
+          sourceUrl: "https://example.com/result.pdf",
+          name: "result.pdf",
+        },
+        {
+          eventId: "event-1",
+          sourceUrl: "https://example.com/notes.pdf",
+          name: "notes.pdf",
+        },
       ],
       tx,
     );
@@ -35,8 +44,18 @@ describe("linkRepository.createLinks", () => {
     assert.equal(createManyCalls.length, 1);
     assert.deepEqual(createManyCalls[0], {
       data: [
-        { eventId: "event-1", url: "https://example.com/page" },
-        { eventId: "event-1", url: "https://example.com/other" },
+        {
+          eventId: "event-1",
+          sourceUrl: "https://example.com/result.pdf",
+          name: "result.pdf",
+          status: BlobStatus.PENDING,
+        },
+        {
+          eventId: "event-1",
+          sourceUrl: "https://example.com/notes.pdf",
+          name: "notes.pdf",
+          status: BlobStatus.PENDING,
+        },
       ],
       skipDuplicates: true,
     });

--- a/packages/database/src/repositories/blob.repository.ts
+++ b/packages/database/src/repositories/blob.repository.ts
@@ -8,32 +8,26 @@ import { type Blob, BlobStatus } from "../generated/prisma/client.js";
  */
 export const blobRepository = {
   /**
-   * Create a pending result Blob record from a source URL (extracted from markdown)
-   * Avoids duplicates by sourceUrl per job event.
+   * Insert PENDING result Blobs from source URLs extracted from markdown,
+   * skipping ones already stored. `skipDuplicates` skips a row that collides
+   * with any unique on the model, not only `eventId_sourceUrl`; today that
+   * unique and the primary key are the only ones. One statement covers the
+   * batch, and Prisma splits a very large one into chunks. The per-URL upsert
+   * this replaced spent a nested write, and so an implicit transaction, on
+   * every URL.
    */
-  async upsertOutputBlob(
+  async createOutputBlobs(
     data: {
       eventId: string;
       sourceUrl: string;
       name?: string;
-    },
+    }[],
     tx: Prisma.TransactionClient,
-  ): Promise<Blob> {
-    const blob = await tx.blob.upsert({
-      where: {
-        eventId_sourceUrl: { eventId: data.eventId, sourceUrl: data.sourceUrl },
-      },
-      update: {
-        name: data.name,
-      },
-      create: {
-        event: { connect: { id: data.eventId } },
-        status: BlobStatus.PENDING,
-        sourceUrl: data.sourceUrl,
-        name: data.name,
-      },
+  ): Promise<void> {
+    await tx.blob.createMany({
+      data: data.map((blob) => ({ ...blob, status: BlobStatus.PENDING })),
+      skipDuplicates: true,
     });
-    return blob;
   },
 
   /**

--- a/packages/database/src/repositories/link.repository.ts
+++ b/packages/database/src/repositories/link.repository.ts
@@ -1,4 +1,4 @@
-import type { Link, Prisma } from "../generated/prisma/client.js";
+import type { Prisma } from "../generated/prisma/client.js";
 import {
   flattenLinkJobId,
   type LinkWithJobId,
@@ -6,26 +6,24 @@ import {
 } from "../types/link.js";
 
 export const linkRepository = {
-  async upsertLink(
+  /**
+   * Insert links for a job event, skipping ones already stored.
+   * `skipDuplicates` skips a row that collides with any unique on the model,
+   * not only `eventId_url`; today that unique and the primary key are the only
+   * ones. One statement covers the batch, and Prisma splits a very large one
+   * into chunks. The per-link upsert this replaced spent a nested write, and so
+   * an implicit transaction, on every URL.
+   */
+  async createLinks(
     data: {
       eventId: string;
       url: string;
-      title?: string;
-    },
+    }[],
     tx: Prisma.TransactionClient,
-  ): Promise<Link> {
-    return tx.link.upsert({
-      where: {
-        eventId_url: { eventId: data.eventId, url: data.url },
-      },
-      update: {
-        title: data.title,
-      },
-      create: {
-        event: { connect: { id: data.eventId } },
-        url: data.url,
-        title: data.title,
-      },
+  ): Promise<void> {
+    await tx.link.createMany({
+      data,
+      skipDuplicates: true,
     });
   },
 


### PR DESCRIPTION
## Summary

`enqueueFromMarkdown` upserted one row per extracted URL, sequentially. Every upsert used `event: { connect }`, so each one was a nested write costing a round trip and an implicit transaction.

Two `createMany` calls with `skipDuplicates` replace both loops: one transaction per kind instead of one per link. Prisma chunks a `createMany` at 32766 bind values, so a very large batch is still more than one `INSERT` (measured: 6000 blob rows produce 2 statements), but it remains a single transaction. The `eventId_url` and `eventId_sourceUrl` uniques still deduplicate.

## Why this matters more after #4117

#4117 (merged) awaits `enqueueFromMarkdown` so it is covered by the run's `waitUntil`. That is correct, and it moves those per-link round trips into the sync's critical path. The last cancellation check for an agent job is in `syncAgentStatus` (`job-sync.service.ts:367`) right after the agent poll, at `:403-412`; nothing checks again once `applyAgentState` starts, and `runSyncPhase` itself only checks at slot entry (`:492-500`). An earlier revision of this line named a function `syncAgentJob`, which does not exist anywhere in the tree. Neither `extractHttpLinks` nor `extractFileLikeLinks` caps how many links a result can contain. A local agent review pass on #4117, run while preparing this branch, raised the resulting overrun as a should-fix. It is not a review comment on that PR: `gh pr view 4117 --json reviews,comments` returns `{"comments":[],"reviews":[]}`. Collapsing the round trips removes most of that exposure without adding cancellation logic, which would drop links permanently since nothing re-reads a job event's markdown.

## Failure isolation, and the trade it makes

Batching moves failure isolation from per URL to per batch: a per-row error that is not a unique conflict aborts the whole statement. The reachable case is a URL whose btree index entry exceeds ~2704 incompressible bytes, which means a long signed query string, since short or repetitive values compress under pglz. Demonstrated on PostgreSQL 18.6 against a hand-built table with an equivalent two-column unique, **not** against this schema's index. The real index is `link_eventId_url_key` (`packages/database/prisma/migrations/20251217142732_rename_jobstatus_to_jobevent/migration.sql:48`); the name in the captured error is the throwaway table's:

```
ERROR:  index row size 3240 exceeds btree version 4 maximum 2704 for index "..._event_id_url_key"
```

The limit it demonstrates is a btree property, not a property of that table, so it transfers. The reproduction does not.

An earlier revision of this PR accepted that as an unavoidable trade-off. That was wrong: it ruled out a per-row fallback and never considered a pre-filter. `keepIndexableUrls` now drops URLs over `MAX_INDEXABLE_URL_BYTES` before the write and reports the dropped count to Sentry with the job event id.

**The cut costs something, and an earlier revision of this body denied it.** That revision said the dropped URL "was unstorable under the old code too, so the loss is unchanged for it". That is false below roughly 2650 bytes. The cut is 2000, while tuple arithmetic (INFERRED, not measured: 2704 minus the index tuple header, the event id, and the varlena header) puts the real ceiling near 2650, and pglz can push it higher on compressible URLs. So a URL between 2000 bytes and that ceiling stored fine under the per-row upsert and is dropped now.

The conservative cut is deliberate. A drop costs one link and emits a Sentry warning naming the job event. An aborted statement costs every link for that job event, silently as far as the URL is concerned, because Postgres' index-size error does not name the offending value. Getting the constant slightly too low loses strictly less than getting it slightly too high.

The other per-row failure mode, a NUL byte in a URL, is unreachable from this caller: `JobEvent.result` is a Postgres `String`, so the same NUL aborts `createJobEventForJobId` inside the sync transaction first and `extractionContext` is never built.

Both `catch` blocks now attach `jobEventId` and the batch size, so a failed batch says which job lost links and how many.

## Behaviour

- The upserts' `update` branches were **unreachable**, not merely no-ops. `finalizeJobSyncResult` has three call sites (`job-sync-state.service.ts:429`, `job-sync-state.service.ts:498`, `job-sync.service.ts:294`). Only `applyAgentState` at :498 ever sets `extractionContext`, and it always sets `eventId: newJobEvent.id` for a `JobEvent` created moments earlier in the transaction that just committed. The other two pass `{ job, jobStatus }` with no `extractionContext`. An unchanged `statusHash` skips event creation entirely, and the call is never retried. There is never an existing row to update.
- Gained for free, and not previously claimed (INFERRED from `skipDuplicates` semantics, not measured here): `createMany` resolves a collision in the database, so it does not carry `upsert`'s read-then-write race, which can throw `P2002` under a concurrent insert.
- Duplicates within one batch cannot occur: both extractors accumulate into a `Set` and return `Array.from(...)` of it (`packages/utils/src/markdown-links-extract.ts:284` and `:303`). An earlier revision wrote that as the literal expression `Array.from(new Set(...))`, which appears in neither function. The Sets key on the raw string, so the deduplication is byte-identical only.
- `skipDuplicates` skips a row colliding with any unique on the model, not only the URL unique. Today the URL unique and the primary key are the only ones. Both repository doc comments say so.
- `skipDuplicates` is confirmed present on `LinkCreateManyArgs` and `BlobCreateManyArgs` in the generated Prisma 7.10.0 client, not assumed from docs.

## Verification

Local, Node 24.14.0, rebased onto current `main`:

- `pnpm --filter core test src/services/source-import.service.test.ts`: `Tests 10 passed (10)`, exit 0.
- `pnpm --filter @sokosumi/database test src/repositories`: `Test Files 17 passed (17)`, `Tests 65 passed (65)`, exit 0.
- `pnpm check`: `No fixes applied.`, exit 0. The file count it also prints is deliberately not quoted: it is not reproducible. On one checkout, switching only the checkout, `main` reported `Checked 3803 files` and this branch `Checked 3805 files`, while the branch adds exactly one tracked file. Two earlier revisions of this line quoted a count and two different explanations for the gap; both were wrong, so the figure is gone rather than re-explained. `pnpm typecheck`: `19 successful, 19 total`, exit 0.
- Mutation checks, each rerun against its own test and each going red (exit 1): removed `keepIndexableUrls` from the `httpLinks` batch; removed it from the `fileLinks` batch; raised `MAX_INDEXABLE_URL_BYTES` to 100000; changed the boundary `<=` to `<`; stripped `blobs` from the blob `catch`'s Sentry `extra`; dropped `skipDuplicates` from `createLinks`; dropped the `await` inside `createOutputBlobs`; dropped the `await` inside `createLinks`; split each repository's single `createMany` into two statements.
- That an unawaited `createMany` sends no SQL was measured directly, driving the generated Prisma 7.10.0 client through a stub driver adapter that records statements:
  ```
  NO-AWAIT  statements = 0 []
  WITH-AWAIT statements = 1 ["INSERT INTO \"public\".\"blob\" (\""]
  ```

## Fixed in response to review

Six adversarial passes ran on this branch. Beyond the pre-filter and the Sentry context above:

- **The repository tests claimed "in one call" and asserted no such thing.** Each recorded only the last `createMany` into a single slot, so a repository splitting the batch into two statements stayed green. That is the exact property this PR exists for. Both now collect every call and assert there was one, and the split-batch mutation is red in both repositories.
- **An earlier revision of this description had the consequence of a dropped `await` backwards.** It said removing the `await` inside `createOutputBlobs` would cause "an unhandled rejection, not a lost write". The opposite is true, and the measurement above shows it: a `PrismaPromise` is lazy, so an unawaited `createMany` sends no SQL, raises nothing, and reports nothing. It is a silent lost write. The same gap existed in `createLinks`, which that revision did not mention, and Biome does not backstop it (no `noFloatingPromises` rule is enabled). Both repository tests now stub `createMany` as a lazy thenable that records on `then`, so both mutations are red.
- **The `httpLinks` half of the pre-filter was gated by nothing.** The oversized fixture was `https://example.com/aaa….pdf`, and `extractHttpLinks` excludes file-like URLs, so it only ever reached the blob batch. Deleting `keepIndexableUrls` from the link batch left the whole suite green. The test now uses a second, extension-less oversized URL, and that mutation is red.
- Added `packages/database/src/repositories/blob.repository.test.ts`. `createOutputBlobs` previously had **zero** coverage: the service test mocks the whole repository module, so nothing observed its `createMany` args or the `status: BlobStatus.PENDING` mapping.
- Added a case for the load-bearing `httpLinks.filter(isHttpUrl)`. `new URL("https:example.com/x").protocol` is `"https:"` but `isHttpUrl` rejects it, so removing that filter would store the schemeless form.
- Dropped the dead `title?: string` parameter from `createLinks`. The one caller passed `title: undefined`, which the diff removes; no caller ever supplied a value, and `Link.title` is written nowhere in `apps/` or `packages/`.
- Both repository doc comments asserted the exact SQL Prisma emits. One review pass measured it by capturing statements through a stub driver adapter; a later pass could not reproduce that capture. The comments now state the `skipDuplicates` behaviour the change relies on, which is what both passes agreed on.
- Corrected claims that did not hold: "one statement per kind whatever the link count" (Prisma chunks at 32766 bind values), the `Blob.name` behaviour difference an earlier draft called "a fix" (unreachable path), and the drop-window claim above.

## Known, not fixed

- A URL between 2000 bytes and the real index ceiling is now dropped where it previously stored. See the trade above. The boundary itself is pinned: a fixture at exactly 2000 bytes must survive, so changing `<=` to `<` fails.
- Two drops in one call emit two Sentry warnings with `dropped: 1` each, not one with `dropped: 2`. That keeps the count attributable to a batch. The test asserts the count, so it cannot change silently.
- `MAX_INDEXABLE_URL_BYTES` lives in the service while it guards a database-layer constraint. Moving it would mean exporting a constant from `@sokosumi/database` for one caller.
- `.filter(isHttpUrl)` on `fileLinks` is dead: `isFileLikeUrl` already requires it. Kept so both branches carry the same guard the loops had.
- The lazy `createMany` stubs always resolve and ignore their reject handler, so a repository that swallowed its own write error would still pass. The shipped repositories have no `try`/`catch`; the failure contract is asserted one layer up, in `source-import.service.test.ts`, against a mocked repository.
- No fixture pins `Buffer.byteLength` against `url.length`. Swapping them survives the suite, because every oversized fixture is ASCII. The shipped code counts bytes, which is what the index limit counts.
- A batch large enough for Prisma to chunk runs inside a Prisma-managed transaction (REPORTED, measured by a review pass as `startTransaction`, two `INSERT`s, `COMMIT`), and no `transactionOptions` is configured on the client, so Prisma's defaults bound it. This is **not** strictly better than the sequential round trips it replaces, and an earlier revision of this line claimed it was. It trades partial progress for speed: if that transaction aborts, every row for that kind is lost, whereas the per-URL loop committed each write independently and an abort at row N kept rows 1 to N-1. Batching is far faster and so far less likely to reach any deadline, which is why the trade is worth making, but it is a trade. Nothing caps how many links a result can contain.
- Rows in one batch share a `createdAt`. Prisma binds a client-generated ISO timestamp per statement, identical for every row in it, so `importPendingResultBlobs`' `orderBy: createdAt asc` is an unstable sort across a batch. Under the old code each awaited round trip generated its own timestamp, so ties needed two writes inside the same millisecond.


