### PR TITLE
chore: sync agent pin versions and workspace folders

### DIFF
--- a/.cursor/rules/pinned-dependencies.mdc
+++ b/.cursor/rules/pinned-dependencies.mdc
@@ -15,7 +15,7 @@ All **external** npm dependencies in workspace `package.json` files must use **e
 ### Exceptions
 
 - **Workspace packages**: `"@sokosumi/database": "workspace:*"` (and other `workspace:*` links) are allowed for monorepo-internal dependencies.
-- **`packageManager`** in the root `package.json` (e.g. `pnpm@12.1.0`) follows pnpm’s required format.
+- **`packageManager`** in the root `package.json` (e.g. `pnpm@12.3.4`) follows pnpm’s required format.
 
 ### When adding or updating dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,8 +386,8 @@ These notes cover non-obvious, durable facts about running this repo in the Curs
 
 ### Runtime versions
 
-- **Node 24 is the required runtime** (`engines: 24.x`, root `.nvmrc` = `lts/krypton`). The base image's `/exec-daemon/node` is Node 22 and is early in `PATH`, so Node 24 (installed via nvm) is symlinked into `/usr/local/cargo/bin` (which is first in `PATH`) as `node`/`npm`/`npx`/`corepack`/`pnpm`. This makes `node -v` = 24 and `pnpm -v` = 12.2.1 in **every** shell (login or not). If a future run somehow sees Node 22, recreate those symlinks from `~/.nvm/versions/node/v24*/bin`.
-- **pnpm via Corepack:** Environment `install`/`start` call `scripts/cloud-agent-db/ensure-pnpm.sh`, which `corepack prepare`s the `packageManager` pin and deletes `~/.local/share/pnpm/.tools/pnpm`. A leftover pnpm 12 standalone placeholder there is not a valid shell script and fails builds with `Syntax error: ")" unexpected`.
+- **Node 24 is the required runtime** (root `.nvmrc` = `lts/krypton`; apps and packages pin `"engines": { "node": "24.x" }` — root `package.json` has no `engines` field). The base image's `/exec-daemon/node` is Node 22 and is early in `PATH`, so Node 24 (installed via nvm) is symlinked into `/usr/local/cargo/bin` (which is first in `PATH`) as `node`/`npm`/`npx`/`corepack`/`pnpm`. This makes `node -v` report Node 24 in **every** shell (login or not). If a future run somehow sees Node 22, recreate those symlinks from `~/.nvm/versions/node/v24*/bin`.
+- **pnpm via Corepack:** Environment `install`/`start` call `scripts/cloud-agent-db/ensure-pnpm.sh`, which `corepack prepare`s the pin in root `package.json` `packageManager` and deletes `~/.local/share/pnpm/.tools/pnpm`. A leftover pnpm 12 standalone placeholder there is not a valid shell script and fails builds with `Syntax error: ")" unexpected`. Read `packageManager` for the version — do not remember a `pnpm -v` number here.
 
 ### Database (Cloud agent Neon branch)
 

--- a/sokosumi.code-workspace
+++ b/sokosumi.code-workspace
@@ -29,6 +29,10 @@
       "path": "packages/chat"
     },
     {
+      "name": "Package: Soko Bot",
+      "path": "packages/soko-bot"
+    },
+    {
       "name": "Package: AI-SDK Provider",
       "path": "packages/ai-provider"
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly cleanup: agent pin / workspace drift only. No product behavior change.

## What drifted

- `AGENTS.md` Cursor Cloud notes claimed `pnpm -v` = `12.2.1` and a root `engines: 24.x` field.
- `.cursor/rules/pinned-dependencies.mdc` still used `pnpm@12.1.0` as the `packageManager` example (fixed on `main` by #4188).
- `sokosumi.code-workspace` listed every workspace package except `packages/soko-bot`.

## What this syncs to

Verified against current `main` after merging #4188:

- Root `package.json` `packageManager` is `pnpm@12.3.4`. Root has **no** `engines` field.
- Root `.nvmrc` is `lts/krypton`. Apps and packages pin `"engines": { "node": "24.x" }`.
- #4188 already set the pinned-dependencies example to `pnpm@12.3.4`, so that file is no longer in this PR.

Edits remaining vs `main`:

1. `AGENTS.md` points agents at `.nvmrc`, app/package `engines`, and root `packageManager` instead of a remembered `pnpm -v` (including #4188’s `12.3.4`).
2. Workspace folder `Package: Soko Bot` → `packages/soko-bot`.

## Merge conflict

Merged `origin/main` (#4188). Only `AGENTS.md` conflicted: kept this PR’s field-based wording; dropped main’s remembered `pnpm -v` = `12.3.4`.

## Verification

- Re-read `package.json`, `.nvmrc`, and app/package `engines` on updated `main`.
- Remaining diff vs `main`: `AGENTS.md` + `sokosumi.code-workspace` only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8679dcdc-6622-4f3f-b8e1-b71bb71f0bb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8679dcdc-6622-4f3f-b8e1-b71bb71f0bb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

