### PR TITLE
chore(email): drop unused failureNotification/inputRequired locale keys

### DIFF
--- a/packages/email/src/locales/de.json
+++ b/packages/email/src/locales/de.json
@@ -77,8 +77,7 @@
       "bodyWithoutJobName": "Dein Job für {agentName} wartet auf deinen Input, um fortzufahren.",
       "button": "Input bereitstellen",
       "linkInstructions": "Oder kopiere diese URL und füge sie in deinen Browser ein:",
-      "footer": "Du erhältst diese E-Mail, weil Job-Benachrichtigungen für deinen Account aktiviert sind.",
-      "fallbackJobName": "Dein Job"
+      "footer": "Du erhältst diese E-Mail, weil Job-Benachrichtigungen für deinen Account aktiviert sind."
     },
     "failureNotification": {
       "subject": "Job-Fehlerbenachrichtigung - {jobId}",
@@ -93,10 +92,7 @@
       "jobBlockchainIdentifier": "Job-Blockchain-Kennung:",
       "onChainStatus": "On-Chain-Status:",
       "agentStatus": "Agent-Status:",
-      "inputHash": "Input-Hash:",
       "resultHash": "Ergebnis-Hash:",
-      "inputSchema": "Input-Schema:",
-      "input": "Input:",
       "output": "Output:",
       "footer": "Dies ist eine automatische Benachrichtigung von Sōkosumi."
     }

--- a/packages/email/src/locales/en.json
+++ b/packages/email/src/locales/en.json
@@ -77,8 +77,7 @@
       "bodyWithoutJobName": "Your job for {agentName} is waiting for your input to continue.",
       "button": "Provide input",
       "linkInstructions": "Or copy and paste this URL into your browser:",
-      "footer": "You're receiving this email because job notifications are enabled for your account.",
-      "fallbackJobName": "Your job"
+      "footer": "You're receiving this email because job notifications are enabled for your account."
     },
     "failureNotification": {
       "subject": "Job Failure Notification - {jobId}",
@@ -93,10 +92,7 @@
       "jobBlockchainIdentifier": "Job Blockchain Identifier:",
       "onChainStatus": "On-Chain Status:",
       "agentStatus": "Agent Status:",
-      "inputHash": "Input Hash:",
       "resultHash": "Result Hash:",
-      "inputSchema": "Input Schema:",
-      "input": "Input:",
       "output": "Output:",
       "footer": "This is an automated notification from Sōkosumi."
     }

--- a/packages/email/src/locales/es.json
+++ b/packages/email/src/locales/es.json
@@ -77,8 +77,7 @@
       "bodyWithoutJobName": "Tu job para {agentName} está esperando tu Input para continuar.",
       "button": "Proporcionar Input",
       "linkInstructions": "O copia esta URL y pégala en tu navegador:",
-      "footer": "Recibes este email porque las notificaciones de jobs están activadas en tu cuenta.",
-      "fallbackJobName": "Tu job"
+      "footer": "Recibes este email porque las notificaciones de jobs están activadas en tu cuenta."
     },
     "failureNotification": {
       "subject": "Notificación de error de job - {jobId}",
@@ -93,10 +92,7 @@
       "jobBlockchainIdentifier": "Identificador blockchain del job:",
       "onChainStatus": "Estado on-chain:",
       "agentStatus": "Estado del Agent:",
-      "inputHash": "Hash de Input:",
       "resultHash": "Hash de resultado:",
-      "inputSchema": "Esquema de Input:",
-      "input": "Input:",
       "output": "Output:",
       "footer": "Esta es una notificación automática de Sōkosumi."
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was deleted

Unused keys from `packages/email/src/locales/{en,de,es}.json`:

- `jobs.failureNotification.inputHash`
- `jobs.failureNotification.inputSchema`
- `jobs.failureNotification.input`
- `jobs.inputRequired.fallbackJobName`

`jobs.finalStatus.fallbackJobName` is still used and was kept.

## How verified

- `rg` in `packages/email`: `renderJobFailureNotificationEmail` never `t()`s `inputHash` / `inputSchema` / `input`. Fields rendered are network, agent, job, on-chain/agent status, resultHash, output.
- `renderJobInputRequiredEmail` uses `body` / `bodyWithoutJobName`, not `fallbackJobName`.
- Only remaining `fallbackJobName` usage: `t("jobs.finalStatus.fallbackJobName")` in `renderJobFinalStatusEmail`.
- After delete: `rg` for the four removed key paths returns no matches.

## Diff size

3 files, +3 / −15.

No renderer, type, or product behavior changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4051962a-f229-4a89-a522-7324aae98912?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4051962a-f229-4a89-a522-7324aae98912&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

