### PR TITLE
chore: drop GET interactive transactions

### DIFF
--- a/apps/core/src/helpers/active-ui-stream-room-metadata.ts
+++ b/apps/core/src/helpers/active-ui-stream-room-metadata.ts
@@ -23,26 +23,24 @@ export async function clearActiveUiStreamIdForRoom(params: {
   userId: string;
 }): Promise<void> {
   const { roomId, userId } = params;
-  await prisma.$transaction(async (tx) => {
-    const room = await tx.chatRoom.findFirst({
-      where: {
-        id: roomId,
-        archivedAt: null,
-        userMembers: {
-          some: { userId },
-        },
+  const room = await prisma.chatRoom.findFirst({
+    where: {
+      id: roomId,
+      archivedAt: null,
+      userMembers: {
+        some: { userId },
       },
-      select: { id: true },
-    });
-    if (!room) {
-      return;
-    }
-    const redis = getRedisClient();
-    if (!redis) {
-      return;
-    }
-    await redis.del(roomActiveStreamRedisKey(roomId));
+    },
+    select: { id: true },
   });
+  if (!room) {
+    return;
+  }
+  const redis = getRedisClient();
+  if (!redis) {
+    return;
+  }
+  await redis.del(roomActiveStreamRedisKey(roomId));
 }
 
 export async function setActiveUiStreamIdForRoom(params: {
@@ -51,24 +49,22 @@ export async function setActiveUiStreamIdForRoom(params: {
   streamId: string;
 }): Promise<void> {
   const { roomId, userId, streamId } = params;
-  await prisma.$transaction(async (tx) => {
-    const room = await tx.chatRoom.findFirst({
-      where: {
-        id: roomId,
-        archivedAt: null,
-        userMembers: {
-          some: { userId },
-        },
+  const room = await prisma.chatRoom.findFirst({
+    where: {
+      id: roomId,
+      archivedAt: null,
+      userMembers: {
+        some: { userId },
       },
-      select: { id: true },
-    });
-    if (!room) {
-      throw new Error("Room not found");
-    }
-    const redis = getRedisClient();
-    if (!redis) {
-      throw new Error("Redis is required for resumable room UI streams");
-    }
-    await redis.set(roomActiveStreamRedisKey(roomId), streamId);
+    },
+    select: { id: true },
   });
+  if (!room) {
+    throw new Error("Room not found");
+  }
+  const redis = getRedisClient();
+  if (!redis) {
+    throw new Error("Redis is required for resumable room UI streams");
+  }
+  await redis.set(roomActiveStreamRedisKey(roomId), streamId);
 }

--- a/apps/core/src/routes/v1/agents/[id]/ratings/eligibility/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/ratings/eligibility/get.ts
@@ -46,15 +46,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = await requireAuthorizedUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    const eligible = await prisma.$transaction(async (tx) => {
-      await requireAvailableAgentOrThrow(id, tx);
+    await requireAvailableAgentOrThrow(id, prisma);
 
-      return await jobRepository.doesUserHaveFinishedJobWithAgent(
-        userContext.userId,
-        id,
-        tx,
-      );
-    });
+    const eligible = await jobRepository.doesUserHaveFinishedJobWithAgent(
+      userContext.userId,
+      id,
+      prisma,
+    );
 
     return ok(c, agentRatingEligibilitySchema.parse({ eligible }));
   });

--- a/apps/core/src/routes/v1/agents/[id]/reviews/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/get.test.ts
@@ -18,14 +18,12 @@ const {
   getAgentRatingDistributionMock,
   getCreditCostsOrThrowMock,
   getRecentAgentReviewsMock,
-  prismaTransactionMock,
 } = vi.hoisted(() => ({
   agentFindFirstMock: vi.fn(),
   buildAvailableAgentWhereClauseMock: vi.fn(),
   getAgentRatingDistributionMock: vi.fn(),
   getCreditCostsOrThrowMock: vi.fn(),
   getRecentAgentReviewsMock: vi.fn(),
-  prismaTransactionMock: vi.fn(),
 }));
 
 vi.mock("@/helpers/agent", () => ({
@@ -41,7 +39,9 @@ vi.mock("@/helpers/agent-rating", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
+    agent: {
+      findFirst: agentFindFirstMock,
+    },
   },
 }));
 
@@ -94,13 +94,6 @@ describe("GET /agents/{id}/reviews", () => {
         },
       },
     ]);
-    prismaTransactionMock.mockImplementation(async (callback) => {
-      return await callback({
-        agent: {
-          findFirst: agentFindFirstMock,
-        },
-      });
-    });
   });
 
   it("returns public review distribution and recent comments", async () => {

--- a/apps/core/src/routes/v1/agents/[id]/reviews/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/get.ts
@@ -78,34 +78,32 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id } = c.req.valid("param");
     const { limit, offset } = c.req.valid("query");
 
-    const reviews = await prisma.$transaction(async (tx) => {
-      const creditCosts = await getCreditCostsOrThrow(tx);
-      const cardanoV2ReadySources = await getCardanoV2ReadySources(tx);
+    const creditCosts = await getCreditCostsOrThrow(prisma);
+    const cardanoV2ReadySources = await getCardanoV2ReadySources(prisma);
 
-      const agent = await tx.agent.findFirst({
-        where: {
-          id,
-          ...buildAvailableAgentWhereClause(creditCosts, cardanoV2ReadySources),
-        },
-        select: {
-          id: true,
-        },
-      });
-
-      if (!agent) {
-        throw notFound("Agent not found");
-      }
-
-      const [distribution, ratingsWithComments] = await Promise.all([
-        getAgentRatingDistribution(id, tx),
-        getRecentAgentReviews(id, limit, tx, offset),
-      ]);
-
-      return {
-        distribution,
-        ratingsWithComments,
-      };
+    const agent = await prisma.agent.findFirst({
+      where: {
+        id,
+        ...buildAvailableAgentWhereClause(creditCosts, cardanoV2ReadySources),
+      },
+      select: {
+        id: true,
+      },
     });
+
+    if (!agent) {
+      throw notFound("Agent not found");
+    }
+
+    const [distribution, ratingsWithComments] = await Promise.all([
+      getAgentRatingDistribution(id, prisma),
+      getRecentAgentReviews(id, limit, prisma, offset),
+    ]);
+
+    const reviews = {
+      distribution,
+      ratingsWithComments,
+    };
 
     return ok(c, agentReviewsSchema.parse(reviews));
   });

--- a/apps/core/src/routes/v1/agents/[id]/reviews/me/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/me/get.test.ts
@@ -18,13 +18,11 @@ const {
   buildAvailableAgentWhereClauseMock,
   getCreditCostsOrThrowMock,
   getUserAgentReviewMock,
-  prismaTransactionMock,
 } = vi.hoisted(() => ({
   agentFindFirstMock: vi.fn(),
   buildAvailableAgentWhereClauseMock: vi.fn(),
   getCreditCostsOrThrowMock: vi.fn(),
   getUserAgentReviewMock: vi.fn(),
-  prismaTransactionMock: vi.fn(),
 }));
 
 vi.mock("@/helpers/agent", () => ({
@@ -39,7 +37,9 @@ vi.mock("@/helpers/agent-rating", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
+    agent: {
+      findFirst: agentFindFirstMock,
+    },
   },
 }));
 
@@ -73,13 +73,6 @@ describe("GET /agents/{id}/reviews/me", () => {
     });
     getCreditCostsOrThrowMock.mockResolvedValue([]);
     agentFindFirstMock.mockResolvedValue({ id: "agent_123" });
-    prismaTransactionMock.mockImplementation(async (callback) => {
-      return await callback({
-        agent: {
-          findFirst: agentFindFirstMock,
-        },
-      });
-    });
   });
 
   it("returns the caller's own review for the agent", async () => {

--- a/apps/core/src/routes/v1/agents/[id]/reviews/me/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/me/get.ts
@@ -51,26 +51,24 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = await requireAuthorizedUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    const review = await prisma.$transaction(async (tx) => {
-      const creditCosts = await getCreditCostsOrThrow(tx);
-      const cardanoV2ReadySources = await getCardanoV2ReadySources(tx);
+    const creditCosts = await getCreditCostsOrThrow(prisma);
+    const cardanoV2ReadySources = await getCardanoV2ReadySources(prisma);
 
-      const agent = await tx.agent.findFirst({
-        where: {
-          id,
-          ...buildAvailableAgentWhereClause(creditCosts, cardanoV2ReadySources),
-        },
-        select: {
-          id: true,
-        },
-      });
-
-      if (!agent) {
-        throw notFound("Agent not found");
-      }
-
-      return await getUserAgentReview(id, userContext.userId, tx);
+    const agent = await prisma.agent.findFirst({
+      where: {
+        id,
+        ...buildAvailableAgentWhereClause(creditCosts, cardanoV2ReadySources),
+      },
+      select: {
+        id: true,
+      },
     });
+
+    if (!agent) {
+      throw notFound("Agent not found");
+    }
+
+    const review = await getUserAgentReview(id, userContext.userId, prisma);
 
     return ok(c, agentMyReviewResponseSchema.parse(review));
   });

--- a/apps/core/src/routes/v1/categories/get.test.ts
+++ b/apps/core/src/routes/v1/categories/get.test.ts
@@ -5,21 +5,26 @@ import { formatZodErrorMessage, unprocessableEntity } from "@/helpers/error";
 
 import mountGetCategories from "./get";
 
-const { prismaTransactionMock, creditCostFindManyMock, categoryFindManyMock } =
-  vi.hoisted(() => ({
-    prismaTransactionMock: vi.fn(),
-    creditCostFindManyMock: vi.fn(),
-    categoryFindManyMock: vi.fn(),
-  }));
+const {
+  creditCostFindManyMock,
+  categoryFindManyMock,
+  syncMetadataFindUniqueMock,
+} = vi.hoisted(() => ({
+  creditCostFindManyMock: vi.fn(),
+  categoryFindManyMock: vi.fn(),
+  syncMetadataFindUniqueMock: vi.fn(),
+}));
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
     creditCost: {
       findMany: creditCostFindManyMock,
     },
     category: {
       findMany: categoryFindManyMock,
+    },
+    syncMetadata: {
+      findUnique: syncMetadataFindUniqueMock,
     },
   },
 }));
@@ -47,14 +52,7 @@ describe("GET /categories", () => {
     vi.clearAllMocks();
     creditCostFindManyMock.mockResolvedValue([{ unit: "default" }]);
     categoryFindManyMock.mockResolvedValue([]);
-    prismaTransactionMock.mockImplementation(async (callback) => {
-      const tx = {
-        creditCost: { findMany: creditCostFindManyMock },
-        syncMetadata: { findUnique: vi.fn().mockResolvedValue(null) },
-        category: { findMany: categoryFindManyMock },
-      };
-      return await callback(tx);
-    });
+    syncMetadataFindUniqueMock.mockResolvedValue(null);
   });
 
   it("returns 200 and list of categories with expected shape", async () => {

--- a/apps/core/src/routes/v1/categories/get.ts
+++ b/apps/core/src/routes/v1/categories/get.ts
@@ -27,20 +27,18 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHono) {
   app.openapi(route, async (c) => {
-    const categories = await prisma.$transaction(async (tx) => {
-      const creditCosts = await getCreditCostsOrThrow(tx);
-      const cardanoV2ReadySources = await getCardanoV2ReadySources(tx);
-      const agentWhere = buildAvailableAgentWhereClause(
-        creditCosts,
-        cardanoV2ReadySources,
-      );
+    const creditCosts = await getCreditCostsOrThrow(prisma);
+    const cardanoV2ReadySources = await getCardanoV2ReadySources(prisma);
+    const agentWhere = buildAvailableAgentWhereClause(
+      creditCosts,
+      cardanoV2ReadySources,
+    );
 
-      return tx.category.findMany({
-        where: {
-          agents: { some: agentWhere },
-        },
-        orderBy: [{ priority: "asc" }, { name: "asc" }],
-      });
+    const categories = await prisma.category.findMany({
+      where: {
+        agents: { some: agentWhere },
+      },
+      orderBy: [{ priority: "asc" }, { name: "asc" }],
     });
 
     return ok(

--- a/apps/core/src/routes/v1/categories/index.auth.test.ts
+++ b/apps/core/src/routes/v1/categories/index.auth.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   authContextState,
-  prismaTransactionMock,
   creditCostFindManyMock,
   categoryFindManyMock,
+  syncMetadataFindUniqueMock,
 } = vi.hoisted(() => ({
   authContextState: {
     current: null as {
@@ -14,9 +14,9 @@ const {
       role: string;
     } | null,
   },
-  prismaTransactionMock: vi.fn(),
   creditCostFindManyMock: vi.fn(),
   categoryFindManyMock: vi.fn(),
+  syncMetadataFindUniqueMock: vi.fn(),
 }));
 
 vi.mock("@/middleware/auth", async (importOriginal) => {
@@ -42,12 +42,14 @@ vi.mock("@/middleware/auth", async (importOriginal) => {
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
     creditCost: {
       findMany: creditCostFindManyMock,
     },
     category: {
       findMany: categoryFindManyMock,
+    },
+    syncMetadata: {
+      findUnique: syncMetadataFindUniqueMock,
     },
   },
 }));
@@ -60,14 +62,7 @@ describe("categories routes auth gate", () => {
     authContextState.current = null;
     creditCostFindManyMock.mockResolvedValue([{ unit: "default" }]);
     categoryFindManyMock.mockResolvedValue([]);
-    prismaTransactionMock.mockImplementation(async (callback) => {
-      const tx = {
-        creditCost: { findMany: creditCostFindManyMock },
-        syncMetadata: { findUnique: vi.fn().mockResolvedValue(null) },
-        category: { findMany: categoryFindManyMock },
-      };
-      return await callback(tx);
-    });
+    syncMetadataFindUniqueMock.mockResolvedValue(null);
   });
 
   it("allows anonymous GET /categories", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/get.test.ts
@@ -18,7 +18,6 @@ const {
   chatRoomMessageCountMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
-  prismaTransactionMock,
   validateUIMessagesMock,
 } = vi.hoisted(() => ({
   roomFindFirstMock: vi.fn(),
@@ -26,7 +25,6 @@ const {
   chatRoomMessageCountMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
-  prismaTransactionMock: vi.fn(),
   validateUIMessagesMock: vi.fn(),
 }));
 
@@ -36,7 +34,19 @@ vi.mock("ai", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
+    chatRoom: {
+      findFirst: roomFindFirstMock,
+    },
+    chatRoomMessage: {
+      findMany: chatRoomMessageFindManyMock,
+      count: chatRoomMessageCountMock,
+    },
+    organization: {
+      findUnique: organizationFindUniqueMock,
+    },
+    member: {
+      findUnique: memberFindUniqueMock,
+    },
   },
 }));
 
@@ -67,23 +77,6 @@ function createApp(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  prismaTransactionMock.mockImplementation(async (callback) =>
-    callback({
-      chatRoom: {
-        findFirst: roomFindFirstMock,
-      },
-      chatRoomMessage: {
-        findMany: chatRoomMessageFindManyMock,
-        count: chatRoomMessageCountMock,
-      },
-      organization: {
-        findUnique: organizationFindUniqueMock,
-      },
-      member: {
-        findUnique: memberFindUniqueMock,
-      },
-    }),
-  );
   organizationFindUniqueMock.mockResolvedValue({ id: "org_1" });
   memberFindUniqueMock.mockResolvedValue({ role: "member" });
   chatRoomMessageCountMock.mockResolvedValue(0);

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/get.ts
@@ -97,37 +97,33 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       });
       const takePlusOne = take + 1;
 
-      const { items, count } = await prisma.$transaction(async (tx) => {
-        await requireChatRoomUserMembership(roomId, userContext.userId, tx);
+      await requireChatRoomUserMembership(roomId, userContext.userId, prisma);
 
-        const where = {
-          roomId,
-          parentMessageId: null,
-        };
+      const where = {
+        roomId,
+        parentMessageId: null,
+      };
 
-        const [items, count] = await Promise.all([
-          tx.chatRoomMessage.findMany({
-            where,
-            // Newest-first page (same as GET /messages): open hydrate is the
-            // most recent window, not the first 200 messages ever written.
-            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-            take: takePlusOne,
-            skip,
-            cursor: cursor ? { id: cursor } : undefined,
-            select: {
-              id: true,
-              content: true,
-              senderUserId: true,
-              senderCoworkerId: true,
-              metadata: true,
-              createdAt: true,
-            },
-          }),
-          tx.chatRoomMessage.count({ where }),
-        ]);
-
-        return { items, count };
-      });
+      const [items, count] = await Promise.all([
+        prisma.chatRoomMessage.findMany({
+          where,
+          // Newest-first page (same as GET /messages): open hydrate is the
+          // most recent window, not the first 200 messages ever written.
+          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+          take: takePlusOne,
+          skip,
+          cursor: cursor ? { id: cursor } : undefined,
+          select: {
+            id: true,
+            content: true,
+            senderUserId: true,
+            senderCoworkerId: true,
+            metadata: true,
+            createdAt: true,
+          },
+        }),
+        prisma.chatRoomMessage.count({ where }),
+      ]);
 
       const hasMore = items.length === takePlusOne;
       const pagedItems = items.slice(0, take);

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/stream-get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/stream-get.test.ts
@@ -16,7 +16,6 @@ const {
   roomFindFirstMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
-  prismaTransactionMock,
   isUiStreamResumptionConfiguredMock,
   getResumableUiStreamContextMock,
   resumeExistingStreamMock,
@@ -26,7 +25,6 @@ const {
   roomFindFirstMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
-  prismaTransactionMock: vi.fn(),
   isUiStreamResumptionConfiguredMock: vi.fn(),
   getResumableUiStreamContextMock: vi.fn(),
   resumeExistingStreamMock: vi.fn(),
@@ -36,7 +34,15 @@ const {
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
+    chatRoom: {
+      findFirst: roomFindFirstMock,
+    },
+    organization: {
+      findUnique: organizationFindUniqueMock,
+    },
+    member: {
+      findUnique: memberFindUniqueMock,
+    },
   },
 }));
 
@@ -77,19 +83,6 @@ function createApp(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  prismaTransactionMock.mockImplementation(async (callback) =>
-    callback({
-      chatRoom: {
-        findFirst: roomFindFirstMock,
-      },
-      organization: {
-        findUnique: organizationFindUniqueMock,
-      },
-      member: {
-        findUnique: memberFindUniqueMock,
-      },
-    }),
-  );
   organizationFindUniqueMock.mockResolvedValue({ id: "org_1" });
   memberFindUniqueMock.mockResolvedValue({ role: "member" });
   clearActiveUiStreamIdForRoomMock.mockResolvedValue(undefined);

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/stream-get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/stream-get.ts
@@ -69,9 +69,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireUserAuthContext(c.var.authContext);
     const { id: roomId } = c.req.valid("param");
 
-    await prisma.$transaction(async (tx) => {
-      await requireChatRoomUserMembership(roomId, userContext.userId, tx);
-    });
+    await requireChatRoomUserMembership(roomId, userContext.userId, prisma);
 
     if (!isUiStreamResumptionConfigured()) {
       return new Response(null, { status: 204 });

--- a/apps/core/src/routes/v1/chats/rooms/auth.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/auth.test.ts
@@ -501,6 +501,8 @@ const membershipScopedCases: AuthRequestCase[] = [
 const membershipCasesWithoutInteractiveTx = new Set([
   "GET /{id}",
   "GET /{id}/messages",
+  "GET /{id}/stream/messages",
+  "GET /{id}/stream/active",
 ]);
 
 describe("chat room membership isolation", () => {
@@ -508,7 +510,7 @@ describe("chat room membership isolation", () => {
     "$label returns 404 when caller is not a room member",
     async ({ label, request }) => {
       // Read GETs no longer open interactive txs — membership miss is on the
-      // default client. Write / stream paths still go through $transaction.
+      // default client. Write paths still go through $transaction.
       roomFindFirstMock.mockResolvedValue(null);
       prismaTransactionMock.mockImplementation(
         async (callback: (tx: unknown) => Promise<unknown>) =>

--- a/apps/core/src/routes/v1/credit-costs/get.ts
+++ b/apps/core/src/routes/v1/credit-costs/get.ts
@@ -29,9 +29,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     requireAdminAuthContext(c.var.authContext);
 
-    const items = await prisma.$transaction(async (tx) =>
-      tx.creditCost.findMany(),
-    );
+    const items = await prisma.creditCost.findMany();
 
     const mapped = items.map(mapCreditCostForApi);
     return ok(c, z.array(creditCostSchema).parse(mapped));

--- a/apps/core/src/routes/v1/jobs/[id]/events/get.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/events/get.test.ts
@@ -4,24 +4,22 @@ import { OpenAPIHonoWithAuth } from "@/lib/hono";
 
 import mountGetJobEventsById from "./get";
 
-const { authContextState, jobFindFirstMock, prismaTransactionMock } =
-  vi.hoisted(() => ({
-    authContextState: {
-      current: {
-        actor: "user",
-        userId: "user_123",
-        organizationId: "org_123",
-        role: "user",
-      } as {
-        actor: "user";
-        userId: string;
-        organizationId: string | null;
-        role: string;
-      } | null,
-    },
-    jobFindFirstMock: vi.fn(),
-    prismaTransactionMock: vi.fn(),
-  }));
+const { authContextState, jobFindFirstMock } = vi.hoisted(() => ({
+  authContextState: {
+    current: {
+      actor: "user",
+      userId: "user_123",
+      organizationId: "org_123",
+      role: "user",
+    } as {
+      actor: "user";
+      userId: string;
+      organizationId: string | null;
+      role: string;
+    } | null,
+  },
+  jobFindFirstMock: vi.fn(),
+}));
 
 vi.mock("@/middleware/auth", () => ({
   authMiddleware: async (
@@ -99,7 +97,9 @@ vi.mock("@/middleware/workspace", async (importOriginal) => {
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: (...args: unknown[]) => prismaTransactionMock(...args),
+    job: {
+      findFirst: jobFindFirstMock,
+    },
   },
 }));
 
@@ -158,18 +158,10 @@ describe("GET /jobs/{id}/events", () => {
       organizationId: "org_123",
       role: "user",
     };
-    prismaTransactionMock.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) =>
-        await callback({
-          job: {
-            findFirst: jobFindFirstMock,
-          },
-        }),
-    );
     jobFindFirstMock.mockResolvedValue(createJobWithEvents());
   });
 
-  it("loads job events with the transaction client and workspace scope", async () => {
+  it("loads job events with workspace scope", async () => {
     const app = createApp();
 
     const response = await app.request("http://localhost/job_123/events");

--- a/apps/core/src/routes/v1/jobs/[id]/events/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/events/get.ts
@@ -78,35 +78,32 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const { id } = c.req.valid("param");
 
-    const events = await prisma.$transaction(async (tx) => {
-      await requireJobReadForRouteVars(c.var, id, tx);
-      const job = await tx.job.findFirst({
-        where: {
-          id,
-          workspaceId: workspaceContext.workspaceId,
-        },
-        include: {
-          ...jobWithEvents,
-        },
-      });
-      if (!job) {
-        throw notFound("Job not found");
-      }
-
-      const events = job.events.map((event) => ({
-        ...event,
-        files: event.blobs.map((blob) => ({
-          ...blob,
-          jobId: id,
-          size: blob.size ? Number(blob.size) : null,
-        })),
-        links: event.links.map((link) => ({
-          ...link,
-          jobId: id,
-        })),
-      }));
-      return events;
+    await requireJobReadForRouteVars(c.var, id, prisma);
+    const job = await prisma.job.findFirst({
+      where: {
+        id,
+        workspaceId: workspaceContext.workspaceId,
+      },
+      include: {
+        ...jobWithEvents,
+      },
     });
+    if (!job) {
+      throw notFound("Job not found");
+    }
+
+    const events = job.events.map((event) => ({
+      ...event,
+      files: event.blobs.map((blob) => ({
+        ...blob,
+        jobId: id,
+        size: blob.size ? Number(blob.size) : null,
+      })),
+      links: event.links.map((link) => ({
+        ...link,
+        jobId: id,
+      })),
+    }));
 
     return ok(c, jobEventsSchema.parse(events));
   });

--- a/apps/core/src/routes/v1/jobs/[id]/files/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/files/get.ts
@@ -60,27 +60,25 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { id } = c.req.valid("param");
 
-    const blobs = await prisma.$transaction(async (tx) => {
-      await requireJobReadForRouteVars(c.var, id, tx);
-      const blobs = await tx.blob.findMany({
-        where: {
-          event: { jobId: id },
-        },
-        include: {
-          event: {
-            select: {
-              jobId: true,
-            },
+    await requireJobReadForRouteVars(c.var, id, prisma);
+    const blobs = await prisma.blob.findMany({
+      where: {
+        event: { jobId: id },
+      },
+      include: {
+        event: {
+          select: {
+            jobId: true,
           },
         },
-      });
-      return blobs.map((blob) => ({
-        ...blob,
-        jobId: blob.event.jobId,
-        size: blob.size ? Number(blob.size) : null,
-      }));
+      },
     });
+    const files = blobs.map((blob) => ({
+      ...blob,
+      jobId: blob.event.jobId,
+      size: blob.size ? Number(blob.size) : null,
+    }));
 
-    return ok(c, filesSchema.parse(blobs));
+    return ok(c, filesSchema.parse(files));
   });
 }

--- a/apps/core/src/routes/v1/jobs/[id]/get.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/get.test.ts
@@ -6,32 +6,37 @@ import { TEST_VENDOR_ID } from "@/test-fixtures/vendor";
 
 import mountGetJobById from "./get";
 
-const { authContextState, prismaTransactionMock, jobFindFirstMock } =
-  vi.hoisted(() => ({
-    authContextState: {
-      current: {
-        actor: "user",
-        userId: "user_123",
-        organizationId: "org_123",
-        role: "user",
-      } as
-        | {
-            actor: "user";
-            userId: string;
-            organizationId: string | null;
-            role: string;
-          }
-        | {
-            actor: "coworker";
-            coworkerId: string;
-            vendorId?: string;
-            context?: { userId: string; organizationId: string | null };
-          }
-        | null,
-    },
-    prismaTransactionMock: vi.fn(),
-    jobFindFirstMock: vi.fn(),
-  }));
+const {
+  authContextState,
+  jobFindFirstMock,
+  coworkerFindFirstMock,
+  taskFindFirstMock,
+} = vi.hoisted(() => ({
+  authContextState: {
+    current: {
+      actor: "user",
+      userId: "user_123",
+      organizationId: "org_123",
+      role: "user",
+    } as
+      | {
+          actor: "user";
+          userId: string;
+          organizationId: string | null;
+          role: string;
+        }
+      | {
+          actor: "coworker";
+          coworkerId: string;
+          vendorId?: string;
+          context?: { userId: string; organizationId: string | null };
+        }
+      | null,
+  },
+  jobFindFirstMock: vi.fn(),
+  coworkerFindFirstMock: vi.fn(),
+  taskFindFirstMock: vi.fn(),
+}));
 
 vi.mock("@/middleware/auth", () => ({
   authMiddleware: async (
@@ -117,7 +122,15 @@ vi.mock("@/middleware/workspace", async (importOriginal) => {
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: (...args: unknown[]) => prismaTransactionMock(...args),
+    job: {
+      findFirst: jobFindFirstMock,
+    },
+    coworker: {
+      findFirst: coworkerFindFirstMock,
+    },
+    task: {
+      findFirst: taskFindFirstMock,
+    },
   },
 }));
 
@@ -256,15 +269,9 @@ describe("GET /jobs/{id}", () => {
       organizationId: "org_123",
       role: "user",
     };
-    prismaTransactionMock.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) =>
-        await callback({
-          job: {
-            findFirst: jobFindFirstMock,
-          },
-        }),
-    );
     jobFindFirstMock.mockResolvedValue(createJob());
+    coworkerFindFirstMock.mockReset();
+    taskFindFirstMock.mockReset();
   });
 
   it("returns a rich job details payload", async () => {
@@ -369,26 +376,18 @@ describe("GET /jobs/{id}", () => {
       vendorId: TEST_VENDOR_ID,
       context: { userId: "user_123", organizationId: "org_123" },
     };
-    const coworkerFindFirstMock = vi.fn().mockResolvedValue({
+    coworkerFindFirstMock.mockResolvedValue({
       id: "cow_123",
       slug: "ops-agent",
       baseURL: null,
     });
-    const taskFindFirstMock = vi.fn().mockResolvedValue({
+    taskFindFirstMock.mockResolvedValue({
       id: "tsk_123",
       coworkerId: "cow_123",
       status: TaskStatus.READY,
       coworker: { vendorId: TEST_VENDOR_ID },
     });
     jobFindFirstMock.mockResolvedValue({ ...createJob(), taskId: "tsk_123" });
-    prismaTransactionMock.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) =>
-        await callback({
-          coworker: { findFirst: coworkerFindFirstMock },
-          job: { findFirst: jobFindFirstMock },
-          task: { findFirst: taskFindFirstMock },
-        }),
-    );
 
     const app = createApp();
     const response = await app.request("http://localhost/job_123");
@@ -411,26 +410,18 @@ describe("GET /jobs/{id}", () => {
       vendorId: TEST_VENDOR_ID,
       context: { userId: "user_123", organizationId: "org_123" },
     };
-    const coworkerFindFirstMock = vi.fn().mockResolvedValue({
+    coworkerFindFirstMock.mockResolvedValue({
       id: "cow_123",
       slug: "ops-agent",
       baseURL: null,
     });
-    const taskFindFirstMock = vi.fn().mockResolvedValue({
+    taskFindFirstMock.mockResolvedValue({
       id: "tsk_123",
       coworkerId: "cow_other",
       status: TaskStatus.READY,
       coworker: { vendorId: TEST_VENDOR_ID },
     });
     jobFindFirstMock.mockResolvedValue({ ...createJob(), taskId: "tsk_123" });
-    prismaTransactionMock.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) =>
-        await callback({
-          coworker: { findFirst: coworkerFindFirstMock },
-          job: { findFirst: jobFindFirstMock },
-          task: { findFirst: taskFindFirstMock },
-        }),
-    );
 
     const app = createApp();
     const response = await app.request("http://localhost/job_123");
@@ -445,21 +436,13 @@ describe("GET /jobs/{id}", () => {
       vendorId: TEST_VENDOR_ID,
       context: { userId: "user_123", organizationId: "org_123" },
     };
-    const coworkerFindFirstMock = vi.fn().mockResolvedValue({
+    coworkerFindFirstMock.mockResolvedValue({
       id: "cow_123",
       slug: "ops-agent",
       baseURL: null,
     });
-    const taskFindFirstMock = vi.fn().mockResolvedValue(null);
+    taskFindFirstMock.mockResolvedValue(null);
     jobFindFirstMock.mockResolvedValue({ ...createJob(), taskId: "tsk_123" });
-    prismaTransactionMock.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) =>
-        await callback({
-          coworker: { findFirst: coworkerFindFirstMock },
-          job: { findFirst: jobFindFirstMock },
-          task: { findFirst: taskFindFirstMock },
-        }),
-    );
 
     const app = createApp();
     const response = await app.request("http://localhost/job_123");

--- a/apps/core/src/routes/v1/jobs/[id]/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/get.ts
@@ -111,23 +111,19 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const { id } = c.req.valid("param");
 
-    const job = await prisma.$transaction(async (tx) => {
-      // Authorize the read (workspace scope for users; assigned-task scope for
-      // delegated coworkers) before loading full details.
-      await requireJobReadForRouteVars(c.var, id, tx);
-      const job = await tx.job.findFirst({
-        where: {
-          id,
-          workspaceId: workspaceContext.workspaceId,
-        },
-        include: jobInclude,
-      });
-      if (!job) {
-        throw notFound("Job not found");
-      }
-      return serializeJobDetails(mapJobWithStatus(job));
+    await requireJobReadForRouteVars(c.var, id, prisma);
+    const job = await prisma.job.findFirst({
+      where: {
+        id,
+        workspaceId: workspaceContext.workspaceId,
+      },
+      include: jobInclude,
     });
+    if (!job) {
+      throw notFound("Job not found");
+    }
+    const payload = serializeJobDetails(mapJobWithStatus(job));
 
-    return ok(c, jobSchema.parse(job));
+    return ok(c, jobSchema.parse(payload));
   });
 }

--- a/apps/core/src/routes/v1/jobs/[id]/input-request/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/input-request/get.ts
@@ -64,28 +64,25 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { id } = c.req.valid("param");
 
-    const jobEvent = await prisma.$transaction(async (tx) => {
-      await requireJobReadForRouteVars(c.var, id, tx);
-      const jobEvent = await tx.jobEvent.findFirst({
-        where: {
-          jobId: id,
-          status: AgentJobStatus.AWAITING_INPUT,
-          input: { is: null },
-        },
-        orderBy: {
-          createdAt: "asc",
-        },
-        take: 1,
-      });
-      if (!jobEvent) {
-        throw notFound("No input request found");
-      }
-
-      if (!jobEvent.inputSchema) {
-        throw unprocessableEntity("Agent did not provide an input schema");
-      }
-      return jobEvent;
+    await requireJobReadForRouteVars(c.var, id, prisma);
+    const jobEvent = await prisma.jobEvent.findFirst({
+      where: {
+        jobId: id,
+        status: AgentJobStatus.AWAITING_INPUT,
+        input: { is: null },
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+      take: 1,
     });
+    if (!jobEvent) {
+      throw notFound("No input request found");
+    }
+
+    if (!jobEvent.inputSchema) {
+      throw unprocessableEntity("Agent did not provide an input schema");
+    }
 
     const inputRequest = {
       eventId: jobEvent.id,

--- a/apps/core/src/routes/v1/jobs/[id]/links/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/links/get.ts
@@ -64,15 +64,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { id } = c.req.valid("param");
 
-    const links = await prisma.$transaction(async (tx) => {
-      await requireJobReadForRouteVars(c.var, id, tx);
-      const links = await tx.link.findMany({
-        where: { event: { jobId: id } },
-        include: linkWithJobIdInclude,
-      });
-      return links.map(flattenLinkJobId);
+    await requireJobReadForRouteVars(c.var, id, prisma);
+    const links = await prisma.link.findMany({
+      where: { event: { jobId: id } },
+      include: linkWithJobIdInclude,
     });
+    const payload = links.map(flattenLinkJobId);
 
-    return ok(c, linksSchema.parse(links));
+    return ok(c, linksSchema.parse(payload));
   });
 }

--- a/apps/core/src/routes/v1/organizations/[id]/billing-plan/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-plan/get.ts
@@ -59,15 +59,16 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireOwnerUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    const billingPlan = await prisma.$transaction(async (tx) => {
-      const { organization } = await resolveMemberOrganizationById({
-        id,
-        userId: userContext.userId,
-        tx,
-      });
-
-      return await resolveOrganizationBillingPlan(organization.id, tx);
+    const { organization } = await resolveMemberOrganizationById({
+      id,
+      userId: userContext.userId,
+      tx: prisma,
     });
+
+    const billingPlan = await resolveOrganizationBillingPlan(
+      organization.id,
+      prisma,
+    );
 
     return ok(
       c,

--- a/apps/core/src/routes/v1/organizations/[id]/enterprise-contract-summary/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/enterprise-contract-summary/get.ts
@@ -67,20 +67,22 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id } = c.req.valid("param");
     const now = new Date();
 
-    const summary = await prisma.$transaction(async (tx) => {
-      await resolveMemberOrganizationById({
-        id,
-        userId: userContext.userId,
-        tx,
-      });
-
-      const billingPlan = await resolveOrganizationBillingPlan(id, tx, now);
-      if (billingPlan.mode !== "enterprise_contract") {
-        return null;
-      }
-
-      return getEnterpriseContractBillingSummary(billingPlan, id, tx, now);
+    await resolveMemberOrganizationById({
+      id,
+      userId: userContext.userId,
+      tx: prisma,
     });
+
+    const billingPlan = await resolveOrganizationBillingPlan(id, prisma, now);
+    const summary =
+      billingPlan.mode === "enterprise_contract"
+        ? await getEnterpriseContractBillingSummary(
+            billingPlan,
+            id,
+            prisma,
+            now,
+          )
+        : null;
 
     if (!summary) {
       throw notFound("Organization is not on an enterprise contract");

--- a/apps/core/src/routes/v1/organizations/[id]/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/get.test.ts
@@ -4,8 +4,9 @@ import { OpenAPIHonoWithAuth } from "@/lib/hono";
 import type { AuthenticationContext } from "@/middleware/auth";
 import { TEST_VENDOR_ID } from "@/test-fixtures/vendor.js";
 
-const { prismaTransactionMock } = vi.hoisted(() => ({
-  prismaTransactionMock: vi.fn(),
+const { organizationFindUniqueMock, memberFindUniqueMock } = vi.hoisted(() => ({
+  organizationFindUniqueMock: vi.fn(),
+  memberFindUniqueMock: vi.fn(),
 }));
 
 vi.mock("@/middleware/auth", async (importOriginal) => ({
@@ -43,7 +44,12 @@ vi.mock("@/middleware/auth", async (importOriginal) => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
+    organization: {
+      findUnique: organizationFindUniqueMock,
+    },
+    member: {
+      findUnique: memberFindUniqueMock,
+    },
   },
 }));
 
@@ -59,15 +65,6 @@ const COWORKER_AUTH_CONTEXT: AuthenticationContext = {
   coworkerId: "cow_123",
   vendorId: TEST_VENDOR_ID,
 };
-
-interface TransactionMock {
-  organization: {
-    findUnique: ReturnType<typeof vi.fn>;
-  };
-  member: {
-    findUnique: ReturnType<typeof vi.fn>;
-  };
-}
 
 let mountGetOrganization: (app: OpenAPIHonoWithAuth) => void;
 
@@ -109,10 +106,9 @@ function createApp(
   return app;
 }
 
-function mockTransaction(tx: TransactionMock) {
-  prismaTransactionMock.mockImplementation(async (callback) => {
-    return await callback(tx);
-  });
+function mockOrgLookup(args: { organization: unknown; member?: unknown }) {
+  organizationFindUniqueMock.mockResolvedValue(args.organization);
+  memberFindUniqueMock.mockResolvedValue(args.member ?? null);
 }
 
 beforeAll(async () => {
@@ -139,19 +135,13 @@ describe("GET /organizations/{id}", () => {
     const response = await app.request("http://localhost/org_123");
 
     expect(response.status).toBe(403);
-    expect(prismaTransactionMock).not.toHaveBeenCalled();
   });
 
   it("returns 403 when the user is not a member of the organization", async () => {
-    const tx: TransactionMock = {
-      organization: {
-        findUnique: vi.fn().mockResolvedValue(createOrganization()),
-      },
-      member: {
-        findUnique: vi.fn().mockResolvedValue(null),
-      },
-    };
-    mockTransaction(tx);
+    mockOrgLookup({
+      organization: createOrganization(),
+      member: null,
+    });
 
     const app = createApp();
     const response = await app.request("http://localhost/org_123");
@@ -160,35 +150,20 @@ describe("GET /organizations/{id}", () => {
   });
 
   it("returns 404 when the organization does not exist", async () => {
-    const tx: TransactionMock = {
-      organization: {
-        findUnique: vi.fn().mockResolvedValue(null),
-      },
-      member: {
-        findUnique: vi.fn(),
-      },
-    };
-    mockTransaction(tx);
+    mockOrgLookup({ organization: null });
 
     const app = createApp();
     const response = await app.request("http://localhost/missing-org");
 
     expect(response.status).toBe(404);
-    expect(tx.member.findUnique).not.toHaveBeenCalled();
+    expect(memberFindUniqueMock).not.toHaveBeenCalled();
   });
 
   it("returns the organization payload when resolved by id", async () => {
-    const tx: TransactionMock = {
-      organization: {
-        findUnique: vi.fn().mockResolvedValue(createOrganization()),
-      },
-      member: {
-        findUnique: vi.fn().mockResolvedValue({
-          role: "member",
-        }),
-      },
-    };
-    mockTransaction(tx);
+    mockOrgLookup({
+      organization: createOrganization(),
+      member: { role: "member" },
+    });
 
     const app = createApp();
     const response = await app.request("http://localhost/org_123");
@@ -203,23 +178,15 @@ describe("GET /organizations/{id}", () => {
   });
 
   it("returns 404 when the identifier only matches a slug", async () => {
-    const tx: TransactionMock = {
-      organization: {
-        findUnique: vi.fn().mockResolvedValueOnce(null),
-      },
-      member: {
-        findUnique: vi.fn(),
-      },
-    };
-    mockTransaction(tx);
+    mockOrgLookup({ organization: null });
 
     const app = createApp();
     const response = await app.request("http://localhost/acme");
 
     expect(response.status).toBe(404);
-    expect(tx.organization.findUnique).toHaveBeenCalledWith({
+    expect(organizationFindUniqueMock).toHaveBeenCalledWith({
       where: { id: "acme" },
     });
-    expect(tx.member.findUnique).not.toHaveBeenCalled();
+    expect(memberFindUniqueMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/organizations/[id]/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/get.ts
@@ -61,20 +61,18 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = await requireAuthorizedUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    const organization = await prisma.$transaction(async (tx) => {
-      const { organization, role } = await resolveMemberOrganizationById({
-        id,
-        userId: userContext.userId,
-        tx,
-      });
-
-      return {
-        ...organization,
-        metadata: parseOrganizationMetadata(organization.metadata),
-        role,
-      };
+    const { organization, role } = await resolveMemberOrganizationById({
+      id,
+      userId: userContext.userId,
+      tx: prisma,
     });
 
-    return ok(c, organizationWithRoleSchema.parse(organization));
+    const payload = {
+      ...organization,
+      metadata: parseOrganizationMetadata(organization.metadata),
+      role,
+    };
+
+    return ok(c, organizationWithRoleSchema.parse(payload));
   });
 }

--- a/apps/core/src/routes/v1/organizations/[id]/seat-summary/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/seat-summary/get.test.ts
@@ -11,14 +11,12 @@ const {
   memberCountMock,
   getAssignedMemberCountMock,
   resolveOrganizationBillingPlanMock,
-  transactionMock,
 } = vi.hoisted(() => ({
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
   memberCountMock: vi.fn(),
   getAssignedMemberCountMock: vi.fn(),
   resolveOrganizationBillingPlanMock: vi.fn(),
-  transactionMock: vi.fn(),
 }));
 
 vi.mock("@/middleware/auth", async (importOriginal) => {
@@ -47,7 +45,13 @@ vi.mock("@/middleware/auth", async (importOriginal) => {
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: (...args: unknown[]) => transactionMock(...args),
+    organization: {
+      findUnique: organizationFindUniqueMock,
+    },
+    member: {
+      findUnique: memberFindUniqueMock,
+      count: memberCountMock,
+    },
   },
 }));
 
@@ -119,16 +123,6 @@ beforeAll(async () => {
 describe("GET /organizations/{id}/seat-summary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    transactionMock.mockImplementation(
-      async (callback: (tx: unknown) => unknown) =>
-        callback({
-          organization: { findUnique: organizationFindUniqueMock },
-          member: {
-            findUnique: memberFindUniqueMock,
-            count: memberCountMock,
-          },
-        }),
-    );
   });
 
   it("returns 404 when the organization does not exist", async () => {
@@ -148,7 +142,6 @@ describe("GET /organizations/{id}/seat-summary", () => {
       "http://localhost/org_123/seat-summary",
     );
     expect(response.status).toBe(403);
-    expect(transactionMock).not.toHaveBeenCalled();
   });
 
   it("returns zeroed seat entitlements for free organizations", async () => {

--- a/apps/core/src/routes/v1/organizations/[id]/seat-summary/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/seat-summary/get.ts
@@ -63,38 +63,36 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireOwnerUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    const summary = await prisma.$transaction(async (tx) => {
-      const { organization } = await resolveMemberOrganizationById({
-        id,
-        userId: userContext.userId,
-        tx,
-      });
-
-      const [assignedCount, memberCount, billingPlan] = await Promise.all([
-        memberRepository.getAssignedMemberCount(organization.id, tx),
-        tx.member.count({
-          where: {
-            organizationId: organization.id,
-          },
-        }),
-        resolveOrganizationBillingPlan(organization.id, tx),
-      ]);
-
-      const paidPlan = billingPlan.plan === "free" ? null : billingPlan.plan;
-      const purchasedSeats = billingPlan.purchasedSeats;
-      const hasSeatEntitlements = paidPlan != null;
-
-      return {
-        assignedCount: hasSeatEntitlements ? assignedCount : 0,
-        memberCount,
-        isEnterpriseContract: billingPlan.mode === "enterprise_contract",
-        paidPlan,
-        purchasedSeats,
-        unusedSeats: hasSeatEntitlements
-          ? getUnusedSeatCount(purchasedSeats, assignedCount)
-          : 0,
-      };
+    const { organization } = await resolveMemberOrganizationById({
+      id,
+      userId: userContext.userId,
+      tx: prisma,
     });
+
+    const [assignedCount, memberCount, billingPlan] = await Promise.all([
+      memberRepository.getAssignedMemberCount(organization.id, prisma),
+      prisma.member.count({
+        where: {
+          organizationId: organization.id,
+        },
+      }),
+      resolveOrganizationBillingPlan(organization.id, prisma),
+    ]);
+
+    const paidPlan = billingPlan.plan === "free" ? null : billingPlan.plan;
+    const purchasedSeats = billingPlan.purchasedSeats;
+    const hasSeatEntitlements = paidPlan != null;
+
+    const summary = {
+      assignedCount: hasSeatEntitlements ? assignedCount : 0,
+      memberCount,
+      isEnterpriseContract: billingPlan.mode === "enterprise_contract",
+      paidPlan,
+      purchasedSeats,
+      unusedSeats: hasSeatEntitlements
+        ? getUnusedSeatCount(purchasedSeats, assignedCount)
+        : 0,
+    };
 
     return ok(c, organizationSeatSummarySchema.parse(summary));
   });

--- a/apps/core/src/routes/v1/organizations/[id]/subscription/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/subscription/get.ts
@@ -61,18 +61,17 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireOwnerUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    const subscription = await prisma.$transaction(async (tx) => {
-      const { organization } = await resolveMemberOrganizationById({
-        id,
-        userId: userContext.userId,
-        tx,
-      });
-
-      return await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
-        organization.id,
-        tx,
-      );
+    const { organization } = await resolveMemberOrganizationById({
+      id,
+      userId: userContext.userId,
+      tx: prisma,
     });
+
+    const subscription =
+      await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
+        organization.id,
+        prisma,
+      );
 
     return ok(c, activeSubscriptionResponseSchema.parse({ subscription }));
   });

--- a/apps/core/src/routes/v1/organizations/slug/[slug]/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/slug/[slug]/get.test.ts
@@ -4,8 +4,9 @@ import { OpenAPIHonoWithAuth } from "@/lib/hono";
 import type { AuthenticationContext } from "@/middleware/auth";
 import { TEST_VENDOR_ID } from "@/test-fixtures/vendor.js";
 
-const { prismaTransactionMock } = vi.hoisted(() => ({
-  prismaTransactionMock: vi.fn(),
+const { organizationFindUniqueMock, memberFindUniqueMock } = vi.hoisted(() => ({
+  organizationFindUniqueMock: vi.fn(),
+  memberFindUniqueMock: vi.fn(),
 }));
 
 vi.mock("@/middleware/auth", async (importOriginal) => ({
@@ -43,7 +44,12 @@ vi.mock("@/middleware/auth", async (importOriginal) => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
+    organization: {
+      findUnique: organizationFindUniqueMock,
+    },
+    member: {
+      findUnique: memberFindUniqueMock,
+    },
   },
 }));
 
@@ -59,15 +65,6 @@ const COWORKER_AUTH_CONTEXT: AuthenticationContext = {
   coworkerId: "cow_123",
   vendorId: TEST_VENDOR_ID,
 };
-
-interface TransactionMock {
-  organization: {
-    findUnique: ReturnType<typeof vi.fn>;
-  };
-  member: {
-    findUnique: ReturnType<typeof vi.fn>;
-  };
-}
 
 let mountGetOrganizationBySlug: (app: OpenAPIHonoWithAuth) => void;
 let mountGetOrganization: (app: OpenAPIHonoWithAuth) => void;
@@ -113,10 +110,9 @@ function createApp(
   return app;
 }
 
-function mockTransaction(tx: TransactionMock) {
-  prismaTransactionMock.mockImplementation(async (callback) => {
-    return await callback(tx);
-  });
+function mockOrgLookup(args: { organization: unknown; member?: unknown }) {
+  organizationFindUniqueMock.mockResolvedValue(args.organization);
+  memberFindUniqueMock.mockResolvedValue(args.member ?? null);
 }
 
 beforeAll(async () => {
@@ -143,19 +139,13 @@ describe("GET /organizations/slug/{slug}", () => {
     const response = await app.request("http://localhost/slug/acme");
 
     expect(response.status).toBe(403);
-    expect(prismaTransactionMock).not.toHaveBeenCalled();
   });
 
   it("returns 403 when the user is not a member of the organization", async () => {
-    const tx: TransactionMock = {
-      organization: {
-        findUnique: vi.fn().mockResolvedValue(createOrganization()),
-      },
-      member: {
-        findUnique: vi.fn().mockResolvedValue(null),
-      },
-    };
-    mockTransaction(tx);
+    mockOrgLookup({
+      organization: createOrganization(),
+      member: null,
+    });
 
     const app = createApp();
     const response = await app.request("http://localhost/slug/acme");
@@ -164,40 +154,23 @@ describe("GET /organizations/slug/{slug}", () => {
   });
 
   it("returns 404 when no organization matches the slug", async () => {
-    const tx: TransactionMock = {
-      organization: {
-        findUnique: vi.fn().mockResolvedValue(null),
-      },
-      member: {
-        findUnique: vi.fn(),
-      },
-    };
-    mockTransaction(tx);
+    mockOrgLookup({ organization: null });
 
     const app = createApp();
     const response = await app.request("http://localhost/slug/missing-org");
 
     expect(response.status).toBe(404);
-    expect(tx.member.findUnique).not.toHaveBeenCalled();
+    expect(memberFindUniqueMock).not.toHaveBeenCalled();
   });
 
   it("returns the raw organization record when resolved by slug", async () => {
-    const tx: TransactionMock = {
-      organization: {
-        findUnique: vi.fn().mockResolvedValue(
-          createOrganization({
-            metadata: '{"url":"https://example.com"}',
-            stripeCustomerId: "cus_123",
-          }),
-        ),
-      },
-      member: {
-        findUnique: vi.fn().mockResolvedValue({
-          role: "member",
-        }),
-      },
-    };
-    mockTransaction(tx);
+    mockOrgLookup({
+      organization: createOrganization({
+        metadata: '{"url":"https://example.com"}',
+        stripeCustomerId: "cus_123",
+      }),
+      member: { role: "member" },
+    });
 
     const app = createApp();
     const response = await app.request("http://localhost/slug/acme");
@@ -213,29 +186,22 @@ describe("GET /organizations/slug/{slug}", () => {
       stripeCustomerId: "cus_123",
     });
     expect(body.data).not.toHaveProperty("role");
-    expect(tx.organization.findUnique).toHaveBeenCalledWith({
+    expect(organizationFindUniqueMock).toHaveBeenCalledWith({
       where: { slug: "acme" },
     });
   });
 
   it("is not shadowed by the `/{id}` route", async () => {
-    const tx: TransactionMock = {
-      organization: {
-        findUnique: vi.fn().mockResolvedValue(createOrganization()),
-      },
-      member: {
-        findUnique: vi.fn().mockResolvedValue({
-          role: "member",
-        }),
-      },
-    };
-    mockTransaction(tx);
+    mockOrgLookup({
+      organization: createOrganization(),
+      member: { role: "member" },
+    });
 
     const app = createApp();
     const response = await app.request("http://localhost/slug/acme");
 
     expect(response.status).toBe(200);
-    expect(tx.organization.findUnique).toHaveBeenCalledWith({
+    expect(organizationFindUniqueMock).toHaveBeenCalledWith({
       where: { slug: "acme" },
     });
   });

--- a/apps/core/src/routes/v1/organizations/slug/[slug]/get.ts
+++ b/apps/core/src/routes/v1/organizations/slug/[slug]/get.ts
@@ -59,14 +59,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = await requireAuthorizedUserContext(c.var.authContext);
     const { slug } = c.req.valid("param");
 
-    const organization = await prisma.$transaction(async (tx) => {
-      const { organization } = await resolveMemberOrganizationBySlug({
-        slug,
-        userId: userContext.userId,
-        tx,
-      });
-
-      return organization;
+    const { organization } = await resolveMemberOrganizationBySlug({
+      slug,
+      userId: userContext.userId,
+      tx: prisma,
     });
 
     return ok(c, organizationRecordSchema.parse(organization));

--- a/apps/core/src/routes/v1/tasks/[id]/events/get.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/get.ts
@@ -34,14 +34,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { id } = c.req.valid("param");
 
-    const events = await prisma.$transaction(async (tx) => {
-      await requireTaskReadForRouteVars(c.var, id, tx);
+    await requireTaskReadForRouteVars(c.var, id, prisma);
 
-      return tx.taskEvent.findMany({
-        where: { taskId: id },
-        orderBy: { createdAt: "asc" },
-        include: taskEventApiInclude,
-      });
+    const events = await prisma.taskEvent.findMany({
+      where: { taskId: id },
+      orderBy: { createdAt: "asc" },
+      include: taskEventApiInclude,
     });
 
     return ok(

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/get.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/get.test.ts
@@ -13,13 +13,8 @@ vi.mock("@/middleware/auth", async (importOriginal) => {
   return { ...actual, authMiddleware: stubAuthMiddleware };
 });
 
-const {
-  jobFindManyMock,
-  prismaTransactionMock,
-  requireTaskReadForRouteVarsMock,
-} = vi.hoisted(() => ({
+const { jobFindManyMock, requireTaskReadForRouteVarsMock } = vi.hoisted(() => ({
   jobFindManyMock: vi.fn(),
-  prismaTransactionMock: vi.fn(),
   requireTaskReadForRouteVarsMock: vi.fn(),
 }));
 
@@ -29,7 +24,9 @@ vi.mock("@/helpers/access-control", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    $transaction: prismaTransactionMock,
+    job: {
+      findMany: jobFindManyMock,
+    },
   },
 }));
 
@@ -64,13 +61,6 @@ describe("GET /tasks/{id}/jobs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     requireTaskReadForRouteVarsMock.mockResolvedValue(undefined);
-    prismaTransactionMock.mockImplementation(async (callback) => {
-      return await callback({
-        job: {
-          findMany: jobFindManyMock,
-        },
-      });
-    });
     jobFindManyMock.mockResolvedValue([]);
   });
 

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/get.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/get.ts
@@ -35,17 +35,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { id } = c.req.valid("param");
 
-    const jobs = await prisma.$transaction(async (tx) => {
-      await requireTaskReadForRouteVars(c.var, id, tx);
+    await requireTaskReadForRouteVars(c.var, id, prisma);
 
-      const jobsList = await tx.job.findMany({
-        where: { taskId: id },
-        include: jobListSummaryInclude,
-        orderBy: { createdAt: "asc" },
-      });
-
-      return jobsList.map((job) => flattenJob(job));
+    const jobsList = await prisma.job.findMany({
+      where: { taskId: id },
+      include: jobListSummaryInclude,
+      orderBy: { createdAt: "asc" },
     });
+
+    const jobs = jobsList.map((job) => flattenJob(job));
 
     return ok(c, jobSummariesSchema.parse(jobs));
   });

--- a/apps/core/src/routes/v1/tasks/[id]/links/get.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/links/get.ts
@@ -36,18 +36,16 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { id } = c.req.valid("param");
 
-    const row = await prisma.$transaction(async (tx) => {
-      await requireTaskReadForRouteVars(c.var, id, tx);
-      return tx.task.findUnique({
-        where: { id, archivedAt: null },
-        select: {
-          id: true,
-          ...buildVisibleTaskLinksInclude(
-            c.var.authContext,
-            c.var.workspaceContext?.workspaceId,
-          ),
-        },
-      });
+    await requireTaskReadForRouteVars(c.var, id, prisma);
+    const row = await prisma.task.findUnique({
+      where: { id, archivedAt: null },
+      select: {
+        id: true,
+        ...buildVisibleTaskLinksInclude(
+          c.var.authContext,
+          c.var.workspaceContext?.workspaceId,
+        ),
+      },
     });
 
     if (!row) {

--- a/apps/core/src/routes/v1/tasks/[id]/links/links.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/links/links.test.ts
@@ -50,6 +50,9 @@ vi.mock("@/helpers/access-control", () => ({
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     $transaction: prismaTransactionMock,
+    task: {
+      findUnique: taskFindUniqueMock,
+    },
   },
 }));
 

--- a/apps/core/src/routes/v1/users/[id]/coworker-user-route-allowlist.test.ts
+++ b/apps/core/src/routes/v1/users/[id]/coworker-user-route-allowlist.test.ts
@@ -49,6 +49,9 @@ vi.mock("@/lib/db/prisma", () => ({
     user: {
       findUnique: userFindUniqueMock,
     },
+    member: {
+      findMany: memberFindManyMock,
+    },
     $transaction: prismaTransactionMock,
   },
 }));
@@ -168,7 +171,7 @@ describe("coworker user route allowlist", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     assertCoworkerUserContextBindingMock.mockResolvedValue(undefined);
-    userFindUniqueMock.mockResolvedValue({ id: "user_123" });
+    userFindUniqueMock.mockResolvedValue(USER_RECORD);
     buildCreditsPayloadMock.mockResolvedValue(CREDITS_PAYLOAD);
     resolveMemberOrganizationByIdMock.mockResolvedValue({
       organization: { id: "org_1" },

--- a/apps/core/src/routes/v1/users/[id]/credits/get.ts
+++ b/apps/core/src/routes/v1/users/[id]/credits/get.ts
@@ -99,19 +99,15 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
       c.var.userRouteContext,
     );
 
-    const payload = await prisma.$transaction(async (tx) => {
-      const organizationId =
-        userContext.userId === resolvedUserId
-          ? userContext.organizationId
-          : null;
-      const referenceId = organizationId ?? resolvedUserId;
+    const organizationId =
+      userContext.userId === resolvedUserId ? userContext.organizationId : null;
+    const referenceId = organizationId ?? resolvedUserId;
 
-      return await buildCreditsPayload({
-        userId: resolvedUserId,
-        organizationId,
-        referenceId,
-        tx,
-      });
+    const payload = await buildCreditsPayload({
+      userId: resolvedUserId,
+      organizationId,
+      referenceId,
+      tx: prisma,
     });
 
     return ok(c, creditsResponseSchema.parse(payload));

--- a/apps/core/src/routes/v1/users/[id]/get.ts
+++ b/apps/core/src/routes/v1/users/[id]/get.ts
@@ -13,7 +13,7 @@ import {
   requireUserRouteContext,
   type UserRouteVariables,
 } from "@/routes/v1/users/user-route-context";
-import { type User, userSchema } from "@/schemas/user.schema";
+import { userSchema } from "@/schemas/user.schema";
 
 const params = z.object({
   id: usersRoutePathUserIdSchema,
@@ -57,17 +57,13 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
     c.req.valid("param");
     const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
 
-    const user: User = await prisma.$transaction(async (tx) => {
-      const user = await tx.user.findUnique({
-        where: { id: resolvedUserId },
-      });
-      if (!user) {
-        throw notFound("User not found");
-      }
-
-      return userSchema.parse(user);
+    const user = await prisma.user.findUnique({
+      where: { id: resolvedUserId },
     });
+    if (!user) {
+      throw notFound("User not found");
+    }
 
-    return ok(c, user);
+    return ok(c, userSchema.parse(user));
   });
 }

--- a/apps/core/src/routes/v1/users/[id]/notices/pending/get.ts
+++ b/apps/core/src/routes/v1/users/[id]/notices/pending/get.ts
@@ -60,37 +60,35 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
     const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
 
     const now = new Date();
-    const pendingNotices = await prisma.$transaction(async (tx) => {
-      const user = await tx.user.findUnique({
-        where: { id: resolvedUserId },
-        select: { id: true, createdAt: true },
-      });
-      if (!user) {
-        throw internalServerError("Failed to retrieve user");
-      }
+    const user = await prisma.user.findUnique({
+      where: { id: resolvedUserId },
+      select: { id: true, createdAt: true },
+    });
+    if (!user) {
+      throw internalServerError("Failed to retrieve user");
+    }
 
-      return await tx.notice.findMany({
-        where: {
-          isActive: true,
-          effectiveAt: {
-            lte: now,
-            gt: user.createdAt,
-          },
-          acknowledgments: {
-            none: {
-              userId: user.id,
-            },
+    const pendingNotices = await prisma.notice.findMany({
+      where: {
+        isActive: true,
+        effectiveAt: {
+          lte: now,
+          gt: user.createdAt,
+        },
+        acknowledgments: {
+          none: {
+            userId: user.id,
           },
         },
-        orderBy: [
-          {
-            effectiveAt: "asc",
-          },
-          {
-            createdAt: "asc",
-          },
-        ],
-      });
+      },
+      orderBy: [
+        {
+          effectiveAt: "asc",
+        },
+        {
+          createdAt: "asc",
+        },
+      ],
     });
 
     return ok(

--- a/apps/core/src/routes/v1/users/[id]/organizations/[organizationId]/credits/get.ts
+++ b/apps/core/src/routes/v1/users/[id]/organizations/[organizationId]/credits/get.ts
@@ -104,18 +104,16 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
     const { organizationId } = c.req.valid("param");
     const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
 
-    const payload = await prisma.$transaction(async (tx) => {
-      const { organization } = await resolveMemberOrganizationById({
-        id: organizationId,
-        userId: resolvedUserId,
-        tx,
-      });
-      return await buildCreditsPayload({
-        userId: resolvedUserId,
-        organizationId: organization.id,
-        referenceId: organization.id,
-        tx,
-      });
+    const { organization } = await resolveMemberOrganizationById({
+      id: organizationId,
+      userId: resolvedUserId,
+      tx: prisma,
+    });
+    const payload = await buildCreditsPayload({
+      userId: resolvedUserId,
+      organizationId: organization.id,
+      referenceId: organization.id,
+      tx: prisma,
     });
 
     return ok(c, creditsResponseSchema.parse(payload));

--- a/apps/core/src/routes/v1/users/[id]/organizations/get.ts
+++ b/apps/core/src/routes/v1/users/[id]/organizations/get.ts
@@ -63,22 +63,19 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
     c.req.valid("param");
     const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
 
-    const organizations = await prisma.$transaction(async (tx) => {
-      const members = await tx.member.findMany({
-        where: { userId: resolvedUserId },
-        include: { organization: true },
-      });
-
-      if (members.length === 0) {
-        return [];
-      }
-
-      return members.map((member) => ({
-        ...member.organization,
-        metadata: parseOrganizationMetadata(member.organization.metadata),
-        role: member.role,
-      }));
+    const members = await prisma.member.findMany({
+      where: { userId: resolvedUserId },
+      include: { organization: true },
     });
+
+    const organizations =
+      members.length === 0
+        ? []
+        : members.map((member) => ({
+            ...member.organization,
+            metadata: parseOrganizationMetadata(member.organization.metadata),
+            role: member.role,
+          }));
     return ok(c, organizationsSchema.parse(organizations));
   });
 }

--- a/apps/core/src/routes/v1/users/[id]/preferences/get.ts
+++ b/apps/core/src/routes/v1/users/[id]/preferences/get.ts
@@ -53,19 +53,15 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
     c.req.valid("param");
     const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
 
-    const preferences = await prisma.$transaction(async (tx) => {
-      const user = await tx.user.findUnique({
-        where: { id: resolvedUserId },
-        select: USER_PREFERENCES_SELECT,
-      });
-
-      if (!user) {
-        throw internalServerError("Failed to retrieve user");
-      }
-
-      return user;
+    const user = await prisma.user.findUnique({
+      where: { id: resolvedUserId },
+      select: USER_PREFERENCES_SELECT,
     });
 
-    return ok(c, userPreferencesResponseSchema.parse(preferences));
+    if (!user) {
+      throw internalServerError("Failed to retrieve user");
+    }
+
+    return ok(c, userPreferencesResponseSchema.parse(user));
   });
 }

--- a/apps/core/src/routes/v1/users/[id]/preferences/preferences.test.ts
+++ b/apps/core/src/routes/v1/users/[id]/preferences/preferences.test.ts
@@ -89,7 +89,10 @@ function patchRequest(path: string, body: unknown) {
 describe("user preferences routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    userFindUniqueMock.mockResolvedValue({ id: "user_123" });
+    userFindUniqueMock.mockResolvedValue({
+      id: "user_123",
+      ...PREFERENCES,
+    });
     txUserFindUniqueMock.mockResolvedValue(PREFERENCES);
     prismaTransactionMock.mockImplementation(
       async (
@@ -117,7 +120,7 @@ describe("user preferences routes", () => {
     // asserting against that constant is self-referential and cannot see a
     // field leave it. The mock ignores `select`, so this literal is the only
     // guard that a narrowed projection would 500 on the response schema parse.
-    expect(txUserFindUniqueMock).toHaveBeenCalledWith({
+    expect(userFindUniqueMock).toHaveBeenCalledWith({
       where: { id: "user_123" },
       select: {
         marketingOptIn: true,
@@ -125,6 +128,7 @@ describe("user preferences routes", () => {
         pushOptIn: true,
       },
     });
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
   });
 
   it("writes pushOptIn on PATCH and returns the stored value", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Read-only Core GET handlers no longer wrap access checks, display reads, or Redis I/O in interactive `prisma.$transaction(async (tx) => …)`. Those paths now use the default `prisma` client (including helpers that already accept `tx | PrismaClient`). Net diff is delete/trim-heavy (`546+/740-`).

## Dropped interactive tx

- `credit-costs/get.ts`
- Org: `organizations/[id]/get.ts`, `organizations/slug/[slug]/get.ts`, `seat-summary/get.ts`, `billing-plan/get.ts`, `subscription/get.ts`, `enterprise-contract-summary/get.ts`
- Jobs: `jobs/[id]/get.ts`, `files/get.ts`, `links/get.ts`, `events/get.ts`, `input-request/get.ts`
- Users: `users/[id]/get.ts`, `credits/get.ts`, `preferences/get.ts`, `organizations/get.ts`, `organizations/[organizationId]/credits/get.ts`, `notices/pending/get.ts`
- Tasks: `tasks/[id]/events/get.ts`, `jobs/get.ts`, `links/get.ts`
- `categories/get.ts`
- Chat stream: `chats/rooms/[id]/stream/get.ts`, `stream-get.ts`, plus `helpers/active-ui-stream-room-metadata.ts` (membership `findFirst`, then Redis outside any tx)
- Reviews without RepeatableRead: `agents/[id]/reviews/get.ts`, `reviews/me/get.ts`, `ratings/eligibility/get.ts`

## Kept

- `agents/[id]/get.ts` interactive tx with `AGENT_PRICING_READ_TRANSACTION_OPTIONS` (RepeatableRead / documented pricing read-skew)
- `agents/get.ts` batch `$transaction([...])` (not interactive)
- Other GET batch `$transaction([...])` (history, projects, notifications, admin lists, etc.)
- Non-GET writes and true multi-statement mutations

Did not add RepeatableRead to review/eligibility GETs. Did not touch members GET, chat room GET, drive-authorized-user-context, waitUntil emails, console logging, orchestrator dual-read, soko-bot mounts, `packages/`, or `apps/web`.

## Verification

- `rg '$transaction(async' --glob '**/get.ts' apps/core/src/routes/v1`: only remaining interactive GET is `agents/[id]/get.ts`
- `stream-get.ts` and `helpers/active-ui-stream-room-metadata.ts`: no interactive `$transaction`
- `pnpm --filter core test` on touched route tests + `agents/[id]/get.test.ts`: **20 files, 116 tests, all passed**
- CI follow-up: `chats/rooms/auth.test.ts` + `categories/index.auth.test.ts` mocks updated for default prisma. `pnpm --filter core test` on those auth files + stream/categories GET tests: **5 files, 39 tests, all passed**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3390daec-25bd-4f57-8720-645efeb339ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3390daec-25bd-4f57-8720-645efeb339ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined read operations across agents, chats, jobs, tasks, organizations, users, categories, and billing-related endpoints.
  - Existing authorization checks, filtering, validation, response formats, and error handling remain unchanged.
  - Independent data lookups may now be processed more efficiently while preserving current behavior.

- **Tests**
  - Updated automated coverage and mocks to reflect the streamlined read paths.
  - Existing authorization, membership, availability, and not-found scenarios continue to be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->