### PR TITLE
chore(core): use requireAuthorizedUserContext on vendors list

### DIFF
--- a/apps/core/src/routes/v1/vendors/get.test.ts
+++ b/apps/core/src/routes/v1/vendors/get.test.ts
@@ -14,9 +14,34 @@ vi.mock("@/middleware/auth", async (importOriginal) => {
   return { ...actual, authMiddleware: stubAuthMiddleware };
 });
 
-const { vendorFindManyMock } = vi.hoisted(() => ({
+const { vendorFindManyMock, workspaceRepositoryMock } = vi.hoisted(() => ({
   vendorFindManyMock: vi.fn(),
+  workspaceRepositoryMock: {
+    resolveWorkspaceForContext: vi.fn(),
+  },
 }));
+
+vi.mock("@sokosumi/database/repositories", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@sokosumi/database/repositories")>();
+  return {
+    ...actual,
+    workspaceRepository: workspaceRepositoryMock,
+  };
+});
+
+vi.mock("@/helpers/vendor-grants", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/helpers/vendor-grants")>();
+  return {
+    ...actual,
+    getWorkspaceGrant: vi.fn().mockResolvedValue({
+      id: "grant_123",
+      status: "GRANTED",
+      permission: "WORKSPACE",
+    }),
+  };
+});
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
@@ -45,6 +70,9 @@ function createApp(authContext: AuthVariables["authContext"]) {
 describe("GET /vendors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    workspaceRepositoryMock.resolveWorkspaceForContext.mockResolvedValue({
+      id: "ws_list_vendors",
+    });
     vendorFindManyMock.mockResolvedValue([
       {
         ...testVendor,

--- a/apps/core/src/routes/v1/vendors/get.ts
+++ b/apps/core/src/routes/v1/vendors/get.ts
@@ -1,11 +1,11 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
+import { requireAuthorizedUserContext } from "@/helpers/coworker-user-context-binding";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import { mapVendor } from "@/helpers/vendor";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 import { vendorSchema } from "@/schemas/vendor.schema";
 
 const vendorListSchema = z.array(vendorSchema).openapi("VendorList");
@@ -44,7 +44,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    requireUserContext(c.var.authContext);
+    await requireAuthorizedUserContext(c.var.authContext);
 
     const vendors = await prisma.vendor.findMany({
       orderBy: [{ name: "asc" }, { slug: "asc" }],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switch `GET /v1/vendors` from `requireUserContext` to `requireAuthorizedUserContext`, matching Drive in #4168.

Vendors list is a user-scoped grant-picker surface (account/org vendor grants UI). It is not a task/job `GRANT_PENDING` create. Core AGENTS default for that class is authorized context: coworker `X-Context-*` must pass grant/baseline binding (DENIED/REVOKED reject, GRANTED allow, else assignee/sibling baseline).

## Changes

- `apps/core/src/routes/v1/vendors/get.ts`: import + `await requireAuthorizedUserContext(...)`
- `apps/core/src/routes/v1/vendors/get.test.ts`: coworker coverage stubs `getWorkspaceGrant` as `GRANTED` (same pattern as #4168 Drive tests)

Out of scope: GRANT_PENDING creates, job-list auth, other `requireUserContext` routes.

## Verification

- `pnpm check` (husky)
- `pnpm typecheck` (husky)
- `pnpm --filter core test src/routes/v1/vendors/get.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f99d4d50-6da3-4802-989c-35648fa98f5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f99d4d50-6da3-4802-989c-35648fa98f5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

