### PR TITLE
chore(agents): install agent-browser on cloud PATH

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "Sokosumi Monorepo",
   "agentCanUpdateSnapshot": true,
-  "install": "bash scripts/cloud-agent-db/ensure-pnpm.sh install && node scripts/cloud-agent-db/provision.mjs",
+  "install": "bash scripts/cloud-agent-db/ensure-pnpm.sh install && node scripts/cloud-agent-db/provision.mjs && bash scripts/cloud-agent-db/ensure-agent-browser.sh",
   "start": "node scripts/cloud-agent-db/with-db.mjs -- bash scripts/cloud-agent-db/ensure-pnpm.sh dev"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,7 +382,7 @@ Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily). Se
 
 ## Cursor Cloud specific instructions
 
-These notes cover non-obvious, durable facts about running this repo in the Cursor Cloud VM. The update script runs Corepack-backed `pnpm install` (`scripts/cloud-agent-db/ensure-pnpm.sh`) then provisions an ephemeral Neon agent database when secrets are present (see below). Node, tooling, and non-DB `.env` values may still come from the VM snapshot.
+These notes cover non-obvious, durable facts about running this repo in the Cursor Cloud VM. The update script runs Corepack-backed `pnpm install` (`scripts/cloud-agent-db/ensure-pnpm.sh`), provisions an ephemeral Neon agent database when secrets are present (see below), then installs `agent-browser` (`scripts/cloud-agent-db/ensure-agent-browser.sh`). Node, tooling, and non-DB `.env` values may still come from the VM snapshot.
 
 ### Runtime versions
 
@@ -394,6 +394,7 @@ These notes cover non-obvious, durable facts about running this repo in the Curs
 Cloud agents get a **disposable Neon branch** forked from production/`main`, not a shared mutable DB and not live production writes.
 
 - **Provision:** `.cursor/environment.json` `install` runs `bash scripts/cloud-agent-db/ensure-pnpm.sh install` then `node scripts/cloud-agent-db/provision.mjs` when `CURSOR_AGENT=1` and `NEON_API_KEY` + `NEON_PROJECT_ID` are set (Cursor Runtime Secrets). Branch name: `cloud-agent-<CURSOR_CONVERSATION_ID>`. Parent is always `NEON_PARENT_BRANCH` (default `main`). Resume reuses the same branch and refreshes the **72h** `expires_at` TTL. Pending migrations run via `pnpm prisma:migrate:deploy` (`DATABASE_URL_UNPOOLED`). After migrate, upserts guarded auth fixtures (`admin@sokosumi.test` / `alice@sokosumi.test` / `bob@sokosumi.test` / `zero@sokosumi.test` / `Password123!`) on agent branches only — **not** a full catalog seed.
+- **agent-browser:** Cloud `install` puts `agent-browser` on `PATH` (symlink in `/usr/local/cargo/bin`) and downloads Chrome for Testing under `~/.agent-browser/browsers/`. Prefer it for UI proof (`verify-sokosumi`). Do not fall back to computer-use when the CLI is present. Do not launch `/usr/local/bin/google-chrome` via agent-browser — that wrapper is computer-use (CDP `9222` + shared profile).
 - **Use:** Prefer `node scripts/cloud-agent-db/with-db.mjs -- <command>` so ambient/stale `DATABASE_URL` cannot win. `start` already wraps `ensure-pnpm.sh dev`. Login shells source `.cursor/cloud-agent-db.env` via bashrc/profile.
 - **Teardown:** deletes only `cloud-agent-*` branches — never production/`main`. Triggers: PR merged/closed (GitHub Action parses `bc-…` from PR body), agent completes with no PR (`pnpm cloud-agent-db:teardown`), agent archived (same when possible). Idle **72h** expiry is Neon `expires_at` only (no scheduled Action GC).
 - **Do not** put a static production `DATABASE_URL` in Cursor secrets. Full runbook: [`docs/agents/cloud-agent-database.md`](./docs/agents/cloud-agent-database.md).

--- a/docs/agents/cloud-agent-database.md
+++ b/docs/agents/cloud-agent-database.md
@@ -30,12 +30,13 @@ branch named `cloud-agent-<run-id>`.
 
 ## Provision (how agents get the URL)
 
-`.cursor/environment.json` runs provision after a Corepack-backed `pnpm install`
+`.cursor/environment.json` `install` runs Corepack-backed `pnpm install`
 (`scripts/cloud-agent-db/ensure-pnpm.sh` avoids a broken pnpm 12 `.tools`
-placeholder that fails environment builds with `Syntax error: ")" unexpected`):
+placeholder that fails environment builds with `Syntax error: ")" unexpected`),
+then provision, then `agent-browser`:
 
 ```bash
-bash scripts/cloud-agent-db/ensure-pnpm.sh install && node scripts/cloud-agent-db/provision.mjs
+bash scripts/cloud-agent-db/ensure-pnpm.sh install && node scripts/cloud-agent-db/provision.mjs && bash scripts/cloud-agent-db/ensure-agent-browser.sh
 ```
 
 When `CURSOR_AGENT=1` and Neon secrets are present, provision:

--- a/scripts/cloud-agent-db/ensure-agent-browser.sh
+++ b/scripts/cloud-agent-db/ensure-agent-browser.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Install agent-browser on PATH for Cloud Agent UI proof (verify-sokosumi).
+#
+# Bare `npm i -g` is unusable here: this image's npm global prefix is `/`.
+# Install into $HOME/.npm-global and symlink onto /usr/local/cargo/bin (first
+# on PATH for login and non-login shells). Chrome for Testing is required so
+# we do not launch /usr/local/bin/google-chrome — that wrapper is computer-use
+# (CDP 9222 + shared profile).
+set -euo pipefail
+
+VERSION="${AGENT_BROWSER_VERSION:-0.36.0}"
+PREFIX="${AGENT_BROWSER_NPM_PREFIX:-$HOME/.npm-global}"
+BIN_NAME="agent-browser"
+
+function bin_dir() {
+  if [[ -d /usr/local/cargo/bin && -w /usr/local/cargo/bin ]]; then
+    echo /usr/local/cargo/bin
+    return
+  fi
+  mkdir -p "${HOME}/.local/bin"
+  echo "${HOME}/.local/bin"
+}
+
+# engines: node>=24 is for building from source; the published native binary
+# runs on this image's Node 22. --loglevel=error hides EBADENGINE noise.
+npm install -g --prefix "${PREFIX}" --loglevel=error "agent-browser@${VERSION}"
+
+SRC="${PREFIX}/bin/${BIN_NAME}"
+if [[ ! -e "${SRC}" ]]; then
+  echo "error: npm did not install ${BIN_NAME} into ${PREFIX}/bin" >&2
+  exit 1
+fi
+
+DEST_DIR="$(bin_dir)"
+ln -sfn "${SRC}" "${DEST_DIR}/${BIN_NAME}"
+hash -r 2>/dev/null || true
+
+if ! command -v "${BIN_NAME}" >/dev/null 2>&1; then
+  export PATH="${DEST_DIR}:${PREFIX}/bin:${PATH}"
+  hash -r 2>/dev/null || true
+fi
+
+# Chrome for Testing (idempotent). Skip --with-deps: snapshot Chrome already
+# has Linux libraries; apt via this script is not always possible.
+agent-browser install
+
+agent-browser --version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Agent install now puts `agent-browser` on `PATH` so UI proof can use the CLI instead of computer-use.

## Why

`verify-sokosumi` prefers `agent-browser`. When it is missing, agents fall back to computer-use (GUI review). Bare `npm i -g` also fails on this image because npm’s global prefix is `/`.

## What

- `.cursor/environment.json` `install` runs `scripts/cloud-agent-db/ensure-agent-browser.sh` after pnpm install and DB provision
- Script installs pinned `agent-browser@0.36.0` into `~/.npm-global`, symlinks onto `/usr/local/cargo/bin`, and downloads Chrome for Testing (not the computer-use Chrome wrapper at `/usr/local/bin/google-chrome`)

## Verification

This VM:

- `bash scripts/cloud-agent-db/ensure-agent-browser.sh` (idempotent; second run ~0.8s)
- `agent-browser open about:blank` → `about:blank`
- pre-commit `pnpm check` and `pnpm typecheck`

Draft environment build [`bld-20260907-85fd3ceb-fae0-48fc-8bb3-ce96703f981e`](https://cursor.com/dashboard/cloud-agents/builds/bld-20260907-85fd3ceb-fae0-48fc-8bb3-ce96703f981e) **SUCCEEDED**. Install log: `agent-browser 0.36.0` and Chrome for Testing 152.0.7977.82, install exit 0.

Fresh Cloud Agent booted from that build (`bc-e72bcd9d-7725-548d-a3f8-e19ce3613a61`):

- `command -v agent-browser` → `/usr/local/cargo/bin/agent-browser`
- version `0.36.0`
- doctor uses Chrome for Testing under `~/.agent-browser/browsers/`, not `/usr/local/bin/google-chrome`
- `open about:blank` → `about:blank`
- CLI was already on PATH from the snapshot (no reinstall)

CI on this PR is green.

This draft build does not become the snapshot new agents boot from. Merge this PR; a later main-line environment build picks up the install change for new agents.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-faaee632-c463-4235-9d1f-929f228ddcef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-faaee632-c463-4235-9d1f-929f228ddcef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

