### PR TITLE
chore: remove Hermes/Eve leftover root docs and scripts

### DIFF
--- a/.agents/skills/translations/SKILL.md
+++ b/.agents/skills/translations/SKILL.md
@@ -15,8 +15,6 @@ When code that uses translations is deleted or modified, check for and remove un
 
 Parity: `pnpm --filter web messages:parity` (write: `messages:parity:write`). Wired into web `test`.
 
-`apps/web/messages/hermes-translations/` is a `de`/`es` overlay pack for `scripts/apply-hermes-i18n.mjs`, not a locale catalog. Do not add keys there instead of `en`/`de`/`es`.
-
 ## Client message bags
 
 Layouts nest `ClientMessageBoundary` so clients get a picked subset (`pickMessages` + `message-namespaces.ts`), not the full catalog. Server `getTranslations` still uses the full request catalog.

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,11 +1,6 @@
-# Only affects CLI uploads (`vercel deploy` from this root) — the web and core
+# Only affects CLI uploads (`vercel deploy` from this root). Web and core
 # production deploys go through scripts/ci/vercel-deploy.mjs, which sends a
 # gitSource ref rather than files.
-#
-# apps/soko-bot is deployed with the CLI from the repo root (its Vercel project
-# sets rootDirectory to apps/soko-bot). Without this file the upload enumerates
-# every local artifact — ~327k files against ~4.9k of actual source — and the
-# create-deployment request exceeds Vercel's 10 MB body limit.
 #
 # Everything below is regenerated on Vercel by `pnpm install` and the build, so
 # none of it should ever be uploaded.

--- a/docs/soko-bot/operations-runbook.md
+++ b/docs/soko-bot/operations-runbook.md
@@ -1,5 +1,7 @@
 # Soko Bot operations runbook
 
+In-process runtime, enablement, and turn drain: [deployment.md](./deployment.md).
+
 ## Crash-fenced Agent hire
 
 An accepted `hire_agent` decision creates a unique Delegation reservation before seller-side execution. Local Job creation and the exact Delegation `jobId` link commit in the same serializable transaction. After seller dispatch starts, failures leave the decision `PROCESSING`; never reset it to `PENDING` or accept it by rerunning Job creation. That could hire and charge twice.
@@ -13,11 +15,3 @@ For a `PROCESSING` decision older than normal Job-start latency:
 5. If repair or closure is required, build incident-scoped tooling first. It must support dry-run, validate expected current state, update link and decision in one transaction, be idempotent, and emit operator/incident evidence. Review and test it before production use; do not hand-edit state or invoke an unnamed script.
 
 Admin fleet/detail views retain `PROCESSING` decision and reservation for diagnosis. User turn history retains resolved decisions but hides expired unresolved approvals.
-
-## Stuck turn
-
-Active-turn cron uses lease fencing for both crash windows. A stale `STARTING` turn with no session replays Eve create using same durable Core turn id as `operationId`; an attached turn resumes its Eve stream from persisted index. Context snapshot and turn are committed atomically before first dispatch, so replay always uses exact original packet. If deadline expires, Core cancels runtime, marks turn failed, clears uncertain session binding, and next turn creates fresh session. Use admin pause before manual investigation; resume only non-archived bot.
-
-## Per-turn sessions
-
-Core creates one fresh Eve session for every Core turn. The durable Core turn id is Eve's create `operationId`, making a lost acceptance response safe to replay without dispatching work twice. Core pre-feeds bounded recent conversation, current Sokosumi state, and canonical memory, so continuity never depends on Eve's non-idempotent follow-up endpoint or an earlier Sandbox. The prior completed session is reset after the replacement is durably acknowledged; cleanup failure is logged and Eve's session timeout remains the backstop.

--- a/scripts/local-env/bootstrap.mjs
+++ b/scripts/local-env/bootstrap.mjs
@@ -15,7 +15,6 @@ import { fileURLToPath } from "node:url";
 
 export const DEFAULT_BETTER_AUTH_SECRET =
   "TFVfK91TGv2YVyVYFk0lu87Md5a13E4l7AjEaoZD8dQ=";
-const DUMMY_URL = "https://local.dev.invalid";
 const PLACEHOLDER_RE = /^<[^>]+>$/;
 
 /** Keys that must be omitted when the value is not a real URL (optional z.url()). */
@@ -29,11 +28,6 @@ const OPTIONAL_URL_KEYS = new Set([
   "JOB_FAILURE_WEBHOOK_URL",
   "VERCEL_BLOB_CALLBACK_URL",
 ]);
-
-/** Required URL keys that get a dummy URL when the example is a placeholder. */
-const REQUIRED_URL_DUMMIES = {
-  HERMES_ORCH_BASE_URL: DUMMY_URL,
-};
 
 const STRING_DUMMIES = {
   APP_SIGNING_SECRET: DEFAULT_BETTER_AUTH_SECRET,
@@ -135,10 +129,6 @@ export function sanitizeEnvContents(contents) {
     }
 
     if (isPlaceholderValue(unquoted)) {
-      if (key in REQUIRED_URL_DUMMIES) {
-        out.push(`${key}="${REQUIRED_URL_DUMMIES[key]}"`);
-        continue;
-      }
       if (key in STRING_DUMMIES) {
         out.push(`${key}="${STRING_DUMMIES[key]}"`);
         continue;

--- a/scripts/local-env/bootstrap.test.mjs
+++ b/scripts/local-env/bootstrap.test.mjs
@@ -82,15 +82,10 @@ describe("sanitizeEnvContents", () => {
   it("fills required placeholders with dummies that pass Zod", () => {
     const out = sanitizeEnvContents(
       [
-        'HERMES_ORCH_BASE_URL="<hermes-orchestrator-base-url>"',
         'RESEND_API_KEY="<your-resend-api-key>"',
         'ABLY_PUBLISH_ONLY_KEY="<your-ably-publish-only-key>"',
         "",
       ].join("\n"),
-    );
-    assert.match(
-      out,
-      /^HERMES_ORCH_BASE_URL="https:\/\/local\.dev\.invalid"$/m,
     );
     assert.match(out, /^RESEND_API_KEY="dummy-resend-api-key"$/m);
     assert.match(out, /^ABLY_PUBLISH_ONLY_KEY="dummy-ably-publish-only-key"$/m);
@@ -118,7 +113,6 @@ describe("bootstrapLocalEnv", () => {
         'BETTER_AUTH_SECRET="core-secret"',
         'BETTER_AUTH_COOKIE_DOMAIN="sokosumi.com"',
         'COMPOSIO_API_KEY="<composio-api-key>"',
-        'HERMES_ORCH_BASE_URL="<hermes-orchestrator-base-url>"',
         'DATABASE_URL="postgresql://sokosumi:sokosumi@sokosumi:5432/core?schema=public"',
         "",
       ].join("\n"),
@@ -143,10 +137,6 @@ describe("bootstrapLocalEnv", () => {
     assert.match(core, /^# BETTER_AUTH_COOKIE_DOMAIN=/m);
     assert.match(core, /^# COMPOSIO_API_KEY=/m);
     assert.match(core, /@localhost:5432/);
-    assert.match(
-      core,
-      /^HERMES_ORCH_BASE_URL="https:\/\/local\.dev\.invalid"$/m,
-    );
     assert.match(web, /^APP_SIGNING_SECRET="core-secret"$/m);
     assert.match(web, /^# NEXT_PUBLIC_SENTRY_DSN=/m);
     assert.match(web, /^CORE_APP_BASE_URL="http:\/\/localhost:8787"$/m);

--- a/skills/translations/SKILL.md
+++ b/skills/translations/SKILL.md
@@ -15,8 +15,6 @@ When code that uses translations is deleted or modified, check for and remove un
 
 Parity: `pnpm --filter web messages:parity` (write: `messages:parity:write`). Wired into web `test`.
 
-`apps/web/messages/hermes-translations/` is a `de`/`es` overlay pack for `scripts/apply-hermes-i18n.mjs`, not a locale catalog. Do not add keys there instead of `en`/`de`/`es`.
-
 ## Client message bags
 
 Layouts nest `ClientMessageBoundary` so clients get a picked subset (`pickMessages` + `message-namespaces.ts`), not the full catalog. Server `getTranslations` still uses the full request catalog.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Subtract-only cleanup of Hermes/Eve leftovers at repo root. No new machinery.

## What changed

- `scripts/local-env/bootstrap.mjs` — dropped `HERMES_ORCH_BASE_URL` dummy URL fill. Core `env.ts` / `.env.example` no longer define it.
- `scripts/local-env/bootstrap.test.mjs` — dropped tests that required that dummy.
- `skills/translations/SKILL.md` and `.agents/skills/translations/SKILL.md` — deleted the stale `hermes-translations/` / `apply-hermes-i18n.mjs` paragraph. Locales remain `en`/`de`/`es` plus `messages:parity`.
- `.vercelignore` — removed the `apps/soko-bot` CLI-upload comment. File kept: production still uses `scripts/ci/vercel-deploy.mjs` gitSource; the ignore list still applies to accidental root `vercel deploy`.
- `docs/soko-bot/operations-runbook.md` — deleted Eve session / Eve stream / Sandbox sections. Kept crash-fenced `hire_agent` (still live in Core). Pointed remaining ops at `docs/soko-bot/deployment.md` (`waitUntil` + `soko_bot_runtime_event`).

## Left alone (still live or out of scope)

- `.cursor/skills/verify-sokosumi` still mentions `HERMES_ORCH_BASE_URL` — skipped (open PR #4158 path).
- `HERMES_ORCH_TOKEN` string dummy in bootstrap — leftover local `.env` sanitizer, not a Core env key. Out of the four-item checklist.
- Historical `docs/soko-bot/implementation-plan.md` / ADR 0007 — archive-shipped-docs / not this queue item.
- Open PRs #4158 #4157 #4156 #4153 #4147 — no overlapping files.

## Verification

| Path | How |
| --- | --- |
| `scripts/local-env/bootstrap.mjs` | Grep: Core `env.ts` / `.env.example` have no `HERMES_ORCH`. `node --test scripts/local-env/bootstrap.test.mjs` — 17/17 pass. |
| `scripts/local-env/bootstrap.test.mjs` | Same test run. Husky `pnpm check` + `pnpm typecheck` on commit: green. |
| `skills/translations/SKILL.md` | Glob: `hermes-translations/` and `apply-hermes-i18n.mjs` absent on current `main`. |
| `.agents/skills/translations/SKILL.md` | Same one-line delete as the canonical skill. |
| `.vercelignore` | `scripts/ci/vercel-deploy.mjs` uses gitSource, not file upload. No `.github` `vercel deploy`. |
| `docs/soko-bot/operations-runbook.md` | `hire_agent` `PROCESSING` still in `soko-bot-runtime.service.ts`. In-process `waitUntil` + `sokoBotRuntimeEvent` in `in-process-runtime.ts`. `deployment.md` already describes live shape. |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e557d84-944e-4e35-a964-b8efbebfc41d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e557d84-944e-4e35-a964-b8efbebfc41d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

