### PR TITLE
fix(core): encode null soko-bot install skill as a union

### DIFF
--- a/apps/core/src/schemas/soko-bot.schema.ts
+++ b/apps/core/src/schemas/soko-bot.schema.ts
@@ -857,7 +857,9 @@ export const installSokoBotSkillRequestSchema = z
 
 export const installSokoBotSkillResponseSchema = z
   .object({
-    skill: sokoBotInstalledSkillSchema.nullable(),
+    // Named schemas must be unioned with null, not `.nullable()`, or the
+    // generated client's transformer breaks.
+    skill: z.union([sokoBotInstalledSkillSchema, z.null()]),
     /** Set when the source offers several skills and none was named. */
     candidates: z.array(
       z.object({ name: z.string(), description: z.string(), path: z.string() }),

--- a/apps/web/src/lib/clients/__tests__/install-soko-bot-skill-transformer.test.ts
+++ b/apps/web/src/lib/clients/__tests__/install-soko-bot-skill-transformer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { installMySokoBotSkillResponseTransformer } from "@/lib/clients/generated/core/transformers.gen";
+
+const meta = { timestamp: "2026-09-02T09:21:35.000Z" };
+
+describe("installMySokoBotSkillResponseTransformer", () => {
+  it("keeps skill null when the source lists unnamed candidates", async () => {
+    const result = await installMySokoBotSkillResponseTransformer({
+      data: {
+        skill: null,
+        candidates: [
+          { name: "skill-a", description: "A", path: "skills/a" },
+          { name: "skill-b", description: "B", path: "skills/b" },
+        ],
+      },
+      meta: { ...meta },
+    });
+
+    expect(result.data.skill).toBeNull();
+    expect(result.data.candidates).toHaveLength(2);
+    expect(result.meta.timestamp).toEqual(new Date(meta.timestamp));
+  });
+
+  it("converts a present skill createdAt to Date", async () => {
+    const result = await installMySokoBotSkillResponseTransformer({
+      data: {
+        skill: {
+          id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+          slug: "example-skill",
+          name: "Example skill",
+          description: "Does a thing",
+          sourceUrl: "https://github.com/acme/skills",
+          sourceRef: "main",
+          createdAt: "2026-09-02T09:21:35.000Z",
+        },
+        candidates: [],
+      },
+      meta: { ...meta },
+    });
+
+    expect(result.data.skill?.createdAt).toBeInstanceOf(Date);
+  });
+});

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -17366,15 +17366,12 @@ export const InstallSokoBotSkillResponseSchema = {
     type: 'object',
     properties: {
         skill: {
-            allOf: [
+            anyOf: [
                 {
                     $ref: '#/components/schemas/SokoBotInstalledSkill'
                 },
                 {
-                    type: [
-                        'object',
-                        'null'
-                    ]
+                    type: 'null'
                 }
             ]
         },

--- a/apps/web/src/lib/clients/generated/core/transformers.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/transformers.gen.ts
@@ -2477,7 +2477,9 @@ export const listMySokoBotSkillsResponseTransformer = async (data: any): Promise
 };
 
 const installSokoBotSkillResponseSchemaResponseTransformer = (data: any) => {
-    data.skill = sokoBotInstalledSkillSchemaResponseTransformer(data.skill);
+    if (data.skill) {
+        data.skill = sokoBotInstalledSkillSchemaResponseTransformer(data.skill);
+    }
     return data;
 };
 

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -5061,9 +5061,7 @@ export type SokoBotInstalledSkill = {
 };
 
 export type InstallSokoBotSkillResponse = {
-    skill: SokoBotInstalledSkill & ({
-        [key: string]: unknown;
-    } | null);
+    skill: SokoBotInstalledSkill | null;
     candidates: Array<{
         name: string;
         description: string;


### PR DESCRIPTION
## Why

Install skill returns `skill: null` plus `candidates` when a source repo lists several skills and none was named. Named `.nullable()` on `sokoBotInstalledSkillSchema` dropped `| null` from OpenAPI. The generated transformer then read `createdAt` on null.

This is the remaining sibling of merged #4101, on `POST /soko-bots/me/skills`. `main` is merged in. Both union encodings coexist.

## Scope

- `installSokoBotSkillResponseSchema.skill` is `z.union([sokoBotInstalledSkillSchema, z.null()])`.
- Regenerated Core client. Transformer guards `if (data.skill)`. Field type is `SokoBotInstalledSkill | null`. Named `SokoBotInstalledSkill` stays an object.
- Transformer test at `apps/web/src/lib/clients/__tests__/install-soko-bot-skill-transformer.test.ts`.

Out of scope: other named `.nullable()` object fields.

## Tradeoffs

Union-with-null is the existing OpenAPI encoding for this generator poison (`taskSchema.share`, `qualityVerdict`, #4101). We did not invent a skill object. Null still means pick from candidates.

## Blast Radius

Web `installMySokoBotSkill` response transformer only. Core payload is unchanged. A multi-skill install that used to 500 in the client now keeps `skill: null`.

## Verification

**RED** (test commit, unguarded transformer):

```
TypeError: Cannot read properties of null (reading 'createdAt')
❯ sokoBotInstalledSkillSchemaResponseTransformer transformers.gen.ts:2469
Tests  1 failed | 1 passed (2)
```

**GREEN** (union schema + regenerated client, after merging #4101):

```
Test Files  2 passed (2)
Tests  7 passed (7)
```

Commands:
- `pnpm --filter web exec vitest run src/lib/clients/__tests__/install-soko-bot-skill-transformer.test.ts`
- `pnpm --filter web exec vitest run src/lib/clients/__tests__/admin-soko-bot-runtime-health-transformer.test.ts`