### PR TITLE
fix(core): clean auto-generated task titles

### DIFF
--- a/apps/core/src/clients/openrouter.client.test.ts
+++ b/apps/core/src/clients/openrouter.client.test.ts
@@ -73,6 +73,24 @@ describe("openrouter.client", () => {
     expect(generateTextMock).toHaveBeenCalledOnce();
   });
 
+  it("caps task description length and asks for a plain-language name", async () => {
+    generateTextMock.mockResolvedValue({ text: "Launch page teardown" });
+
+    const { openrouterClient } = await import("./openrouter.client");
+
+    const name = await openrouterClient.generateTaskName(
+      `${"A".repeat(1200)}\n# Heading dump`,
+    );
+
+    expect(name).toBe("Launch page teardown");
+    const call = generateTextMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(call.prompt).toBe(`Task Description: ${"A".repeat(1000)}`);
+    expect(call.temperature).toBe(0.5);
+    expect(call.instructions).toEqual(
+      expect.stringContaining("Do NOT: use markdown"),
+    );
+  });
+
   it("returns null without calling generateText when OpenRouter is not configured", async () => {
     getEnvMock.mockReturnValue({});
 

--- a/apps/core/src/clients/openrouter.client.ts
+++ b/apps/core/src/clients/openrouter.client.ts
@@ -95,20 +95,25 @@ export const openrouterClient = (() => {
         return null;
       }
 
+      const trimmed = description.trim().slice(0, 1000);
+      if (!trimmed) {
+        return null;
+      }
+
       const instructions = `Generate a concise task name following these rules:
         - Length: 30-60 characters (including spaces and punctuation)
         - Language: Match the input
-        - Format: Single sentence
-        - Output: Name only, no other text
-        - Do NOT: include end of sentence punctuation
+        - Format: Short plain-language label, not a snippet of the document
+        - Output: Name only, no quotes, no other text
+        - Do NOT: use markdown, copy headings or the description, include refusal text, include end of sentence punctuation
       `;
-      const userPrompt = `Task Description: ${description}`;
+      const userPrompt = `Task Description: ${trimmed}`;
 
       return generateOpenRouterText(defaultOpenrouter, {
         abortSignal: AbortSignal.timeout(NAME_GENERATION_TIMEOUT_MS),
         instructions,
         prompt: userPrompt,
-        temperature: 0.9,
+        temperature: 0.5,
         maxOutputTokens: 40,
         failureLogLabel: "task name generation",
       });

--- a/apps/core/src/helpers/task-name.test.ts
+++ b/apps/core/src/helpers/task-name.test.ts
@@ -216,6 +216,52 @@ describe("resolveTaskName", () => {
     ).toBe("Write the launch email");
   });
 
+  it("does not treat a backtick fence inside a tilde fence as a close", async () => {
+    generateTaskNameMock.mockResolvedValue(null);
+    expect(
+      await resolveTaskName({
+        description: [
+          "~~~",
+          "const leaked = 1;",
+          "```",
+          'console.log("still inside");',
+          "~~~",
+          "Write the launch email",
+        ].join("\n"),
+      }),
+    ).toBe("Write the launch email");
+  });
+
+  it("does not close a longer fence with a shorter marker of the same delimiter", async () => {
+    generateTaskNameMock.mockResolvedValue(null);
+    expect(
+      await resolveTaskName({
+        description: [
+          "````",
+          "not the title",
+          "```",
+          "still inside",
+          "````",
+          "Write the launch email",
+        ].join("\n"),
+      }),
+    ).toBe("Write the launch email");
+  });
+
+  it("closes a fence with a longer marker of the same delimiter", async () => {
+    generateTaskNameMock.mockResolvedValue(null);
+    expect(
+      await resolveTaskName({
+        description: [
+          "```",
+          "not the title",
+          "````",
+          "Write the launch email",
+        ].join("\n"),
+      }),
+    ).toBe("Write the launch email");
+  });
+
   it("keeps a hash that is part of ordinary generated text", async () => {
     generateTaskNameMock.mockResolvedValue("Upgrade C# API");
     expect(await resolveTaskName({ description: "Upgrade the C# API" })).toBe(

--- a/apps/core/src/helpers/task-name.test.ts
+++ b/apps/core/src/helpers/task-name.test.ts
@@ -166,6 +166,17 @@ describe("resolveTaskName", () => {
     ).toBe("Landing page competitor teardown");
   });
 
+  it("rejects a numbered outline concatenated after a label", async () => {
+    generateTaskNameMock.mockResolvedValue(
+      "Marketing Deliverables: Current Market Rates 1. LANDING PAGE BRIEF 2. Freelance Rates",
+    );
+    expect(
+      await resolveTaskName({
+        description: "Landing page competitor teardown",
+      }),
+    ).toBe("Landing page competitor teardown");
+  });
+
   it("uses fallback when generation is empty or whitespace", async () => {
     generateTaskNameMock.mockResolvedValue("   ");
     expect(

--- a/apps/core/src/helpers/task-name.test.ts
+++ b/apps/core/src/helpers/task-name.test.ts
@@ -27,12 +27,31 @@ describe("resolveTaskName", () => {
     expect(await resolveTaskName({ name: long, description: null })).toBe(long);
   });
 
+  it("keeps markdown a user typed into the name field", async () => {
+    expect(
+      await resolveTaskName({
+        name: "# Keep this heading",
+        description: "x",
+      }),
+    ).toBe("# Keep this heading");
+    expect(generateTaskNameMock).not.toHaveBeenCalled();
+  });
+
   it("generates from the description when no name is provided", async () => {
     generateTaskNameMock.mockResolvedValue("Generated name");
     expect(await resolveTaskName({ description: "Build landing page" })).toBe(
       "Generated name",
     );
     expect(generateTaskNameMock).toHaveBeenCalledWith("Build landing page");
+  });
+
+  it("stores a good generated name after cleanup", async () => {
+    generateTaskNameMock.mockResolvedValue(
+      '"Landing page competitor teardown."',
+    );
+    expect(
+      await resolveTaskName({ description: "Teardown the homepage" }),
+    ).toBe("Landing page competitor teardown");
   });
 
   it("strips DESIGN.md links before naming", async () => {
@@ -59,6 +78,19 @@ describe("resolveTaskName", () => {
     ).toBe("Draft the LinkedIn launch post");
   });
 
+  it("returns Untitled Task when the description is only attachment links", async () => {
+    expect(
+      await resolveTaskName({
+        description: [
+          "[DESIGN.md](https://blob.example/design.md)",
+          "[BRIEFING.md](https://blob.example/projects/p1/BRIEFING.md)",
+          "[CONTEXT.md](https://blob.example/projects/p1/CONTEXT.md)",
+        ].join("\n"),
+      }),
+    ).toBe("Untitled Task");
+    expect(generateTaskNameMock).not.toHaveBeenCalled();
+  });
+
   it("falls back to the first non-empty line when generation returns null", async () => {
     generateTaskNameMock.mockResolvedValue(null);
     expect(await resolveTaskName({ description: "First line\nsecond" })).toBe(
@@ -66,13 +98,101 @@ describe("resolveTaskName", () => {
     );
   });
 
+  it("cleans a heading first line when generation is missing", async () => {
+    generateTaskNameMock.mockResolvedValue(null);
+    expect(
+      await resolveTaskName({
+        description: "# Marketing Deliverables: Current Market Rates\nBody",
+      }),
+    ).toBe("Marketing Deliverables: Current Market Rates");
+  });
+
   it("returns 'Untitled Task' when there is no naming source", async () => {
     expect(await resolveTaskName({ description: "   " })).toBe("Untitled Task");
     expect(generateTaskNameMock).not.toHaveBeenCalled();
   });
 
-  it("preserves a generated name longer than 120 characters", async () => {
+  it("caps an auto-generated name at 60 characters", async () => {
     generateTaskNameMock.mockResolvedValue("B".repeat(200));
-    expect(await resolveTaskName({ description: "x" })).toBe("B".repeat(200));
+    expect(await resolveTaskName({ description: "x" })).toBe("B".repeat(60));
+  });
+
+  it("caps first-line fallback at 60 characters", async () => {
+    generateTaskNameMock.mockResolvedValue(null);
+    expect(await resolveTaskName({ description: "C".repeat(80) })).toBe(
+      "C".repeat(60),
+    );
+  });
+
+  it("rejects a heading dump and uses the cleaned first line", async () => {
+    generateTaskNameMock.mockResolvedValue(
+      "# Marketing Deliverables: Current Market Rates ## 1. LANDING PAGE BRIEF (Competitor Teardown + Structure + Copy Direction) ### Freelance Rates",
+    );
+    expect(
+      await resolveTaskName({
+        description:
+          "# Marketing Deliverables: Current Market Rates\n## 1. LANDING PAGE BRIEF",
+      }),
+    ).toBe("Marketing Deliverables: Current Market Rates");
+  });
+
+  it("rejects refusal-like generated text and uses fallback", async () => {
+    generateTaskNameMock.mockResolvedValue(
+      "# Answer Engine Optimization Keyword Research Report ## Keyword Analysis Summary I need to be transparent: I cannot actually pull live keyword data",
+    );
+    expect(
+      await resolveTaskName({
+        description:
+          "# Answer Engine Optimization Keyword Research Report\nI cannot actually pull live keyword data",
+      }),
+    ).toBe("Answer Engine Optimization Keyword Research Report");
+  });
+
+  it("rejects Unable to generated text and uses fallback", async () => {
+    generateTaskNameMock.mockResolvedValue("Unable to summarize this brief");
+    expect(
+      await resolveTaskName({ description: "Write the pricing one-pager" }),
+    ).toBe("Write the pricing one-pager");
+  });
+
+  it("rejects a concatenated numbered outline and uses fallback", async () => {
+    generateTaskNameMock.mockResolvedValue(
+      "1. LANDING PAGE BRIEF 2. Freelance Rates 3. Copy Direction",
+    );
+    expect(
+      await resolveTaskName({
+        description: "Landing page competitor teardown\n1. rates",
+      }),
+    ).toBe("Landing page competitor teardown");
+  });
+
+  it("uses fallback when generation is empty or whitespace", async () => {
+    generateTaskNameMock.mockResolvedValue("   ");
+    expect(
+      await resolveTaskName({ description: "Ship the onboarding checklist" }),
+    ).toBe("Ship the onboarding checklist");
+  });
+
+  it("strips HTML, markdown tokens, and wrapping quotes from auto-names", async () => {
+    generateTaskNameMock.mockResolvedValue("<b>Launch</b> `plan` *draft*");
+    expect(await resolveTaskName({ description: "Launch plan" })).toBe(
+      "Launch plan draft",
+    );
+  });
+
+  it("keeps emoji in a short clean generated name", async () => {
+    generateTaskNameMock.mockResolvedValue("🚀 Launch campaign");
+    expect(await resolveTaskName({ description: "Launch the campaign" })).toBe(
+      "🚀 Launch campaign",
+    );
+  });
+
+  it("omits fence markers when the description starts with a code fence", async () => {
+    generateTaskNameMock.mockResolvedValue(null);
+    expect(
+      await resolveTaskName({
+        description: "```markdown\n# Notes\n```\nWrite the launch email",
+      }),
+    ).toBe("Write the launch email");
   });
 });

--- a/apps/core/src/helpers/task-name.test.ts
+++ b/apps/core/src/helpers/task-name.test.ts
@@ -206,4 +206,43 @@ describe("resolveTaskName", () => {
       }),
     ).toBe("Write the launch email");
   });
+
+  it("omits tilde fence markers when the description starts with a tilde fence", async () => {
+    generateTaskNameMock.mockResolvedValue(null);
+    expect(
+      await resolveTaskName({
+        description: "~~~markdown\n# Notes\n~~~\nWrite the launch email",
+      }),
+    ).toBe("Write the launch email");
+  });
+
+  it("keeps a hash that is part of ordinary generated text", async () => {
+    generateTaskNameMock.mockResolvedValue("Upgrade C# API");
+    expect(await resolveTaskName({ description: "Upgrade the C# API" })).toBe(
+      "Upgrade C# API",
+    );
+  });
+
+  it("uses a markdown link label as the generated name", async () => {
+    generateTaskNameMock.mockResolvedValue(
+      "[Launch plan](https://example.com)",
+    );
+    expect(await resolveTaskName({ description: "Launch plan" })).toBe(
+      "Launch plan",
+    );
+  });
+
+  it("unwraps wrapping emphasis instead of leaving markdown markers", async () => {
+    generateTaskNameMock.mockResolvedValue("_Launch plan_");
+    expect(await resolveTaskName({ description: "Launch plan" })).toBe(
+      "Launch plan",
+    );
+  });
+
+  it("does not split a trailing emoji when capping at 60 characters", async () => {
+    generateTaskNameMock.mockResolvedValue(`${"A".repeat(59)}🚀`);
+    expect(await resolveTaskName({ description: "x" })).toBe(
+      `${"A".repeat(59)}🚀`,
+    );
+  });
 });

--- a/apps/core/src/helpers/task-name.ts
+++ b/apps/core/src/helpers/task-name.ts
@@ -2,12 +2,74 @@ import { removeTaskContextAttachmentLinks } from "@sokosumi/utils";
 
 import { openrouterClient } from "@/clients/openrouter.client";
 
-const TASK_FALLBACK_NAME_MAX_LENGTH = 60;
+const TASK_AUTO_NAME_MAX_LENGTH = 60;
 const UNTITLED_TASK_NAME = "Untitled Task";
+const HTML_TAG_REGEX = /<[^>]*>/g;
+const CODE_FENCE_BLOCK_REGEX = /```[\s\S]*?```/g;
+const FENCE_LINE_REGEX = /^\s*```/;
+const HEADING_MARKER_REGEX = /^#{1,6}\s+/gm;
+const MARKDOWN_TOKEN_REGEX = /[#*`>~]/g;
+const WRAPPING_QUOTES_REGEX = /^["'“”‘’«»]+|["'“”‘’«»]+$/g;
+const TRAILING_PERIODS_REGEX = /\.+$/u;
+const REFUSAL_REGEX = /\b(?:i cannot|unable to|i need to be transparent)\b/i;
+const DUMP_REGEX = /^\s*#|##|```|[\n\r]|^\d+\.\s.+\s\d+\.\s/;
+
+function stripHtmlTags(text: string): string {
+  let current = text;
+  let previous: string;
+  do {
+    previous = current;
+    current = current.replace(HTML_TAG_REGEX, "");
+  } while (current !== previous);
+  return current;
+}
+
+function cleanAutoName(text: string): string {
+  const cleaned = stripHtmlTags(text)
+    .replace(CODE_FENCE_BLOCK_REGEX, " ")
+    .replace(HEADING_MARKER_REGEX, "")
+    .replace(/`+/g, "")
+    .replace(MARKDOWN_TOKEN_REGEX, "")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(WRAPPING_QUOTES_REGEX, "")
+    .trim()
+    .replace(TRAILING_PERIODS_REGEX, "")
+    .trim();
+
+  return cleaned.slice(0, TASK_AUTO_NAME_MAX_LENGTH).trim();
+}
+
+function isRejectedGeneratedName(raw: string, cleaned: string): boolean {
+  if (!cleaned) {
+    return true;
+  }
+  if (REFUSAL_REGEX.test(raw) || REFUSAL_REGEX.test(cleaned)) {
+    return true;
+  }
+  if (DUMP_REGEX.test(raw)) {
+    return true;
+  }
+  return /[#*`]/.test(cleaned);
+}
 
 function fallbackTaskName(source: string): string {
-  const firstLine = source.split("\n").find((line) => line.trim());
-  return (firstLine ?? "").trim().slice(0, TASK_FALLBACK_NAME_MAX_LENGTH);
+  let inFence = false;
+  for (const line of source.split("\n")) {
+    if (FENCE_LINE_REGEX.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || !line.trim()) {
+      continue;
+    }
+    const cleaned = cleanAutoName(line);
+    if (cleaned) {
+      return cleaned;
+    }
+  }
+  return "";
 }
 
 export async function resolveTaskName(input: {
@@ -29,6 +91,12 @@ export async function resolveTaskName(input: {
   const generated = (
     await openrouterClient.generateTaskName(namingSource)
   )?.trim();
-  const candidate = generated || fallbackTaskName(namingSource);
-  return candidate || UNTITLED_TASK_NAME;
+  if (generated) {
+    const cleaned = cleanAutoName(generated);
+    if (!isRejectedGeneratedName(generated, cleaned)) {
+      return cleaned;
+    }
+  }
+
+  return fallbackTaskName(namingSource) || UNTITLED_TASK_NAME;
 }

--- a/apps/core/src/helpers/task-name.ts
+++ b/apps/core/src/helpers/task-name.ts
@@ -1,14 +1,18 @@
-import { removeTaskContextAttachmentLinks } from "@sokosumi/utils";
+import {
+  removeTaskContextAttachmentLinks,
+  replaceMarkdownLinks,
+} from "@sokosumi/utils";
 
 import { openrouterClient } from "@/clients/openrouter.client";
 
 const TASK_AUTO_NAME_MAX_LENGTH = 60;
 const UNTITLED_TASK_NAME = "Untitled Task";
 const HTML_TAG_REGEX = /<[^>]*>/g;
-const CODE_FENCE_BLOCK_REGEX = /```[\s\S]*?```/g;
-const FENCE_LINE_REGEX = /^\s*```/;
+const CODE_FENCE_BLOCK_REGEX = /(`{3,}|~{3,})[\s\S]*?\1/g;
+const FENCE_LINE_REGEX = /^\s*(`{3,}|~{3,})/;
 const HEADING_MARKER_REGEX = /^#{1,6}\s+/gm;
-const MARKDOWN_TOKEN_REGEX = /[#*`>~]/g;
+const BLOCKQUOTE_PREFIX_REGEX = /^>\s?/gm;
+const INLINE_CODE_REGEX = /`([^`]+)`/g;
 const WRAPPING_QUOTES_REGEX = /^["'“”‘’«»]+|["'“”‘’«»]+$/g;
 const TRAILING_PERIODS_REGEX = /\.+$/u;
 const REFUSAL_REGEX = /\b(?:i cannot|unable to|i need to be transparent)\b/i;
@@ -24,11 +28,22 @@ function stripHtmlTags(text: string): string {
   return current;
 }
 
+function unwrapEmphasis(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/__(.+?)__/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/^_(.+)_$/s, "$1");
+}
+
 function cleanAutoName(text: string): string {
-  const cleaned = stripHtmlTags(text)
-    .replace(CODE_FENCE_BLOCK_REGEX, " ")
-    .replace(HEADING_MARKER_REGEX, "")
-    .replace(MARKDOWN_TOKEN_REGEX, "")
+  const cleaned = unwrapEmphasis(
+    stripHtmlTags(replaceMarkdownLinks(text, (link) => link.text))
+      .replace(CODE_FENCE_BLOCK_REGEX, " ")
+      .replace(HEADING_MARKER_REGEX, "")
+      .replace(BLOCKQUOTE_PREFIX_REGEX, "")
+      .replace(INLINE_CODE_REGEX, "$1"),
+  )
     .replace(/[\r\n]+/g, " ")
     .replace(/\s+/g, " ")
     .trim()
@@ -37,7 +52,7 @@ function cleanAutoName(text: string): string {
     .replace(TRAILING_PERIODS_REGEX, "")
     .trim();
 
-  return cleaned.slice(0, TASK_AUTO_NAME_MAX_LENGTH).trim();
+  return [...cleaned].slice(0, TASK_AUTO_NAME_MAX_LENGTH).join("").trim();
 }
 
 function isRejectedGeneratedName(raw: string, cleaned: string): boolean {

--- a/apps/core/src/helpers/task-name.ts
+++ b/apps/core/src/helpers/task-name.ts
@@ -12,7 +12,7 @@ const MARKDOWN_TOKEN_REGEX = /[#*`>~]/g;
 const WRAPPING_QUOTES_REGEX = /^["'“”‘’«»]+|["'“”‘’«»]+$/g;
 const TRAILING_PERIODS_REGEX = /\.+$/u;
 const REFUSAL_REGEX = /\b(?:i cannot|unable to|i need to be transparent)\b/i;
-const DUMP_REGEX = /^\s*#|##|```|[\n\r]|^\d+\.\s.+\s\d+\.\s/;
+const DUMP_REGEX = /^\s*#|##|```|[\n\r]|(?:^|\s)\d+\.\s.+\s\d+\.\s/;
 
 function stripHtmlTags(text: string): string {
   let current = text;
@@ -28,7 +28,6 @@ function cleanAutoName(text: string): string {
   const cleaned = stripHtmlTags(text)
     .replace(CODE_FENCE_BLOCK_REGEX, " ")
     .replace(HEADING_MARKER_REGEX, "")
-    .replace(/`+/g, "")
     .replace(MARKDOWN_TOKEN_REGEX, "")
     .replace(/[\r\n]+/g, " ")
     .replace(/\s+/g, " ")
@@ -48,10 +47,7 @@ function isRejectedGeneratedName(raw: string, cleaned: string): boolean {
   if (REFUSAL_REGEX.test(raw) || REFUSAL_REGEX.test(cleaned)) {
     return true;
   }
-  if (DUMP_REGEX.test(raw)) {
-    return true;
-  }
-  return /[#*`]/.test(cleaned);
+  return DUMP_REGEX.test(raw);
 }
 
 function fallbackTaskName(source: string): string {

--- a/apps/core/src/helpers/task-name.ts
+++ b/apps/core/src/helpers/task-name.ts
@@ -66,13 +66,22 @@ function isRejectedGeneratedName(raw: string, cleaned: string): boolean {
 }
 
 function fallbackTaskName(source: string): string {
-  let inFence = false;
+  let openFence: string | null = null;
   for (const line of source.split("\n")) {
-    if (FENCE_LINE_REGEX.test(line)) {
-      inFence = !inFence;
+    const fence = line.match(FENCE_LINE_REGEX)?.[1];
+    if (fence) {
+      if (
+        openFence &&
+        fence[0] === openFence[0] &&
+        fence.length >= openFence.length
+      ) {
+        openFence = null;
+      } else if (!openFence) {
+        openFence = fence;
+      }
       continue;
     }
-    if (inFence || !line.trim()) {
+    if (openFence || !line.trim()) {
       continue;
     }
     const cleaned = cleanAutoName(line);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [SOK-962](https://linear.app/masumi/issue/SOK-962/make-auto-generated-task-titles-short-and-readable). Auto-named tasks store a short plain-language `Task.name` instead of a markdown dump of the description.

## Why

Model output and first-line fallback were storing heading dumps, numbered outlines, and leftover markdown. A later global token class then ate ordinary text such as `C#` and could split emoji at the 60-character cap. Fallback fence tracking also treated any fence line as a close, so a backtick line inside a tilde block could leak code into the title.

## Scope

- Post-process both model output and first-line fallback in `apps/core/src/helpers/task-name.ts`: strip HTML, unwrap links/emphasis/code, drop heading and blockquote prefixes, collapse whitespace, unwrap quotes, drop trailing periods, cap at 60 Unicode code points.
- Skip backtick and tilde fenced blocks when choosing a fallback line. Close a fence only on the same delimiter with equal or greater length.
- Reject generated names that still look like a heading dump, numbered outline, or refusal, then fall back to a cleaned first line, then `Untitled Task`.
- User-supplied names stay trim-only.

## Tradeoffs

Cleanup stays in `task-name.ts`. Shared strip helpers (`buildQuoteSnippet`, web `stripMarkdownToText`) still globally delete `#` and would reintroduce the `C#` bug.

## Out of scope

Job names, chat titles, backfill of existing tasks, retitling on patch, and the public create schema max length for user-typed names.

## Verification

- `pnpm --filter core test src/helpers/task-name.test.ts` — 30 passed, including C#, markdown links, wrapping emphasis, tilde fences, mixed backtick/tilde fences, shorter-vs-longer close markers, and emoji at the 60-char cap.
- `pnpm --filter core typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63f6d400-b33c-4014-8272-47be4747f5db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63f6d400-b33c-4014-8272-47be4747f5db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Task names generated from descriptions are now clearer and more consistent, with formatting such as Markdown, HTML, code fences, quotes, and headings cleaned up.
  * Generated names are limited to 60 characters and avoid trailing punctuation.
  * Descriptions used for generation are trimmed and limited to 1,000 characters.
  * Blank, invalid, refusal-like, or unusable generated names now receive a suitable fallback name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->