### PR TITLE
feat(core): give a finished task its own notification row

### DIFF
--- a/apps/core/src/helpers/notification-attention-keys.test.ts
+++ b/apps/core/src/helpers/notification-attention-keys.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   JOB_ATTENTION_MESSAGE_KEYS,
   TASK_ATTENTION_MESSAGE_KEYS,
+  TASK_COMPLETED_MESSAGE_KEY,
 } from "./notification-delivery";
 
 /**
@@ -15,14 +16,13 @@ import {
  * a key nobody classified falls to the update row on its own. That fallback is
  * the safe direction for noise and the wrong one for work that waits on the
  * reader, and it is silent either way. This test is the noise: add a producer
- * key and it fails until someone puts the key on one of the two rows.
+ * key and it fails until someone puts the key on a row.
  */
 const UPDATE_MESSAGE_KEYS: readonly string[] = [
   "Notifications.Job.completed",
   "Notifications.Job.failed",
   "Notifications.Job.disputeResolved",
   "Notifications.Job.refundResolved",
-  "Notifications.Task.completed",
   "Notifications.Task.failed",
   "Notifications.Task.canceled",
   "Notifications.Task.scheduleRepaired",
@@ -76,10 +76,11 @@ function emittedMessageKeys(): string[] {
 }
 
 describe("the job and task keys Core names", () => {
-  it("are each classified as waiting on the reader or not", () => {
+  it("are each classified onto a row", () => {
     const classified = new Set([
       ...JOB_ATTENTION_MESSAGE_KEYS,
       ...TASK_ATTENTION_MESSAGE_KEYS,
+      TASK_COMPLETED_MESSAGE_KEY,
       ...UPDATE_MESSAGE_KEYS,
     ]);
 
@@ -96,6 +97,7 @@ describe("the job and task keys Core names", () => {
       [
         ...JOB_ATTENTION_MESSAGE_KEYS,
         ...TASK_ATTENTION_MESSAGE_KEYS,
+        TASK_COMPLETED_MESSAGE_KEY,
         ...UPDATE_MESSAGE_KEYS,
       ].filter((key) => !emitted.has(key)),
     ).toEqual([]);

--- a/apps/core/src/helpers/notification-attention-keys.test.ts
+++ b/apps/core/src/helpers/notification-attention-keys.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   JOB_ATTENTION_MESSAGE_KEYS,
+  JOB_COMPLETED_MESSAGE_KEY,
   TASK_ATTENTION_MESSAGE_KEYS,
   TASK_COMPLETED_MESSAGE_KEY,
 } from "./notification-delivery";
@@ -19,7 +20,6 @@ import {
  * key and it fails until someone puts the key on a row.
  */
 const UPDATE_MESSAGE_KEYS: readonly string[] = [
-  "Notifications.Job.completed",
   "Notifications.Job.failed",
   "Notifications.Job.disputeResolved",
   "Notifications.Job.refundResolved",
@@ -79,6 +79,7 @@ describe("the job and task keys Core names", () => {
   it("are each classified onto a row", () => {
     const classified = new Set([
       ...JOB_ATTENTION_MESSAGE_KEYS,
+      JOB_COMPLETED_MESSAGE_KEY,
       ...TASK_ATTENTION_MESSAGE_KEYS,
       TASK_COMPLETED_MESSAGE_KEY,
       ...UPDATE_MESSAGE_KEYS,
@@ -96,6 +97,7 @@ describe("the job and task keys Core names", () => {
     expect(
       [
         ...JOB_ATTENTION_MESSAGE_KEYS,
+        JOB_COMPLETED_MESSAGE_KEY,
         ...TASK_ATTENTION_MESSAGE_KEYS,
         TASK_COMPLETED_MESSAGE_KEY,
         ...UPDATE_MESSAGE_KEYS,

--- a/apps/core/src/helpers/notification-delivery.test.ts
+++ b/apps/core/src/helpers/notification-delivery.test.ts
@@ -14,6 +14,7 @@ import {
   resolveNotificationMatrix,
   type StoredNotificationPreference,
   TASK_ATTENTION_MESSAGE_KEYS,
+  TASK_COMPLETED_MESSAGE_KEY,
   toNotificationCategory,
 } from "./notification-delivery";
 
@@ -30,7 +31,7 @@ describe("toNotificationCategory", () => {
     ).toBe("JOB_UPDATE");
   });
 
-  it("splits tasks the same way", () => {
+  it("splits tasks three ways", () => {
     expect(
       toNotificationCategory(
         NotificationKind.TASK,
@@ -40,9 +41,34 @@ describe("toNotificationCategory", () => {
     expect(
       toNotificationCategory(
         NotificationKind.TASK,
-        "Notifications.Task.completed",
+        "Notifications.Task.canceled",
       ),
     ).toBe("TASK_UPDATE");
+  });
+
+  /**
+   * The row the reader started the task for. It is written out rather than
+   * read from the constant on both sides, so renaming the constant cannot
+   * quietly move a finished task back in with the cancellations.
+   */
+  it("gives a finished task a row of its own", () => {
+    expect(TASK_COMPLETED_MESSAGE_KEY).toBe("Notifications.Task.completed");
+    expect(
+      toNotificationCategory(
+        NotificationKind.TASK,
+        "Notifications.Task.completed",
+      ),
+    ).toBe("TASK_COMPLETED");
+  });
+
+  /** A finished job is still an update: only tasks split that row. */
+  it("leaves a finished job on the update row", () => {
+    expect(
+      toNotificationCategory(
+        NotificationKind.JOB,
+        "Notifications.Job.completed",
+      ),
+    ).toBe("JOB_UPDATE");
   });
 
   /**

--- a/apps/core/src/helpers/notification-delivery.test.ts
+++ b/apps/core/src/helpers/notification-delivery.test.ts
@@ -10,6 +10,7 @@ import {
   CHAT_DIRECT_MESSAGE_MESSAGE_KEY,
   CHAT_MENTION_MESSAGE_KEY,
   JOB_ATTENTION_MESSAGE_KEYS,
+  JOB_COMPLETED_MESSAGE_KEY,
   resolveNotificationDelivery,
   resolveNotificationMatrix,
   type StoredNotificationPreference,
@@ -19,7 +20,7 @@ import {
 } from "./notification-delivery";
 
 describe("toNotificationCategory", () => {
-  it("splits jobs by whether the reader has to do something", () => {
+  it("splits jobs three ways", () => {
     expect(
       toNotificationCategory(
         NotificationKind.JOB,
@@ -61,14 +62,15 @@ describe("toNotificationCategory", () => {
     ).toBe("TASK_COMPLETED");
   });
 
-  /** A finished job is still an update: only tasks split that row. */
-  it("leaves a finished job on the update row", () => {
+  /** Same row, same reason, for the kind the reader started themselves. */
+  it("gives a finished job a row of its own", () => {
+    expect(JOB_COMPLETED_MESSAGE_KEY).toBe("Notifications.Job.completed");
     expect(
       toNotificationCategory(
         NotificationKind.JOB,
         "Notifications.Job.completed",
       ),
-    ).toBe("JOB_UPDATE");
+    ).toBe("JOB_COMPLETED");
   });
 
   /**

--- a/apps/core/src/helpers/notification-delivery.ts
+++ b/apps/core/src/helpers/notification-delivery.ts
@@ -48,6 +48,9 @@ export const JOB_ATTENTION_MESSAGE_KEYS: readonly string[] = [
   "Notifications.Job.paymentFailed",
 ];
 
+/** The key a finished job carries. Its own row for the same reason. */
+export const JOB_COMPLETED_MESSAGE_KEY = "Notifications.Job.completed";
+
 /**
  * One stored choice, as the database holds it: strings rather than the unions,
  * because a row written by an older build can name a category or a channel this
@@ -79,7 +82,7 @@ export interface NotificationDelivery {
  * Every kind splits by message key, because a reader chooses between an
  * @mention and a direct message, or between a task that waits on them, a task
  * that finished and a task that was canceled, rather than between the kinds a
- * producer happens to emit.
+ * producer happens to emit. Jobs split the same three ways.
  *
  * Null means the defaults apply and nothing is stored against it: a chat key
  * added later that nobody mapped, and BILLING, which no producer emits yet. A
@@ -91,8 +94,11 @@ export function toNotificationCategory(
 ): NotificationCategory | null {
   switch (kind) {
     case "JOB":
-      return JOB_ATTENTION_MESSAGE_KEYS.includes(messageKey)
-        ? "JOB_ATTENTION"
+      if (JOB_ATTENTION_MESSAGE_KEYS.includes(messageKey)) {
+        return "JOB_ATTENTION";
+      }
+      return messageKey === JOB_COMPLETED_MESSAGE_KEY
+        ? "JOB_COMPLETED"
         : "JOB_UPDATE";
     case "TASK":
       if (TASK_ATTENTION_MESSAGE_KEYS.includes(messageKey)) {

--- a/apps/core/src/helpers/notification-delivery.ts
+++ b/apps/core/src/helpers/notification-delivery.ts
@@ -20,9 +20,9 @@ export const CHAT_ROOM_MESSAGE_MESSAGE_KEY = "Notifications.Chat.roomMessage";
  *
  * A task that needs input, approval, authentication or credits stops until the
  * reader acts. Everything else a task emits is an outcome they can read later,
- * so the two are separate rows and the loud one can stay on while the quiet one
- * goes off. A key added later is an update until it is listed here, which is
- * the safe way round: an unknown key is never louder than the reader asked for.
+ * so each is a row of its own and the loud one can stay on while the quiet ones
+ * go off. A key added later is an update until it is listed here, which is the
+ * safe way round: an unknown key is never louder than the reader asked for.
  */
 export const TASK_ATTENTION_MESSAGE_KEYS: readonly string[] = [
   "Notifications.Task.assigned",
@@ -32,6 +32,15 @@ export const TASK_ATTENTION_MESSAGE_KEYS: readonly string[] = [
   "Notifications.Task.outOfCredits",
   "Notifications.Task.scheduleRemovedByOperator",
 ];
+
+/**
+ * The key a finished task carries.
+ *
+ * Its own row rather than an update, because finishing is what the reader
+ * started the task for. Grouped with the cancellations, it could only be kept
+ * by keeping them too.
+ */
+export const TASK_COMPLETED_MESSAGE_KEY = "Notifications.Task.completed";
 
 /** The job keys that wait on the reader. Same split as the task keys. */
 export const JOB_ATTENTION_MESSAGE_KEYS: readonly string[] = [
@@ -68,9 +77,9 @@ export interface NotificationDelivery {
  * The matrix row a Notification belongs to, or null when it belongs to none.
  *
  * Every kind splits by message key, because a reader chooses between an
- * @mention and a direct message, or between a task that waits on them and a
- * task that finished, rather than between the kinds a producer happens to
- * emit.
+ * @mention and a direct message, or between a task that waits on them, a task
+ * that finished and a task that was canceled, rather than between the kinds a
+ * producer happens to emit.
  *
  * Null means the defaults apply and nothing is stored against it: a chat key
  * added later that nobody mapped, and BILLING, which no producer emits yet. A
@@ -86,8 +95,11 @@ export function toNotificationCategory(
         ? "JOB_ATTENTION"
         : "JOB_UPDATE";
     case "TASK":
-      return TASK_ATTENTION_MESSAGE_KEYS.includes(messageKey)
-        ? "TASK_ATTENTION"
+      if (TASK_ATTENTION_MESSAGE_KEYS.includes(messageKey)) {
+        return "TASK_ATTENTION";
+      }
+      return messageKey === TASK_COMPLETED_MESSAGE_KEY
+        ? "TASK_COMPLETED"
         : "TASK_UPDATE";
     case "SYSTEM":
       return "SYSTEM";

--- a/apps/core/src/helpers/notifications.test.ts
+++ b/apps/core/src/helpers/notifications.test.ts
@@ -426,7 +426,7 @@ describe("createNotification push gating", () => {
     );
     mockReader({
       preferences: [
-        { category: "JOB_UPDATE", channel: "IN_APP", enabled: false },
+        { category: "JOB_COMPLETED", channel: "IN_APP", enabled: false },
       ],
     });
 
@@ -455,7 +455,7 @@ describe("createNotification push gating", () => {
     );
     mockReader({
       preferences: [
-        { category: "JOB_UPDATE", channel: "OS_BANNER", enabled: false },
+        { category: "JOB_COMPLETED", channel: "OS_BANNER", enabled: false },
       ],
     });
 
@@ -509,8 +509,8 @@ describe("createNotification push gating", () => {
     );
     mockReader({
       preferences: [
-        { category: "JOB_UPDATE", channel: "IN_APP", enabled: false },
-        { category: "JOB_UPDATE", channel: "OS_BANNER", enabled: false },
+        { category: "JOB_COMPLETED", channel: "IN_APP", enabled: false },
+        { category: "JOB_COMPLETED", channel: "OS_BANNER", enabled: false },
       ],
     });
 

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -12675,6 +12675,7 @@ export const NotificationPreferenceSchema = {
                 'JOB_ATTENTION',
                 'JOB_UPDATE',
                 'TASK_ATTENTION',
+                'TASK_COMPLETED',
                 'TASK_UPDATE',
                 'CHAT_ROOM_MESSAGE',
                 'CHAT_MENTION',

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -12673,6 +12673,7 @@ export const NotificationPreferenceSchema = {
             type: 'string',
             enum: [
                 'JOB_ATTENTION',
+                'JOB_COMPLETED',
                 'JOB_UPDATE',
                 'TASK_ATTENTION',
                 'TASK_COMPLETED',

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -3743,7 +3743,7 @@ export type NotificationPreference = {
     /**
      * What the notification is about
      */
-    category: 'JOB_ATTENTION' | 'JOB_UPDATE' | 'TASK_ATTENTION' | 'TASK_COMPLETED' | 'TASK_UPDATE' | 'CHAT_ROOM_MESSAGE' | 'CHAT_MENTION' | 'CHAT_DIRECT_MESSAGE' | 'SYSTEM';
+    category: 'JOB_ATTENTION' | 'JOB_COMPLETED' | 'JOB_UPDATE' | 'TASK_ATTENTION' | 'TASK_COMPLETED' | 'TASK_UPDATE' | 'CHAT_ROOM_MESSAGE' | 'CHAT_MENTION' | 'CHAT_DIRECT_MESSAGE' | 'SYSTEM';
     /**
      * Where it is delivered: in the app, or as an OS banner (which also needs pushOptIn)
      */

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -3743,7 +3743,7 @@ export type NotificationPreference = {
     /**
      * What the notification is about
      */
-    category: 'JOB_ATTENTION' | 'JOB_UPDATE' | 'TASK_ATTENTION' | 'TASK_UPDATE' | 'CHAT_ROOM_MESSAGE' | 'CHAT_MENTION' | 'CHAT_DIRECT_MESSAGE' | 'SYSTEM';
+    category: 'JOB_ATTENTION' | 'JOB_UPDATE' | 'TASK_ATTENTION' | 'TASK_COMPLETED' | 'TASK_UPDATE' | 'CHAT_ROOM_MESSAGE' | 'CHAT_MENTION' | 'CHAT_DIRECT_MESSAGE' | 'SYSTEM';
     /**
      * Where it is delivered: in the app, or as an OS banner (which also needs pushOptIn)
      */

--- a/packages/database/prisma/migrations/20260907120000_copy_update_preferences_to_completed/migration.sql
+++ b/packages/database/prisma/migrations/20260907120000_copy_update_preferences_to_completed/migration.sql
@@ -1,0 +1,28 @@
+-- Completed jobs and tasks moved out of their former update categories.
+-- Keep each reader's existing update choice for the new completed category.
+-- An explicit completed preference wins when one already exists.
+
+INSERT INTO "notification_preference" (
+  "id",
+  "userId",
+  "category",
+  "channel",
+  "enabled",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  gen_random_uuid()::text,
+  old."userId",
+  completed.category,
+  old."channel",
+  old."enabled",
+  old."createdAt",
+  now()
+FROM "notification_preference" AS old
+JOIN (
+  VALUES
+    ('JOB_UPDATE', 'JOB_COMPLETED'),
+    ('TASK_UPDATE', 'TASK_COMPLETED')
+) AS completed(old_category, category) ON old."category" = completed.old_category
+ON CONFLICT ("userId", "category", "channel") DO NOTHING;

--- a/packages/utils/src/notification-preferences.ts
+++ b/packages/utils/src/notification-preferences.ts
@@ -6,12 +6,12 @@
  * than a schema migration. Core validates an incoming value against these
  * lists.
  *
- * Jobs are two rows and tasks are three. Something that waits on you and
+ * Jobs and tasks are three rows each. Something that waits on you and
  * something that merely happened are the same kind to the producer and
  * different things to the reader, and one row for both meant silencing the ones
- * that need you to be rid of the ones that do not. A finished task is the third
- * row: it is the answer the reader was waiting for, and it read as noise only
- * while it sat with the cancellations.
+ * that need you to be rid of the ones that do not. Finishing is the third row:
+ * it is the answer the reader was waiting for, and it read as noise only while
+ * it sat with the failures and the cancellations.
  *
  * Chat is three rows: every message in a room you belong to, the messages that
  * name you, and your direct messages. The first is the only one that is off
@@ -22,6 +22,7 @@
  */
 export const NOTIFICATION_CATEGORIES = [
   "JOB_ATTENTION",
+  "JOB_COMPLETED",
   "JOB_UPDATE",
   "TASK_ATTENTION",
   "TASK_COMPLETED",

--- a/packages/utils/src/notification-preferences.ts
+++ b/packages/utils/src/notification-preferences.ts
@@ -6,10 +6,12 @@
  * than a schema migration. Core validates an incoming value against these
  * lists.
  *
- * Jobs and tasks are two rows each. Something that waits on you and something
- * that merely happened are the same kind to the producer and different things
- * to the reader, and one row for both meant silencing the ones that need you to
- * be rid of the ones that do not.
+ * Jobs are two rows and tasks are three. Something that waits on you and
+ * something that merely happened are the same kind to the producer and
+ * different things to the reader, and one row for both meant silencing the ones
+ * that need you to be rid of the ones that do not. A finished task is the third
+ * row: it is the answer the reader was waiting for, and it read as noise only
+ * while it sat with the cancellations.
  *
  * Chat is three rows: every message in a room you belong to, the messages that
  * name you, and your direct messages. The first is the only one that is off
@@ -22,6 +24,7 @@ export const NOTIFICATION_CATEGORIES = [
   "JOB_ATTENTION",
   "JOB_UPDATE",
   "TASK_ATTENTION",
+  "TASK_COMPLETED",
   "TASK_UPDATE",
   "CHAT_ROOM_MESSAGE",
   "CHAT_MENTION",


### PR DESCRIPTION
A job or a task that finished is what the reader started it for, and each sat
on the same row as its own cancellations and failures. Silencing that noise
silenced the answer with it.

TASK_COMPLETED and JOB_COMPLETED are now categories of their own.
Notifications.Task.completed and Notifications.Job.completed map to them;
everything else a task or a job reports still falls to TASK_UPDATE or
JOB_UPDATE, including a key nobody has classified.

Nothing stored has to move. No build has written an update row yet, and both
new rows default to on for both channels, so a reader who never opens the
matrix keeps hearing about finished work exactly as before.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
