### PR TITLE
fix(core): wrap auth and invitation emails in waitUntil

### DIFF
--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -324,19 +324,21 @@ export const auth = betterAuth({
             });
           }
 
-          void webhookService
-            .callAccountCreated(account.userId, account.providerId)
-            .catch((error) => {
-              Sentry.captureException(error, {
-                tags: {
-                  context: "account_created_webhook",
-                },
-                extra: {
-                  userId: account.userId,
-                  providerId: account.providerId,
-                },
-              });
-            });
+          waitUntil(
+            webhookService
+              .callAccountCreated(account.userId, account.providerId)
+              .catch((error) => {
+                Sentry.captureException(error, {
+                  tags: {
+                    context: "account_created_webhook",
+                  },
+                  extra: {
+                    userId: account.userId,
+                    providerId: account.providerId,
+                  },
+                });
+              }),
+          );
         },
       },
     },
@@ -424,16 +426,18 @@ export const auth = betterAuth({
           return { data: guarded };
         },
         after: async (user, _ctx) => {
-          void webhookService.callUserUpdated(user).catch((error) => {
-            Sentry.captureException(error, {
-              tags: {
-                context: "user_updated_webhook",
-              },
-              extra: {
-                userId: user.id,
-              },
-            });
-          });
+          waitUntil(
+            webhookService.callUserUpdated(user).catch((error) => {
+              Sentry.captureException(error, {
+                tags: {
+                  context: "user_updated_webhook",
+                },
+                extra: {
+                  userId: user.id,
+                },
+              });
+            }),
+          );
           void handleUserUpdateStripeEmailSync(user);
         },
       },
@@ -500,24 +504,26 @@ export const auth = betterAuth({
         resetLink: url,
       });
 
-      void sendEmail({
-        to: user.email,
-        tag: "reset-password",
-        subject: email.subject,
-        html: email.html,
-      }).catch((error) => {
-        captureExternalServiceError(error, {
-          label: "reset_password_email",
-          sentry: {
-            tags: {
-              context: "reset_password_email",
+      waitUntil(
+        sendEmail({
+          to: user.email,
+          tag: "reset-password",
+          subject: email.subject,
+          html: email.html,
+        }).catch((error) => {
+          captureExternalServiceError(error, {
+            label: "reset_password_email",
+            sentry: {
+              tags: {
+                context: "reset_password_email",
+              },
             },
-          },
-          extra: {
-            userId: user.id,
-          },
-        });
-      });
+            extra: {
+              userId: user.id,
+            },
+          });
+        }),
+      );
     },
   },
   emailVerification: {
@@ -528,24 +534,26 @@ export const auth = betterAuth({
         verificationLink: url,
       });
 
-      void sendEmail({
-        to: user.email,
-        tag: "verification-email",
-        subject: email.subject,
-        html: email.html,
-      }).catch((error) => {
-        captureExternalServiceError(error, {
-          label: "verification_email",
-          sentry: {
-            tags: {
-              context: "verification_email",
+      waitUntil(
+        sendEmail({
+          to: user.email,
+          tag: "verification-email",
+          subject: email.subject,
+          html: email.html,
+        }).catch((error) => {
+          captureExternalServiceError(error, {
+            label: "verification_email",
+            sentry: {
+              tags: {
+                context: "verification_email",
+              },
             },
-          },
-          extra: {
-            userId: user.id,
-          },
-        });
-      });
+            extra: {
+              userId: user.id,
+            },
+          });
+        }),
+      );
     },
     sendOnSignUp: true,
     sendOnSignIn: true,
@@ -603,24 +611,26 @@ export const auth = betterAuth({
           name,
         });
 
-        void sendEmail({
-          to: email,
-          tag: "magic-link",
-          subject: renderedEmail.subject,
-          html: renderedEmail.html,
-        }).catch((error) => {
-          captureExternalServiceError(error, {
-            label: "magic_link_email",
-            sentry: {
-              tags: {
-                context: "magic_link_email",
+        waitUntil(
+          sendEmail({
+            to: email,
+            tag: "magic-link",
+            subject: renderedEmail.subject,
+            html: renderedEmail.html,
+          }).catch((error) => {
+            captureExternalServiceError(error, {
+              label: "magic_link_email",
+              sentry: {
+                tags: {
+                  context: "magic_link_email",
+                },
               },
-            },
-            extra: {
-              email,
-            },
-          });
-        });
+              extra: {
+                email,
+              },
+            });
+          }),
+        );
       },
     }),
     i18n({
@@ -762,25 +772,27 @@ export const auth = betterAuth({
           organizationName: data.organization.name,
         });
 
-        void sendEmail({
-          to: data.email,
-          tag: "invitation-email",
-          subject: email.subject,
-          html: email.html,
-        }).catch((error) => {
-          captureExternalServiceError(error, {
-            label: "organization_invitation_email",
-            sentry: {
-              tags: {
-                context: "organization_invitation_email",
+        waitUntil(
+          sendEmail({
+            to: data.email,
+            tag: "invitation-email",
+            subject: email.subject,
+            html: email.html,
+          }).catch((error) => {
+            captureExternalServiceError(error, {
+              label: "organization_invitation_email",
+              sentry: {
+                tags: {
+                  context: "organization_invitation_email",
+                },
               },
-            },
-            extra: {
-              invitationId: data.id,
-              organizationId: data.organization.id,
-            },
-          });
-        });
+              extra: {
+                invitationId: data.id,
+                organizationId: data.organization.id,
+              },
+            });
+          }),
+        );
       },
       invitationLimit: LIMITS.ORGANIZATION_INVITATION_LIMIT,
       cancelPendingInvitationsOnReInvite: true,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/invitations/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/invitations/post.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { renderChatRoomInvitationEmail } from "@sokosumi/email";
 import { getEmailLocale } from "@sokosumi/utils";
+import { waitUntil } from "@vercel/functions";
 
 import { sendEmail } from "@/clients/email.client";
 import { getWebAppBaseUrl } from "@/config/env";
@@ -178,26 +179,28 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       organizationName: invitation.organizationName,
     });
 
-    void sendEmail({
-      to: invitation.email,
-      tag: "chat-room-invitation-email",
-      subject: renderedEmail.subject,
-      html: renderedEmail.html,
-    }).catch((error) => {
-      captureExternalServiceError(error, {
-        label: "chat_room_invitation_email",
-        sentry: {
-          tags: {
-            context: "chat_room_invitation_email",
+    waitUntil(
+      sendEmail({
+        to: invitation.email,
+        tag: "chat-room-invitation-email",
+        subject: renderedEmail.subject,
+        html: renderedEmail.html,
+      }).catch((error) => {
+        captureExternalServiceError(error, {
+          label: "chat_room_invitation_email",
+          sentry: {
+            tags: {
+              context: "chat_room_invitation_email",
+            },
           },
-        },
-        extra: {
-          invitationId: invitation.id,
-          roomId: invitation.roomId,
-          organizationId: invitation.organizationId,
-        },
-      });
-    });
+          extra: {
+            invitationId: invitation.id,
+            roomId: invitation.roomId,
+            organizationId: invitation.organizationId,
+          },
+        });
+      }),
+    );
 
     return created(c, invitation);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Vercel can freeze fire-and-forget `void promise` work before the promise settles. Signup already registers background work with `waitUntil` from `@vercel/functions`. This PR does the same for the remaining auth emails, matching auth webhooks, and the chat-room invitation email.

**What changed**
- Wrap remaining `void sendEmail(...).catch(...)` and bare `void webhookService...catch(...)` in `waitUntil(...)`.
- Keep existing `.catch` / `captureExternalServiceError` / Sentry handling.
- Leave sites that already used `waitUntil` (signup bonus, Stripe customer create/delete, user-created webhook) unchanged. Leave `void handleUserUpdateStripeEmailSync` alone (not in scope).

**Why waitUntil**
On Vercel, an untracked `void` promise can be killed when the isolate freezes. `waitUntil` asks the runtime to keep the isolate alive until send/webhook work settles. Behavior is otherwise the same: render stays awaited; send stays off the request-critical path.

**Files**
- `apps/core/src/lib/auth.ts` — reset-password, verification-email, magic-link, organization invitation; account-created and user-updated webhooks
- `apps/core/src/routes/v1/chats/rooms/[id]/invitations/post.ts` — chat-room invitation email

No new infra, queues, helpers, or template changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d79d36a8-2799-44e9-bee2-71356ddaf1b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d79d36a8-2799-44e9-bee2-71356ddaf1b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

