### PR TITLE
feat(you): stack mobile You submenus as routes

### DIFF
--- a/apps/web/src/app/(app)/chat/__tests__/tab-destinations-instant-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/__tests__/tab-destinations-instant-contract.test.ts
@@ -24,16 +24,23 @@ describe("mobile tab destinations Instant Nav contract", () => {
     "(welcome)/page.tsx",
     "chat/page.tsx",
     "you/page.tsx",
+    "you/developer/page.tsx",
+    "you/help/page.tsx",
+    "you/legal/page.tsx",
   ] as const;
 
   const loadingShells = [
     "(welcome)/loading.tsx",
     "chat/loading.tsx",
     "you/loading.tsx",
+    "you/developer/loading.tsx",
+    "you/help/loading.tsx",
+    "you/legal/loading.tsx",
     "chat/components/chat-home-loading-view.tsx",
     "chat/components/chat-chats-loading-view.tsx",
     "chat/components/chat-chats-page-skeleton-host.tsx",
     "you/components/you-loading-view.tsx",
+    "components/mobile-stacked-menu/mobile-stacked-menu-skeleton.tsx",
   ] as const;
 
   for (const rel of pages) {
@@ -74,5 +81,18 @@ describe("mobile tab destinations Instant Nav contract", () => {
   it("you/page.tsx Suspense fallback paints YouPageSkeleton", () => {
     const code = stripComments(readApp("you/page.tsx"));
     expect(code).toMatch(/fallback=\{\s*<\s*YouPageSkeleton\s*\/>\s*\}/);
+  });
+
+  it("You submenu loadings return MobileStackedMenuSkeleton", () => {
+    for (const rel of [
+      "you/developer/loading.tsx",
+      "you/help/loading.tsx",
+      "you/legal/loading.tsx",
+    ] as const) {
+      const code = stripComments(readApp(rel));
+      expect(code).toMatch(
+        /export\s+default\s+function[\s\S]*?return\s+<\s*MobileStackedMenuSkeleton\s*\/>/,
+      );
+    }
   });
 });

--- a/apps/web/src/app/(app)/components/__tests__/app-mobile-chrome.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/app-mobile-chrome.test.tsx
@@ -159,6 +159,18 @@ describe("AppMobileChrome", () => {
     expect(screen.queryByRole("navigation", { name: "ariaLabel" })).toBeNull();
   });
 
+  it("hides bottom nav on You submenu stacks", () => {
+    mockPathname = "/you/developer";
+
+    render(
+      <AppMobileChrome>
+        <div>child</div>
+      </AppMobileChrome>,
+    );
+
+    expect(screen.queryByRole("navigation", { name: "ariaLabel" })).toBeNull();
+  });
+
   it("keeps bottom nav on bare /chat home", () => {
     mockPathname = "/chat";
 

--- a/apps/web/src/app/(app)/components/header/header-leading-control.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/header-leading-control.client.test.tsx
@@ -165,6 +165,16 @@ describe("HeaderLeadingControl", () => {
     expect(back).toHaveAttribute("href", "/tasks");
   });
 
+  it("shows back to You on You submenu stacks", () => {
+    for (const path of ["/you/developer", "/you/help", "/you/legal"]) {
+      mockPathname = path;
+      const { unmount } = render(<HeaderLeadingControl />);
+      const back = screen.getByRole("link", { name: "back" });
+      expect(back).toHaveAttribute("href", "/you");
+      unmount();
+    }
+  });
+
   it("restores stored tasks view and filters on nested tasks back", async () => {
     window.sessionStorage.setItem(
       TASKS_RETURN_PATH_SESSION_KEY,

--- a/apps/web/src/app/(app)/components/mobile-app-chrome.test.ts
+++ b/apps/web/src/app/(app)/components/mobile-app-chrome.test.ts
@@ -86,12 +86,26 @@ describe("mobile-app-chrome", () => {
         href: "/notifications",
         labelKey: "back",
       });
+      expect(resolveMobileAppBackTarget("/you/developer")).toEqual({
+        href: "/you",
+        labelKey: "back",
+      });
+      expect(resolveMobileAppBackTarget("/you/help")).toEqual({
+        href: "/you",
+        labelKey: "back",
+      });
+      expect(resolveMobileAppBackTarget("/you/legal")).toEqual({
+        href: "/you",
+        labelKey: "back",
+      });
     });
 
     it("returns null outside the main hub tree", () => {
       expect(resolveMobileAppBackTarget("/chat")).toBeNull();
       expect(resolveMobileAppBackTarget("/chat/rooms/r1")).toBeNull();
       expect(resolveMobileAppBackTarget("/account")).toBeNull();
+      expect(resolveMobileAppBackTarget("/developer/docs")).toBeNull();
+      expect(resolveMobileAppBackTarget("/billing")).toBeNull();
       expect(resolveMobileAppBackTarget(null)).toBeNull();
     });
   });
@@ -129,6 +143,9 @@ describe("mobile-app-chrome", () => {
       expect(shouldShowMobileBottomNav("/agents/a1")).toBe(false);
       expect(shouldShowMobileBottomNav("/admin/users")).toBe(false);
       expect(shouldShowMobileBottomNav("/notifications/n1")).toBe(false);
+      expect(shouldShowMobileBottomNav("/you/developer")).toBe(false);
+      expect(shouldShowMobileBottomNav("/you/help")).toBe(false);
+      expect(shouldShowMobileBottomNav("/you/legal")).toBe(false);
       expect(shouldShowMobileBottomNav("/account")).toBe(false);
       expect(shouldShowMobileBottomNav(null)).toBe(false);
     });
@@ -160,6 +177,9 @@ describe("mobile-app-chrome", () => {
         shouldShowMobileBrandLeading("/", new URLSearchParams("dm=new")),
       ).toBe(true);
       expect(shouldShowMobileBrandLeading("/tasks/t1")).toBe(false);
+      expect(shouldShowMobileBrandLeading("/you/developer")).toBe(false);
+      expect(shouldShowMobileBrandLeading("/you/help")).toBe(false);
+      expect(shouldShowMobileBrandLeading("/you/legal")).toBe(false);
       expect(shouldShowMobileBrandLeading("/agents")).toBe(false);
       expect(shouldShowMobileBrandLeading("/personal-assistant")).toBe(false);
       expect(shouldShowMobileBrandLeading("/account")).toBe(false);

--- a/apps/web/src/app/(app)/components/mobile-stacked-menu/mobile-stacked-menu-screen.tsx
+++ b/apps/web/src/app/(app)/components/mobile-stacked-menu/mobile-stacked-menu-screen.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement, ReactNode } from "react";
+
+/**
+ * Full stacked list screen for mobile App Shell intermediate menus.
+ * Header back / tab-bar chrome come from App Shell via the route path;
+ * this surface only owns title + grouped list body.
+ */
+export function MobileStackedMenuScreen({
+  title,
+  children,
+  testId = "mobile-stacked-menu-screen",
+}: {
+  title: string;
+  children: ReactNode;
+  testId?: string;
+}): ReactElement {
+  return (
+    <div
+      className="mx-auto w-full py-6 md:max-w-4xl md:py-8"
+      data-testid={testId}
+    >
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-xl leading-tight font-semibold">{title}</h1>
+        </header>
+        <nav aria-label={title} className="space-y-6">
+          {children}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/components/mobile-stacked-menu/mobile-stacked-menu-skeleton.tsx
+++ b/apps/web/src/app/(app)/components/mobile-stacked-menu/mobile-stacked-menu-skeleton.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Sync Instant Nav shell for stacked menu screens (no cookies/`connection()`). */
+export function MobileStackedMenuSkeleton(): React.ReactElement {
+  return (
+    <div
+      className="mx-auto w-full py-6 md:max-w-4xl md:py-8"
+      data-testid="mobile-stacked-menu-loading"
+    >
+      <div className="space-y-6">
+        <Skeleton className="h-6 w-32" />
+        <ul className="flex flex-col gap-2">
+          {Array.from({ length: 4 }, (_, index) => (
+            <li key={index}>
+              <Skeleton className="h-12 w-full rounded-lg" />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/components/mobile-stacked-menu/mobile-stacked-menu.tsx
+++ b/apps/web/src/app/(app)/components/mobile-stacked-menu/mobile-stacked-menu.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 
 /**
  * Grouped list primitives matching You’s section language.
- * Reusable for any mobile App Shell stacked menu screen.
+ * First consumer: You root + You submenu stacks; reusable for other App Shell menus.
  */
 export function MobileStackedMenuGroup({
   children,

--- a/apps/web/src/app/(app)/components/mobile-stacked-menu/mobile-stacked-menu.tsx
+++ b/apps/web/src/app/(app)/components/mobile-stacked-menu/mobile-stacked-menu.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import type { ReactElement, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Grouped list primitives matching You’s section language.
+ * Reusable for any mobile App Shell stacked menu screen.
+ */
+export function MobileStackedMenuGroup({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <div className="border-border bg-card-background divide-border divide-y overflow-hidden rounded-lg border">
+      {children}
+    </div>
+  );
+}
+
+export function MobileStackedMenuLink({
+  href,
+  icon,
+  label,
+  testId,
+}: {
+  href: string;
+  icon: ReactElement;
+  label: string;
+  testId: string;
+}): ReactElement {
+  return (
+    <Button
+      asChild
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="text-muted-foreground hover:text-foreground h-11 w-full justify-between gap-2 rounded-none font-normal md:h-10"
+    >
+      <Link href={href} data-testid={testId}>
+        <span className="flex min-w-0 items-center gap-2">
+          {icon}
+          <span className="truncate">{label}</span>
+        </span>
+        <ChevronRight className="size-4 shrink-0 opacity-60" aria-hidden />
+      </Link>
+    </Button>
+  );
+}
+
+export function MobileStackedMenuAction({
+  icon,
+  label,
+  testId,
+  onClick,
+  chevron = true,
+}: {
+  icon: ReactElement;
+  label: string;
+  testId: string;
+  onClick: () => void;
+  chevron?: boolean;
+}): ReactElement {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      className="text-muted-foreground hover:text-foreground h-11 w-full justify-between gap-2 rounded-none font-normal md:h-10"
+      data-testid={testId}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        {icon}
+        <span className="truncate">{label}</span>
+      </span>
+      {chevron ? (
+        <ChevronRight className="size-4 shrink-0 opacity-60" aria-hidden />
+      ) : null}
+    </Button>
+  );
+}

--- a/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.test.tsx
@@ -192,49 +192,23 @@ describe("YouPageClient", () => {
     );
   });
 
-  it("drills Developer inside the section while keeping credits and logout", () => {
+  it("opens Developer, Help, and Legal as stacked routes under You", () => {
     renderYouPage();
 
-    fireEvent.click(screen.getByTestId("you-developer"));
-
-    expect(screen.getByTestId("you-drill-section")).toBeInTheDocument();
-    expect(screen.getByTestId("you-drill-back")).toBeInTheDocument();
-    expect(screen.getByTestId("you-developer-docs")).toHaveAttribute(
+    expect(screen.getByTestId("you-developer")).toHaveAttribute(
       "href",
-      "/developer/docs",
+      "/you/developer",
     );
+    expect(screen.getByTestId("you-help")).toHaveAttribute("href", "/you/help");
+    expect(screen.getByTestId("you-legal")).toHaveAttribute(
+      "href",
+      "/you/legal",
+    );
+    expect(screen.queryByTestId("you-drill-section")).toBeNull();
+    expect(screen.queryByTestId("you-drill-back")).toBeNull();
     expect(screen.getByTestId("you-buy-credits")).toBeInTheDocument();
     expect(screen.getByTestId("you-logout")).toBeInTheDocument();
     expect(screen.getByTestId("you-files")).toBeInTheDocument();
-    expect(screen.queryByTestId("you-developer")).toBeNull();
-    expect(screen.queryByTestId("you-settings")).toBeNull();
-  });
-
-  it("returns to root drill triggers from a nested back control", () => {
-    renderYouPage();
-
-    fireEvent.click(screen.getByTestId("you-help"));
-    expect(screen.getByTestId("you-help-documentation")).toBeInTheDocument();
-    expect(screen.getByTestId("you-buy-credits")).toBeInTheDocument();
-    expect(screen.getByTestId("you-logout")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("you-drill-back"));
-
-    expect(screen.getByTestId("you-developer")).toBeInTheDocument();
-    expect(screen.getByTestId("you-help")).toBeInTheDocument();
-    expect(screen.getByTestId("you-legal")).toBeInTheDocument();
-    expect(screen.queryByTestId("you-help-documentation")).toBeNull();
-  });
-
-  it("drills Legal nested rows including cookie consent", () => {
-    renderYouPage();
-
-    fireEvent.click(screen.getByTestId("you-legal"));
-
-    expect(screen.getByTestId("you-legal-termsOfService")).toBeInTheDocument();
-    expect(screen.getByTestId("you-cookie-consent")).toBeInTheDocument();
-    expect(screen.getByTestId("you-buy-credits")).toBeInTheDocument();
-    expect(screen.getByTestId("you-logout")).toBeInTheDocument();
   });
 
   it("hides Admin when adminMenuEnabled is false", () => {

--- a/apps/web/src/app/(app)/you/components/you-page.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-page.client.tsx
@@ -3,28 +3,22 @@
 import { resolveAccountDisplayName, type SessionUser } from "@sokosumi/utils";
 import {
   Calendar,
-  ChevronLeft,
-  ChevronRight,
   Code2,
   Coins,
-  Cookie,
   HardDrive,
   LifeBuoy,
   LogOut,
   Scale,
   ShieldCheck,
 } from "lucide-react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type ReactElement, useState } from "react";
+import { type ReactElement } from "react";
 import {
-  getAccountNavItems,
-  HELP_LINKS,
-  type HelpLinkItem,
-  LEGAL_LINKS,
-  type LegalLinkItem,
-} from "@/app/components/sidebar/components/account-menu-config";
+  MobileStackedMenuGroup,
+  MobileStackedMenuLink,
+} from "@/app/components/mobile-stacked-menu/mobile-stacked-menu";
+import { getAccountNavItems } from "@/app/components/sidebar/components/account-menu-config";
 import {
   isLowCreditsBalance,
   resolveAccountCreditsLabel,
@@ -33,8 +27,11 @@ import type {
   AccountAdminSettingsChrome,
   AccountSummaryCreditProps,
 } from "@/app/components/sidebar/components/account-summary-types";
-import { getDeveloperNavItems } from "@/app/components/sidebar/components/developer-menu-config";
-import { openConsentPreferences } from "@/components/analytics/cookie-banner";
+import {
+  YOU_DEVELOPER_PATH,
+  YOU_HELP_PATH,
+  YOU_LEGAL_PATH,
+} from "@/app/you/you-submenu-paths";
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { useGlobalModalsContext } from "@/components/modals/global-modals-context";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -49,12 +46,6 @@ const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 const ADMIN_HREF = "/admin";
 const DRIVE_HREF = "/drive";
 const CALENDAR_HREF = "/calendar";
-
-type YouNavPanel =
-  | { kind: "root" }
-  | { kind: "developer" }
-  | { kind: "help" }
-  | { kind: "legal" };
 
 export interface YouPageClientProps extends AccountSummaryCreditProps {
   sessionUser: SessionUser;
@@ -82,13 +73,9 @@ export function YouPageClient({
   const tPresence = useTranslations("App.Channels.Presence");
   const tMenu = useTranslations("App.Sidebar.Content.MenuItems");
   const tYou = useTranslations("App.You.Metadata");
-  const tDeveloper = useTranslations("App.Developer.tabs");
-  const tConsent = useTranslations("CookieConsent");
   const { showLogoutModal } = useGlobalModalsContext();
   const router = useRouter();
   const presence = useSelfPresence();
-  const [panel, setPanel] = useState<YouNavPanel>({ kind: "root" });
-  const [slideFrom, setSlideFrom] = useState<"right" | "left" | null>(null);
 
   const displayName = resolveAccountDisplayName(
     sessionUser.name,
@@ -135,33 +122,11 @@ export function YouPageClient({
     showLogoutModal({ id: sessionUser.id, email: sessionUser.email });
   }
 
-  function handleNavigatePanel(next: YouNavPanel) {
-    setSlideFrom(next.kind === "root" ? "left" : "right");
-    setPanel(next);
-  }
-
-  function handleOpenExternal(url: string) {
-    if (url.startsWith("mailto:")) {
-      window.location.href = url;
-      return;
-    }
-    window.open(url, "_blank", "noopener,noreferrer");
-  }
-
   function getAccountItemLabel(translationKey: string): string {
     return tCredit(
       translationKey as "account" | "billing" | "connections" | "organization",
     );
   }
-
-  const drillTitle =
-    panel.kind === "developer"
-      ? tCredit("developer")
-      : panel.kind === "help"
-        ? tCredit("help")
-        : panel.kind === "legal"
-          ? tCredit("legal")
-          : null;
 
   return (
     <div
@@ -267,37 +232,37 @@ export function YouPageClient({
         </section>
 
         <nav aria-label={tYou("title")} className="space-y-6">
-          <YouMenuGroup>
+          <MobileStackedMenuGroup>
             {calendarMenuEnabled ? (
-              <YouMenuLink
+              <MobileStackedMenuLink
                 href={CALENDAR_HREF}
                 icon={<Calendar className="size-4 shrink-0" aria-hidden />}
                 label={tMenu("calendar")}
                 testId="you-schedules"
               />
             ) : null}
-            <YouMenuLink
+            <MobileStackedMenuLink
               href={DRIVE_HREF}
               icon={<HardDrive className="size-4 shrink-0" aria-hidden />}
               label={tMenu("drive")}
               testId="you-files"
             />
-          </YouMenuGroup>
+          </MobileStackedMenuGroup>
 
           {adminSettingsChrome.adminMenuEnabled ? (
-            <YouMenuGroup>
-              <YouMenuLink
+            <MobileStackedMenuGroup>
+              <MobileStackedMenuLink
                 href={ADMIN_HREF}
                 icon={<ShieldCheck className="size-4 shrink-0" aria-hidden />}
                 label={tMenu("admin")}
                 testId="you-admin"
               />
-            </YouMenuGroup>
+            </MobileStackedMenuGroup>
           ) : null}
 
-          <YouMenuGroup>
+          <MobileStackedMenuGroup>
             {accountNavItems.map(({ key, href, translationKey, Icon }) => (
-              <YouMenuLink
+              <MobileStackedMenuLink
                 key={key}
                 href={href}
                 icon={<Icon className="size-4 shrink-0" aria-hidden />}
@@ -305,123 +270,28 @@ export function YouPageClient({
                 testId={`you-${key}`}
               />
             ))}
-          </YouMenuGroup>
+          </MobileStackedMenuGroup>
 
-          <div
-            key={panel.kind}
-            data-testid="you-drill-section"
-            className={cn(
-              slideFrom !== null && "animate-in fade-in duration-200",
-              slideFrom === "right" && "slide-in-from-right-4",
-              slideFrom === "left" && "slide-in-from-left-4",
-            )}
-          >
-            <YouMenuGroup>
-              {panel.kind === "root" ? (
-                <>
-                  <YouMenuAction
-                    icon={<Code2 className="size-4 shrink-0" aria-hidden />}
-                    label={tCredit("developer")}
-                    testId="you-developer"
-                    onClick={() => handleNavigatePanel({ kind: "developer" })}
-                  />
-                  <YouMenuAction
-                    icon={<LifeBuoy className="size-4 shrink-0" aria-hidden />}
-                    label={tCredit("help")}
-                    testId="you-help"
-                    onClick={() => handleNavigatePanel({ kind: "help" })}
-                  />
-                  <YouMenuAction
-                    icon={<Scale className="size-4 shrink-0" aria-hidden />}
-                    label={tCredit("legal")}
-                    testId="you-legal"
-                    onClick={() => handleNavigatePanel({ kind: "legal" })}
-                  />
-                </>
-              ) : (
-                <>
-                  <YouMenuBack
-                    title={drillTitle ?? tMenu("back")}
-                    backLabel={tMenu("back")}
-                    testId="you-drill-back"
-                    onClick={() => handleNavigatePanel({ kind: "root" })}
-                  />
-                  {panel.kind === "developer"
-                    ? getDeveloperNavItems({
-                        showVendors: adminSettingsChrome.showDeveloperVendors,
-                      }).map(({ key, href, translationKey, Icon }) => (
-                        <YouMenuLink
-                          key={key}
-                          href={href}
-                          icon={
-                            <Icon className="size-4 shrink-0" aria-hidden />
-                          }
-                          label={tDeveloper(translationKey)}
-                          testId={`you-developer-${key}`}
-                        />
-                      ))
-                    : null}
-                  {panel.kind === "help"
-                    ? HELP_LINKS.map((item) => {
-                        const Icon = item.icon;
-                        return (
-                          <YouMenuAction
-                            key={item.translationKey}
-                            icon={
-                              Icon ? (
-                                <Icon className="size-4 shrink-0" aria-hidden />
-                              ) : (
-                                <span className="size-4 shrink-0" aria-hidden />
-                              )
-                            }
-                            label={tCredit(
-                              item.translationKey as HelpLinkItem["translationKey"],
-                            )}
-                            testId={`you-help-${item.translationKey}`}
-                            onClick={() => handleOpenExternal(item.url)}
-                            chevron={false}
-                          />
-                        );
-                      })
-                    : null}
-                  {panel.kind === "legal" ? (
-                    <>
-                      {LEGAL_LINKS.map((item) => {
-                        const Icon = item.icon;
-                        return (
-                          <YouMenuAction
-                            key={item.translationKey}
-                            icon={
-                              Icon ? (
-                                <Icon className="size-4 shrink-0" aria-hidden />
-                              ) : (
-                                <span className="size-4 shrink-0" aria-hidden />
-                              )
-                            }
-                            label={tCredit(
-                              item.translationKey as LegalLinkItem["translationKey"],
-                            )}
-                            testId={`you-legal-${item.translationKey}`}
-                            onClick={() => handleOpenExternal(item.url)}
-                            chevron={false}
-                          />
-                        );
-                      })}
-                      <YouMenuAction
-                        icon={
-                          <Cookie className="size-4 shrink-0" aria-hidden />
-                        }
-                        label={tConsent("settings")}
-                        testId="you-cookie-consent"
-                        onClick={openConsentPreferences}
-                        chevron={false}
-                      />
-                    </>
-                  ) : null}
-                </>
-              )}
-            </YouMenuGroup>
-          </div>
+          <MobileStackedMenuGroup>
+            <MobileStackedMenuLink
+              href={YOU_DEVELOPER_PATH}
+              icon={<Code2 className="size-4 shrink-0" aria-hidden />}
+              label={tCredit("developer")}
+              testId="you-developer"
+            />
+            <MobileStackedMenuLink
+              href={YOU_HELP_PATH}
+              icon={<LifeBuoy className="size-4 shrink-0" aria-hidden />}
+              label={tCredit("help")}
+              testId="you-help"
+            />
+            <MobileStackedMenuLink
+              href={YOU_LEGAL_PATH}
+              icon={<Scale className="size-4 shrink-0" aria-hidden />}
+              label={tCredit("legal")}
+              testId="you-legal"
+            />
+          </MobileStackedMenuGroup>
         </nav>
 
         <Button
@@ -456,103 +326,5 @@ function YouPageAvatar({
         {getInitials(displayName)}
       </AvatarFallback>
     </Avatar>
-  );
-}
-
-function YouMenuGroup({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="border-border bg-card-background divide-border divide-y overflow-hidden rounded-lg border">
-      {children}
-    </div>
-  );
-}
-
-function YouMenuLink({
-  href,
-  icon,
-  label,
-  testId,
-}: {
-  href: string;
-  icon: ReactElement;
-  label: string;
-  testId: string;
-}) {
-  return (
-    <Button
-      asChild
-      type="button"
-      variant="ghost"
-      size="sm"
-      className="text-muted-foreground hover:text-foreground h-11 w-full justify-between gap-2 rounded-none font-normal md:h-10"
-    >
-      <Link href={href} data-testid={testId}>
-        <span className="flex min-w-0 items-center gap-2">
-          {icon}
-          <span className="truncate">{label}</span>
-        </span>
-        <ChevronRight className="size-4 shrink-0 opacity-60" aria-hidden />
-      </Link>
-    </Button>
-  );
-}
-
-function YouMenuAction({
-  icon,
-  label,
-  testId,
-  onClick,
-  chevron = true,
-}: {
-  icon: ReactElement;
-  label: string;
-  testId: string;
-  onClick: () => void;
-  chevron?: boolean;
-}) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      onClick={onClick}
-      className="text-muted-foreground hover:text-foreground h-11 w-full justify-between gap-2 rounded-none font-normal md:h-10"
-      data-testid={testId}
-    >
-      <span className="flex min-w-0 items-center gap-2">
-        {icon}
-        <span className="truncate">{label}</span>
-      </span>
-      {chevron ? (
-        <ChevronRight className="size-4 shrink-0 opacity-60" aria-hidden />
-      ) : null}
-    </Button>
-  );
-}
-
-function YouMenuBack({
-  title,
-  backLabel,
-  testId,
-  onClick,
-}: {
-  title: string;
-  backLabel: string;
-  testId: string;
-  onClick: () => void;
-}) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      onClick={onClick}
-      className="text-muted-foreground hover:text-foreground h-11 w-full justify-start gap-2 rounded-none font-normal md:h-10"
-      data-testid={testId}
-      aria-label={backLabel}
-    >
-      <ChevronLeft className="size-4 shrink-0" aria-hidden />
-      <span className="truncate">{title}</span>
-    </Button>
   );
 }

--- a/apps/web/src/app/(app)/you/components/you-submenu-stack.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-submenu-stack.client.test.tsx
@@ -12,17 +12,19 @@ vi.mock("@/components/analytics/cookie-banner", () => ({
     openConsentPreferencesMock(...args),
 }));
 
-import { YouSubmenuStackClient } from "@/app/you/components/you-submenu-stack.client";
+import {
+  YouDeveloperStackClient,
+  YouHelpStackClient,
+  YouLegalStackClient,
+} from "@/app/you/components/you-submenu-stack.client";
 
-describe("YouSubmenuStackClient", () => {
+describe("You submenu stacked screens", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("lists developer destinations in the stacked menu surface", () => {
-    render(
-      <YouSubmenuStackClient kind="developer" showDeveloperVendors={false} />,
-    );
+    render(<YouDeveloperStackClient showDeveloperVendors={false} />);
 
     const screenRoot = screen.getByTestId("mobile-stacked-menu-screen");
     expect(screenRoot).toBeInTheDocument();
@@ -43,9 +45,7 @@ describe("YouSubmenuStackClient", () => {
   });
 
   it("shows gated developer vendors when enabled", () => {
-    render(
-      <YouSubmenuStackClient kind="developer" showDeveloperVendors={true} />,
-    );
+    render(<YouDeveloperStackClient showDeveloperVendors={true} />);
 
     expect(screen.getByTestId("you-developer-vendors")).toHaveAttribute(
       "href",
@@ -56,7 +56,7 @@ describe("YouSubmenuStackClient", () => {
   it("lists help actions that open shared help destinations", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
-    render(<YouSubmenuStackClient kind="help" showDeveloperVendors={false} />);
+    render(<YouHelpStackClient />);
 
     expect(screen.getByRole("heading", { name: "help" })).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("you-help-documentation"));
@@ -70,7 +70,7 @@ describe("YouSubmenuStackClient", () => {
   });
 
   it("lists legal links and cookie consent on the Legal stack", () => {
-    render(<YouSubmenuStackClient kind="legal" showDeveloperVendors={false} />);
+    render(<YouLegalStackClient />);
 
     expect(screen.getByRole("heading", { name: "legal" })).toBeInTheDocument();
     expect(screen.getByTestId("you-legal-termsOfService")).toBeInTheDocument();

--- a/apps/web/src/app/(app)/you/components/you-submenu-stack.client.test.tsx
+++ b/apps/web/src/app/(app)/you/components/you-submenu-stack.client.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const openConsentPreferencesMock = vi.fn();
+
+vi.mock("@/components/analytics/cookie-banner", () => ({
+  openConsentPreferences: (...args: unknown[]) =>
+    openConsentPreferencesMock(...args),
+}));
+
+import { YouSubmenuStackClient } from "@/app/you/components/you-submenu-stack.client";
+
+describe("YouSubmenuStackClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists developer destinations in the stacked menu surface", () => {
+    render(
+      <YouSubmenuStackClient kind="developer" showDeveloperVendors={false} />,
+    );
+
+    const screenRoot = screen.getByTestId("mobile-stacked-menu-screen");
+    expect(screenRoot).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "developer" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("you-developer-docs")).toHaveAttribute(
+      "href",
+      "/developer/docs",
+    );
+    expect(screen.getByTestId("you-developer-oauthClients")).toHaveAttribute(
+      "href",
+      "/developer/oauth-clients",
+    );
+    expect(screen.queryByTestId("you-developer-vendors")).toBeNull();
+    expect(screen.queryByTestId("you-buy-credits")).toBeNull();
+    expect(screen.queryByTestId("you-logout")).toBeNull();
+  });
+
+  it("shows gated developer vendors when enabled", () => {
+    render(
+      <YouSubmenuStackClient kind="developer" showDeveloperVendors={true} />,
+    );
+
+    expect(screen.getByTestId("you-developer-vendors")).toHaveAttribute(
+      "href",
+      "/developer/vendors",
+    );
+  });
+
+  it("lists help actions that open shared help destinations", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<YouSubmenuStackClient kind="help" showDeveloperVendors={false} />);
+
+    expect(screen.getByRole("heading", { name: "help" })).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("you-help-documentation"));
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://www.masumi.network/dev/sokosumi/documentation",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    openSpy.mockRestore();
+  });
+
+  it("lists legal links and cookie consent on the Legal stack", () => {
+    render(<YouSubmenuStackClient kind="legal" showDeveloperVendors={false} />);
+
+    expect(screen.getByRole("heading", { name: "legal" })).toBeInTheDocument();
+    expect(screen.getByTestId("you-legal-termsOfService")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("you-cookie-consent"));
+    expect(openConsentPreferencesMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/you/components/you-submenu-stack.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-submenu-stack.client.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Cookie } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { ReactElement } from "react";
+import {
+  MobileStackedMenuAction,
+  MobileStackedMenuGroup,
+  MobileStackedMenuLink,
+} from "@/app/components/mobile-stacked-menu/mobile-stacked-menu";
+import { MobileStackedMenuScreen } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-screen";
+import {
+  HELP_LINKS,
+  type HelpLinkItem,
+  LEGAL_LINKS,
+  type LegalLinkItem,
+} from "@/app/components/sidebar/components/account-menu-config";
+import { getDeveloperNavItems } from "@/app/components/sidebar/components/developer-menu-config";
+import type { YouSubmenuKind } from "@/app/you/you-submenu-paths";
+import { openConsentPreferences } from "@/components/analytics/cookie-banner";
+
+export interface YouSubmenuStackClientProps {
+  kind: YouSubmenuKind;
+  showDeveloperVendors?: boolean;
+}
+
+function openExternalUrl(url: string): void {
+  if (url.startsWith("mailto:")) {
+    window.location.href = url;
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+export function YouSubmenuStackClient({
+  kind,
+  showDeveloperVendors = false,
+}: YouSubmenuStackClientProps): ReactElement {
+  const tCredit = useTranslations("Components.UserAvatar");
+  const tDeveloper = useTranslations("App.Developer.tabs");
+  const tConsent = useTranslations("CookieConsent");
+
+  const title =
+    kind === "developer"
+      ? tCredit("developer")
+      : kind === "help"
+        ? tCredit("help")
+        : tCredit("legal");
+
+  return (
+    <MobileStackedMenuScreen title={title}>
+      <MobileStackedMenuGroup>
+        {kind === "developer"
+          ? getDeveloperNavItems({ showVendors: showDeveloperVendors }).map(
+              ({ key, href, translationKey, Icon }) => (
+                <MobileStackedMenuLink
+                  key={key}
+                  href={href}
+                  icon={<Icon className="size-4 shrink-0" aria-hidden />}
+                  label={tDeveloper(translationKey)}
+                  testId={`you-developer-${key}`}
+                />
+              ),
+            )
+          : null}
+        {kind === "help"
+          ? HELP_LINKS.map((item) => {
+              const Icon = item.icon;
+              return (
+                <MobileStackedMenuAction
+                  key={item.translationKey}
+                  icon={
+                    Icon ? (
+                      <Icon className="size-4 shrink-0" aria-hidden />
+                    ) : (
+                      <span className="size-4 shrink-0" aria-hidden />
+                    )
+                  }
+                  label={tCredit(
+                    item.translationKey as HelpLinkItem["translationKey"],
+                  )}
+                  testId={`you-help-${item.translationKey}`}
+                  onClick={() => openExternalUrl(item.url)}
+                  chevron={false}
+                />
+              );
+            })
+          : null}
+        {kind === "legal" ? (
+          <>
+            {LEGAL_LINKS.map((item) => {
+              const Icon = item.icon;
+              return (
+                <MobileStackedMenuAction
+                  key={item.translationKey}
+                  icon={
+                    Icon ? (
+                      <Icon className="size-4 shrink-0" aria-hidden />
+                    ) : (
+                      <span className="size-4 shrink-0" aria-hidden />
+                    )
+                  }
+                  label={tCredit(
+                    item.translationKey as LegalLinkItem["translationKey"],
+                  )}
+                  testId={`you-legal-${item.translationKey}`}
+                  onClick={() => openExternalUrl(item.url)}
+                  chevron={false}
+                />
+              );
+            })}
+            <MobileStackedMenuAction
+              icon={<Cookie className="size-4 shrink-0" aria-hidden />}
+              label={tConsent("settings")}
+              testId="you-cookie-consent"
+              onClick={openConsentPreferences}
+              chevron={false}
+            />
+          </>
+        ) : null}
+      </MobileStackedMenuGroup>
+    </MobileStackedMenuScreen>
+  );
+}

--- a/apps/web/src/app/(app)/you/components/you-submenu-stack.client.tsx
+++ b/apps/web/src/app/(app)/you/components/you-submenu-stack.client.tsx
@@ -16,13 +16,7 @@ import {
   type LegalLinkItem,
 } from "@/app/components/sidebar/components/account-menu-config";
 import { getDeveloperNavItems } from "@/app/components/sidebar/components/developer-menu-config";
-import type { YouSubmenuKind } from "@/app/you/you-submenu-paths";
 import { openConsentPreferences } from "@/components/analytics/cookie-banner";
-
-export interface YouSubmenuStackClientProps {
-  kind: YouSubmenuKind;
-  showDeveloperVendors?: boolean;
-}
 
 function openExternalUrl(url: string): void {
   if (url.startsWith("mailto:")) {
@@ -32,92 +26,100 @@ function openExternalUrl(url: string): void {
   window.open(url, "_blank", "noopener,noreferrer");
 }
 
-export function YouSubmenuStackClient({
-  kind,
+export function YouDeveloperStackClient({
   showDeveloperVendors = false,
-}: YouSubmenuStackClientProps): ReactElement {
+}: {
+  showDeveloperVendors?: boolean;
+}): ReactElement {
   const tCredit = useTranslations("Components.UserAvatar");
   const tDeveloper = useTranslations("App.Developer.tabs");
-  const tConsent = useTranslations("CookieConsent");
-
-  const title =
-    kind === "developer"
-      ? tCredit("developer")
-      : kind === "help"
-        ? tCredit("help")
-        : tCredit("legal");
 
   return (
-    <MobileStackedMenuScreen title={title}>
+    <MobileStackedMenuScreen title={tCredit("developer")}>
       <MobileStackedMenuGroup>
-        {kind === "developer"
-          ? getDeveloperNavItems({ showVendors: showDeveloperVendors }).map(
-              ({ key, href, translationKey, Icon }) => (
-                <MobileStackedMenuLink
-                  key={key}
-                  href={href}
-                  icon={<Icon className="size-4 shrink-0" aria-hidden />}
-                  label={tDeveloper(translationKey)}
-                  testId={`you-developer-${key}`}
-                />
-              ),
-            )
-          : null}
-        {kind === "help"
-          ? HELP_LINKS.map((item) => {
-              const Icon = item.icon;
-              return (
-                <MobileStackedMenuAction
-                  key={item.translationKey}
-                  icon={
-                    Icon ? (
-                      <Icon className="size-4 shrink-0" aria-hidden />
-                    ) : (
-                      <span className="size-4 shrink-0" aria-hidden />
-                    )
-                  }
-                  label={tCredit(
-                    item.translationKey as HelpLinkItem["translationKey"],
-                  )}
-                  testId={`you-help-${item.translationKey}`}
-                  onClick={() => openExternalUrl(item.url)}
-                  chevron={false}
-                />
-              );
-            })
-          : null}
-        {kind === "legal" ? (
-          <>
-            {LEGAL_LINKS.map((item) => {
-              const Icon = item.icon;
-              return (
-                <MobileStackedMenuAction
-                  key={item.translationKey}
-                  icon={
-                    Icon ? (
-                      <Icon className="size-4 shrink-0" aria-hidden />
-                    ) : (
-                      <span className="size-4 shrink-0" aria-hidden />
-                    )
-                  }
-                  label={tCredit(
-                    item.translationKey as LegalLinkItem["translationKey"],
-                  )}
-                  testId={`you-legal-${item.translationKey}`}
-                  onClick={() => openExternalUrl(item.url)}
-                  chevron={false}
-                />
-              );
-            })}
+        {getDeveloperNavItems({ showVendors: showDeveloperVendors }).map(
+          ({ key, href, translationKey, Icon }) => (
+            <MobileStackedMenuLink
+              key={key}
+              href={href}
+              icon={<Icon className="size-4 shrink-0" aria-hidden />}
+              label={tDeveloper(translationKey)}
+              testId={`you-developer-${key}`}
+            />
+          ),
+        )}
+      </MobileStackedMenuGroup>
+    </MobileStackedMenuScreen>
+  );
+}
+
+export function YouHelpStackClient(): ReactElement {
+  const tCredit = useTranslations("Components.UserAvatar");
+
+  return (
+    <MobileStackedMenuScreen title={tCredit("help")}>
+      <MobileStackedMenuGroup>
+        {HELP_LINKS.map((item) => {
+          const Icon = item.icon;
+          return (
             <MobileStackedMenuAction
-              icon={<Cookie className="size-4 shrink-0" aria-hidden />}
-              label={tConsent("settings")}
-              testId="you-cookie-consent"
-              onClick={openConsentPreferences}
+              key={item.translationKey}
+              icon={
+                Icon ? (
+                  <Icon className="size-4 shrink-0" aria-hidden />
+                ) : (
+                  <span className="size-4 shrink-0" aria-hidden />
+                )
+              }
+              label={tCredit(
+                item.translationKey as HelpLinkItem["translationKey"],
+              )}
+              testId={`you-help-${item.translationKey}`}
+              onClick={() => openExternalUrl(item.url)}
               chevron={false}
             />
-          </>
-        ) : null}
+          );
+        })}
+      </MobileStackedMenuGroup>
+    </MobileStackedMenuScreen>
+  );
+}
+
+export function YouLegalStackClient(): ReactElement {
+  const tCredit = useTranslations("Components.UserAvatar");
+  const tConsent = useTranslations("CookieConsent");
+
+  return (
+    <MobileStackedMenuScreen title={tCredit("legal")}>
+      <MobileStackedMenuGroup>
+        {LEGAL_LINKS.map((item) => {
+          const Icon = item.icon;
+          return (
+            <MobileStackedMenuAction
+              key={item.translationKey}
+              icon={
+                Icon ? (
+                  <Icon className="size-4 shrink-0" aria-hidden />
+                ) : (
+                  <span className="size-4 shrink-0" aria-hidden />
+                )
+              }
+              label={tCredit(
+                item.translationKey as LegalLinkItem["translationKey"],
+              )}
+              testId={`you-legal-${item.translationKey}`}
+              onClick={() => openExternalUrl(item.url)}
+              chevron={false}
+            />
+          );
+        })}
+        <MobileStackedMenuAction
+          icon={<Cookie className="size-4 shrink-0" aria-hidden />}
+          label={tConsent("settings")}
+          testId="you-cookie-consent"
+          onClick={openConsentPreferences}
+          chevron={false}
+        />
       </MobileStackedMenuGroup>
     </MobileStackedMenuScreen>
   );

--- a/apps/web/src/app/(app)/you/developer/loading.tsx
+++ b/apps/web/src/app/(app)/you/developer/loading.tsx
@@ -1,0 +1,6 @@
+import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function YouDeveloperLoading() {
+  return <MobileStackedMenuSkeleton />;
+}

--- a/apps/web/src/app/(app)/you/developer/page.tsx
+++ b/apps/web/src/app/(app)/you/developer/page.tsx
@@ -4,7 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
 import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
-import { YouSubmenuStackClient } from "@/app/you/components/you-submenu-stack.client";
+import { YouDeveloperStackClient } from "@/app/you/components/you-submenu-stack.client";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("Components.UserAvatar");
@@ -19,10 +19,7 @@ async function YouDeveloperContent() {
     await getDeveloperVendorAdminAccess();
 
   return (
-    <YouSubmenuStackClient
-      kind="developer"
-      showDeveloperVendors={showDeveloperVendors}
-    />
+    <YouDeveloperStackClient showDeveloperVendors={showDeveloperVendors} />
   );
 }
 

--- a/apps/web/src/app/(app)/you/developer/page.tsx
+++ b/apps/web/src/app/(app)/you/developer/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+import { connection } from "next/server";
+import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
+import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
+import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
+import { YouSubmenuStackClient } from "@/app/you/components/you-submenu-stack.client";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("Components.UserAvatar");
+
+  return {
+    title: t("developer"),
+  };
+}
+
+async function YouDeveloperContent() {
+  const { showVendors: showDeveloperVendors } =
+    await getDeveloperVendorAdminAccess();
+
+  return (
+    <YouSubmenuStackClient
+      kind="developer"
+      showDeveloperVendors={showDeveloperVendors}
+    />
+  );
+}
+
+export default async function YouDeveloperPage() {
+  await connection();
+
+  return (
+    <Suspense fallback={<MobileStackedMenuSkeleton />}>
+      <YouDeveloperContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/(app)/you/help/loading.tsx
+++ b/apps/web/src/app/(app)/you/help/loading.tsx
@@ -1,0 +1,6 @@
+import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function YouHelpLoading() {
+  return <MobileStackedMenuSkeleton />;
+}

--- a/apps/web/src/app/(app)/you/help/page.tsx
+++ b/apps/web/src/app/(app)/you/help/page.tsx
@@ -3,7 +3,7 @@ import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
-import { YouSubmenuStackClient } from "@/app/you/components/you-submenu-stack.client";
+import { YouHelpStackClient } from "@/app/you/components/you-submenu-stack.client";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("Components.UserAvatar");
@@ -18,7 +18,7 @@ export default async function YouHelpPage() {
 
   return (
     <Suspense fallback={<MobileStackedMenuSkeleton />}>
-      <YouSubmenuStackClient kind="help" />
+      <YouHelpStackClient />
     </Suspense>
   );
 }

--- a/apps/web/src/app/(app)/you/help/page.tsx
+++ b/apps/web/src/app/(app)/you/help/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { connection } from "next/server";
+import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
+import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
+import { YouSubmenuStackClient } from "@/app/you/components/you-submenu-stack.client";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("Components.UserAvatar");
+
+  return {
+    title: t("help"),
+  };
+}
+
+export default async function YouHelpPage() {
+  await connection();
+
+  return (
+    <Suspense fallback={<MobileStackedMenuSkeleton />}>
+      <YouSubmenuStackClient kind="help" />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/(app)/you/legal/loading.tsx
+++ b/apps/web/src/app/(app)/you/legal/loading.tsx
@@ -1,0 +1,6 @@
+import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function YouLegalLoading() {
+  return <MobileStackedMenuSkeleton />;
+}

--- a/apps/web/src/app/(app)/you/legal/page.tsx
+++ b/apps/web/src/app/(app)/you/legal/page.tsx
@@ -3,7 +3,7 @@ import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
-import { YouSubmenuStackClient } from "@/app/you/components/you-submenu-stack.client";
+import { YouLegalStackClient } from "@/app/you/components/you-submenu-stack.client";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("Components.UserAvatar");
@@ -18,7 +18,7 @@ export default async function YouLegalPage() {
 
   return (
     <Suspense fallback={<MobileStackedMenuSkeleton />}>
-      <YouSubmenuStackClient kind="legal" />
+      <YouLegalStackClient />
     </Suspense>
   );
 }

--- a/apps/web/src/app/(app)/you/legal/page.tsx
+++ b/apps/web/src/app/(app)/you/legal/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { connection } from "next/server";
+import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
+import { MobileStackedMenuSkeleton } from "@/app/components/mobile-stacked-menu/mobile-stacked-menu-skeleton";
+import { YouSubmenuStackClient } from "@/app/you/components/you-submenu-stack.client";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("Components.UserAvatar");
+
+  return {
+    title: t("legal"),
+  };
+}
+
+export default async function YouLegalPage() {
+  await connection();
+
+  return (
+    <Suspense fallback={<MobileStackedMenuSkeleton />}>
+      <YouSubmenuStackClient kind="legal" />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/(app)/you/you-submenu-paths.ts
+++ b/apps/web/src/app/(app)/you/you-submenu-paths.ts
@@ -2,5 +2,3 @@
 export const YOU_DEVELOPER_PATH = "/you/developer";
 export const YOU_HELP_PATH = "/you/help";
 export const YOU_LEGAL_PATH = "/you/legal";
-
-export type YouSubmenuKind = "developer" | "help" | "legal";

--- a/apps/web/src/app/(app)/you/you-submenu-paths.ts
+++ b/apps/web/src/app/(app)/you/you-submenu-paths.ts
@@ -1,0 +1,6 @@
+/** Intermediate You submenu stacks (mobile App Shell nested list routes). */
+export const YOU_DEVELOPER_PATH = "/you/developer";
+export const YOU_HELP_PATH = "/you/help";
+export const YOU_LEGAL_PATH = "/you/legal";
+
+export type YouSubmenuKind = "developer" | "help" | "legal";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- On mobile You, Developer / Help / Legal open as nested `/you/*` stacked list screens instead of in-page drills.
- Adds a reusable `MobileStackedMenu*` surface (group / link / action + screen + Instant loading skeleton) for App Shell intermediate menus.
- Explicit `YouDeveloperStackClient` / `YouHelpStackClient` / `YouLegalStackClient` variants compose that surface.
- Intermediate stacks inherit existing list-root chrome: header back → `/you`, bottom tab bar hidden; leaf routes outside You keep today’s return chrome.
- Desktop account popover drills are unchanged.

Closes SOK-959 (parent SOK-923).

## Verification

- Targeted Vitest: You page, You submenu stacks, mobile App Shell chrome, header leading, Instant Nav contracts — 73 passed
- `pnpm check` / `pnpm typecheck` (pre-commit)
- CI green on head; Bugbot High = 0

## Manual UI

Blocked in this Cloud VM: `NEON_API_KEY` / `NEON_PROJECT_ID` unset (no agent DB / Alice fixtures), `VERIFY_SOKOSUMI_*` unset, no local Postgres. Automated seam tests cover stack outcomes and chrome.

[Unit test evidence](https://cursor.com/agents/bc-314a9c96-29c8-4e25-ab4a-79679899fef7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-959-unit-tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-314a9c96-29c8-4e25-ab4a-79679899fef7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-314a9c96-29c8-4e25-ab4a-79679899fef7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated Developer, Help, and Legal pages under the You section.
  - Added mobile stacked-menu navigation with grouped links, actions, and loading skeletons.
  - Added localized metadata and configured links for developer tools, help resources, legal information, and cookie settings.
  - Added mobile back navigation from submenu pages to the You section.

- **Bug Fixes**
  - Updated mobile navigation chrome so submenu pages display the appropriate controls and hide unrelated navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->