### PR TITLE
chore: drop orchestrator dual-read for chat keys and api keys

### DIFF
--- a/apps/core/src/lib/coworker-api-key.ts
+++ b/apps/core/src/lib/coworker-api-key.ts
@@ -5,16 +5,11 @@ import { createHash } from "@better-auth/utils/hash";
 
 /** Prefix for third-party vendor Coworker API keys. */
 export const COWORKER_API_KEY_PREFIX = "coworker_";
-/** Prefix for newly issued Soko Bot API keys. */
+/** Prefix for Soko Bot API keys. */
 export const SOKO_BOT_API_KEY_PREFIX = "sokoBot_";
-/** Prefix on keys issued before the sokoBot_ rename. Still accepted at auth. */
-export const LEGACY_SOKO_BOT_API_KEY_PREFIX = "orchestrator_";
 
 export function isSokoBotApiKeyToken(token: string): boolean {
-  return (
-    token.startsWith(SOKO_BOT_API_KEY_PREFIX) ||
-    token.startsWith(LEGACY_SOKO_BOT_API_KEY_PREFIX)
-  );
+  return token.startsWith(SOKO_BOT_API_KEY_PREFIX);
 }
 
 /** Length of the stored key start used for display. */

--- a/apps/core/src/middleware/auth.test.ts
+++ b/apps/core/src/middleware/auth.test.ts
@@ -146,11 +146,7 @@ describe("authMiddleware", () => {
     expect(oauthAccessTokenFindUniqueMock).not.toHaveBeenCalled();
   });
 
-  it.each([
-    "coworker_legacytoken",
-    "orchestrator_currenttoken",
-    "sokoBot_currenttoken",
-  ])(
+  it.each(["coworker_legacytoken", "sokoBot_currenttoken"])(
     "authenticates %s for a remapped Soko Bot key as the soko bot",
     async (token) => {
       coworkerApiKeyFindUniqueMock.mockResolvedValue({
@@ -184,6 +180,19 @@ describe("authMiddleware", () => {
       expect(verifyApiKeyMock).not.toHaveBeenCalled();
     },
   );
+
+  it("does not treat an orchestrator_ token as a Soko Bot API key", async () => {
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer orchestrator_currenttoken",
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(coworkerApiKeyFindUniqueMock).not.toHaveBeenCalled();
+    expect(verifyApiKeyMock).toHaveBeenCalled();
+  });
 
   it("rejects the removed orchestrator service token", async () => {
     verifyApiKeyMock.mockResolvedValue({ valid: false, key: null });

--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -321,14 +321,14 @@ describe("resolveMentionedSokoBotIds", () => {
     ).toEqual([id]);
   });
 
-  it("still matches a stored @orchestrator:<uuid> token", () => {
+  it("does not match a leftover @orchestrator:<uuid> token", () => {
     const id = "01960001-0001-7001-8001-000000000099";
     expect(
       resolveMentionedSokoBotIds({
         content: `hello @orchestrator:${id}`,
         roomSokoBots: [{ id, name: "Jarvis" }],
       }),
-    ).toEqual([id]);
+    ).toEqual([]);
   });
 
   it("lowercases an uppercase token", () => {

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -1427,15 +1427,6 @@ export function buildDirectSokoBotRoomKey(
   return `sokoBot:${userId}:${sokoBotId}`;
 }
 
-function directKeyLookup(directKey: string): string | { in: string[] } {
-  const alternate = directKey.includes("sokoBot:")
-    ? directKey.replaceAll("sokoBot:", "orchestrator:")
-    : directKey.includes("orchestrator:")
-      ? directKey.replaceAll("orchestrator:", "sokoBot:")
-      : null;
-  return alternate ? { in: [directKey, alternate] } : directKey;
-}
-
 export function buildDirectParticipantRoomKey(params: {
   currentUserId: string;
   memberUserIds: readonly string[];
@@ -2006,11 +1997,10 @@ export async function findLiveDirectByParticipantKey(
   directKey: string,
   organizationId: string | null,
 ) {
-  const key = directKeyLookup(directKey);
   const personal = await tx.chatRoom.findFirst({
     where: {
       organizationId: null,
-      directKey: key,
+      directKey,
       archivedAt: null,
     },
     include: chatRoomInclude,
@@ -2024,7 +2014,7 @@ export async function findLiveDirectByParticipantKey(
   return tx.chatRoom.findFirst({
     where: {
       organizationId,
-      directKey: key,
+      directKey,
       archivedAt: null,
     },
     include: chatRoomInclude,
@@ -2203,7 +2193,7 @@ export function resolveMentionedSokoBotIds(params: {
     ),
   );
 
-  const tokenRegex = /@(?:sokoBot|orchestrator):([0-9a-f-]{36})/gi;
+  const tokenRegex = /@sokoBot:([0-9a-f-]{36})/gi;
   for (const match of params.content.matchAll(tokenRegex)) {
     const id = match[1]?.toLowerCase();
     if (id && roomIds.has(id)) {
@@ -2333,7 +2323,7 @@ async function findOrRestoreDirectByKey(
   const existing = await tx.chatRoom.findFirst({
     where: {
       organizationId: params.organizationId,
-      directKey: directKeyLookup(params.directKey),
+      directKey: params.directKey,
     },
     include: chatRoomInclude,
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Subtract-only: drop leftover `orchestrator:` chat dual-read and `orchestrator_` Soko Bot API-key accept.

## Deleted / shrunk

- Removed `directKeyLookup` (`sokoBot:` ↔ `orchestrator:` `{ in: [...] }` dual-read) from `findLiveDirectByParticipantKey` and `findOrRestoreDirectByKey`.
- Mention regex is `@sokoBot:<uuid>` only; leftover `@orchestrator:` tokens no longer match.
- Removed `LEGACY_SOKO_BOT_API_KEY_PREFIX`. `isSokoBotApiKeyToken` accepts `sokoBot_` only. An `orchestrator_…` bearer is no longer an agent API key.

## Left alone

- Vendor `coworker_` keys (including remapped Soko Bot keys still presented as `coworker_`).
- `membership-status.ts` JSON `subject.type === "orchestrator"` remap — rewrite migration did not touch membership metadata.
- Applied migrations not rewritten.

## Verification

- Husky: `pnpm check` + `pnpm typecheck` green on both commits.
- `pnpm --filter core test src/middleware/auth.test.ts src/routes/v1/chats/rooms/helpers.test.ts src/routes/v1/soko-bots/api-keys.test.ts` — 135 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1154d6a-54f6-48a6-94b1-27712077f68a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1154d6a-54f6-48a6-94b1-27712077f68a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

