### PR TITLE
fix(web): cut the on-in-this-browser notice to one line

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4099,7 +4099,6 @@
         "pushBannerUnsupportedTitle": "Dieser Browser kann keine Push-Benachrichtigungen anzeigen",
         "pushBannerUnsupportedBody": "Push-Benachrichtigungen kommen hier nicht an, egal was die Zeilen unten sagen. Deine anderen Geräte bekommen sie möglicherweise weiterhin.",
         "deviceBannerTitle": "Push-Benachrichtigungen sind in diesem Browser aktiviert",
-        "deviceBannerBody": "Was auf Push eingestellt ist, kommt hier an. Deine anderen Geräte sind davon nicht betroffen.",
         "deviceBannerAction": "Deaktivieren",
         "deviceDisabledSuccess": "Push-Benachrichtigungen in diesem Browser aus",
         "pushEnabledSuccess": "Push-Benachrichtigungen aktiviert",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4098,7 +4098,7 @@
         "pushBannerDeniedBody": "Sokosumi kann nicht erneut fragen. Erlaube Benachrichtigungen für diese Website in den Browser-Einstellungen. Deine anderen Geräte bekommen sie möglicherweise weiterhin.",
         "pushBannerUnsupportedTitle": "Dieser Browser kann keine Push-Benachrichtigungen anzeigen",
         "pushBannerUnsupportedBody": "Push-Benachrichtigungen kommen hier nicht an, egal was die Zeilen unten sagen. Deine anderen Geräte bekommen sie möglicherweise weiterhin.",
-        "deviceBannerTitle": "Push-Benachrichtigungen sind in diesem Browser aktiviert",
+        "deviceBannerTitle": "Push-Benachrichtigungen sind in diesem Browser aktiviert. Deine anderen Geräte sind davon nicht betroffen.",
         "deviceBannerAction": "Deaktivieren",
         "deviceDisabledSuccess": "Push-Benachrichtigungen in diesem Browser aus",
         "pushEnabledSuccess": "Push-Benachrichtigungen aktiviert",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4129,7 +4129,7 @@
         "pushBannerDeniedBody": "Sokosumi cannot ask again. Allow notifications for this site in your browser settings. Your other devices may still get them.",
         "pushBannerUnsupportedTitle": "This browser cannot show push notifications",
         "pushBannerUnsupportedBody": "Push notifications do not arrive here, whatever the rows below say. Your other devices may still get them.",
-        "deviceBannerTitle": "Push notifications are on in this browser",
+        "deviceBannerTitle": "Push notifications are on in this browser. Your other devices are unaffected.",
         "deviceBannerAction": "Turn off",
         "deviceDisabledSuccess": "Push notifications off in this browser",
         "pushEnabledSuccess": "Push notifications enabled",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4130,7 +4130,6 @@
         "pushBannerUnsupportedTitle": "This browser cannot show push notifications",
         "pushBannerUnsupportedBody": "Push notifications do not arrive here, whatever the rows below say. Your other devices may still get them.",
         "deviceBannerTitle": "Push notifications are on in this browser",
-        "deviceBannerBody": "Notifications set to Push arrive here. Your other devices are unaffected.",
         "deviceBannerAction": "Turn off",
         "deviceDisabledSuccess": "Push notifications off in this browser",
         "pushEnabledSuccess": "Push notifications enabled",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4099,7 +4099,6 @@
         "pushBannerUnsupportedTitle": "Este navegador no puede mostrar notificaciones push",
         "pushBannerUnsupportedBody": "Las notificaciones push no llegan aquí, digan lo que digan las filas de abajo. Tus otros dispositivos puede que sigan recibiéndolas.",
         "deviceBannerTitle": "Las notificaciones push están activadas en este navegador",
-        "deviceBannerBody": "Lo que está configurado como Push llega aquí. Tus otros dispositivos no se ven afectados.",
         "deviceBannerAction": "Desactivar",
         "deviceDisabledSuccess": "Notificaciones push desactivadas en este navegador",
         "pushEnabledSuccess": "Notificaciones push activadas",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4098,7 +4098,7 @@
         "pushBannerDeniedBody": "Sokosumi no puede volver a preguntar. Permite las notificaciones para este sitio en la configuración del navegador. Puede que tus otros dispositivos sigan recibiéndolas.",
         "pushBannerUnsupportedTitle": "Este navegador no puede mostrar notificaciones push",
         "pushBannerUnsupportedBody": "Las notificaciones push no llegan aquí, digan lo que digan las filas de abajo. Tus otros dispositivos puede que sigan recibiéndolas.",
-        "deviceBannerTitle": "Las notificaciones push están activadas en este navegador",
+        "deviceBannerTitle": "Las notificaciones push están activadas en este navegador. Tus otros dispositivos no se ven afectados.",
         "deviceBannerAction": "Desactivar",
         "deviceDisabledSuccess": "Notificaciones push desactivadas en este navegador",
         "pushEnabledSuccess": "Notificaciones push activadas",

--- a/apps/web/src/app/(app)/account/components/notification-push-banner.tsx
+++ b/apps/web/src/app/(app)/account/components/notification-push-banner.tsx
@@ -80,11 +80,16 @@ function BrowserNotice({
         // A card is how this page marks something the reader has to deal
         // with, and the rows below sit in one. Only the warning is that: a
         // push was asked for and will not arrive. The other is a receipt for
-        // a setting that worked, so it drops the box, the fill and the
-        // padding and reads as a note above the grid rather than a second
-        // thing to answer.
-        warning &&
-          "border-semantic-warning-tertiary bg-semantic-warning-quinary rounded-lg border p-4",
+        // a setting that worked, so it drops the box and the fill and reads
+        // as a note above the grid rather than a second thing to answer.
+        //
+        // It keeps room around itself. Without a box, the gap is the only
+        // thing holding the line off the heading above it and the grid
+        // below, and one line pressed against both reads as a caption
+        // belonging to whichever it touches.
+        warning
+          ? "border-semantic-warning-tertiary bg-semantic-warning-quinary rounded-lg border p-4"
+          : "py-2",
       )}
     >
       <div className="flex flex-col gap-3 @xl:flex-row @xl:items-center">
@@ -235,8 +240,9 @@ export function DeviceBanner({
       warning={false}
       icon={Smartphone}
       titleKey="deviceBannerTitle"
-      // The title is the whole notice: which push, and where it lands. A
-      // second line under it can only repeat that in more words.
+      // The title is the whole notice: which push, where it lands, and what
+      // the press here leaves alone. A second line under it can only repeat
+      // that in more words.
       bodyKey={null}
       action={{
         labelKey: "deviceBannerAction",

--- a/apps/web/src/app/(app)/account/components/notification-push-banner.tsx
+++ b/apps/web/src/app/(app)/account/components/notification-push-banner.tsx
@@ -76,10 +76,15 @@ function BrowserNotice({
     // instead, where one short fade is the whole of it.
     <div
       className={cn(
-        "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-1 animation-duration-200 rounded-lg border p-4",
-        warning
-          ? "border-semantic-warning-tertiary bg-semantic-warning-quinary"
-          : "bg-muted/50",
+        "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-1 animation-duration-200",
+        // A card is how this page marks something the reader has to deal
+        // with, and the rows below sit in one. Only the warning is that: a
+        // push was asked for and will not arrive. The other is a receipt for
+        // a setting that worked, so it drops the box, the fill and the
+        // padding and reads as a note above the grid rather than a second
+        // thing to answer.
+        warning &&
+          "border-semantic-warning-tertiary bg-semantic-warning-quinary rounded-lg border p-4",
       )}
     >
       <div className="flex flex-col gap-3 @xl:flex-row @xl:items-center">
@@ -87,8 +92,9 @@ function BrowserNotice({
           {/* The tint and the mark carry the warning; the words do not.
               `--semantic-warning` is a 40% yellow, about 2.3:1 on its own
               quinary tint in light mode, which is under what a paragraph
-              needs. The account notices colour their text with it and get
-              away with one short line. This one has a reason to explain. */}
+              needs, and the warning half has a reason to explain under its
+              title. The account notices colour their text with it and get
+              away with one short line. */}
           <Icon
             className={cn(
               "mt-0.5 size-4 shrink-0",
@@ -97,7 +103,13 @@ function BrowserNotice({
             aria-hidden="true"
           />
           <div className="min-w-0 space-y-1">
-            <p id={titleId} className="text-sm leading-5 font-medium">
+            <p
+              id={titleId}
+              className={cn(
+                "text-sm leading-5",
+                warning ? "font-medium" : "text-muted-foreground",
+              )}
+            >
               {t(titleKey)}
             </p>
             {bodyKey ? (
@@ -109,7 +121,10 @@ function BrowserNotice({
         </div>
         {action ? (
           <Button
-            variant="outline"
+            // The press follows the words. A warning gets an outlined button
+            // over its tint; the quiet half gets no box of its own, or the
+            // note would carry the loudest control on the card.
+            variant={warning ? "outline" : "ghost"}
             size="sm"
             // The line above says which push and which browser, so the button
             // does not have to. Read on its own, "Turn off" answers nothing;
@@ -141,6 +156,7 @@ function BrowserNotice({
             // would leave the box the same way.
             className={cn(
               "ml-7 h-auto min-h-8 self-start py-1.5 whitespace-normal @xl:ml-0 @xl:h-8 @xl:self-auto @xl:py-0",
+              !warning && "text-muted-foreground",
               action.saving && "opacity-50",
             )}
           >

--- a/apps/web/src/app/(app)/account/components/notification-push-banner.tsx
+++ b/apps/web/src/app/(app)/account/components/notification-push-banner.tsx
@@ -46,9 +46,10 @@ interface NoticeAction {
  * Drawing them apart would give the same sentence two layouts and put the
  * button in two places.
  *
- * Only the tint and the mark tell them apart. A browser that cannot show a
- * push the reader asked for is a warning; a browser that can is not, so the
- * second one takes the card's own colours and says its piece quietly.
+ * A browser that cannot show a push the reader asked for is a warning: it
+ * takes the warning tint and the warning mark, and owes the reader a second
+ * line saying why. A browser that can show one is not a warning. It keeps the
+ * card's own colours, says its piece in the title, and stops there.
  */
 function BrowserNotice({
   warning,
@@ -60,7 +61,7 @@ function BrowserNotice({
   warning: boolean;
   icon: LucideIcon;
   titleKey: string;
-  bodyKey: string;
+  bodyKey: string | null;
   action: NoticeAction | null;
 }) {
   const t = useTranslations("App.Account.Notifications");
@@ -99,9 +100,11 @@ function BrowserNotice({
             <p id={titleId} className="text-sm leading-5 font-medium">
               {t(titleKey)}
             </p>
-            <p className="text-muted-foreground text-sm leading-5">
-              {t(bodyKey)}
-            </p>
+            {bodyKey ? (
+              <p className="text-muted-foreground text-sm leading-5">
+                {t(bodyKey)}
+              </p>
+            ) : null}
           </div>
         </div>
         {action ? (
@@ -200,7 +203,8 @@ export function PushBanner({
  *
  * It carries the mark of the Push column rather than a warning's, because
  * nothing here is wrong. It is the state the reader asked for, and the press
- * is there for the day they stop wanting it.
+ * is there for the day they stop wanting it. Nothing being wrong is also why
+ * it is one line: a reader who set this up is being told it worked.
  */
 export function DeviceBanner({
   saving,
@@ -215,7 +219,9 @@ export function DeviceBanner({
       warning={false}
       icon={Smartphone}
       titleKey="deviceBannerTitle"
-      bodyKey="deviceBannerBody"
+      // The title is the whole notice: which push, and where it lands. A
+      // second line under it can only repeat that in more words.
+      bodyKey={null}
       action={{
         labelKey: "deviceBannerAction",
         saving,


### PR DESCRIPTION
## What changed

The notice above the notification grid that says a push lands in this browser is now one line, and it no longer looks like something to answer.

- **One line.** The title said which push and which browser, and the body said it again. `App.Account.Notifications.deviceBannerBody` is removed from `en`, `de`, and `es`, and `bodyKey` is now optional on the shared `BrowserNotice`.
- **The scope stays.** The line still tells the reader, before they press, that other devices are unaffected. It is folded into the same sentence rather than given a second line of its own.
- **Quieter.** The card, the fill and the border go to the warning half alone. The quiet half keeps its mark and its press, with a muted title, a ghost button, and `py-2` so the line is not pressed against the heading above it and the grid below.

The warning half is untouched: a browser that cannot show a push the reader asked for still gets the card and still explains why.

## Before / after

| | Before | After |
| --- | --- | --- |
| Line 1 | Push notifications are on in this browser | Push notifications are on in this browser. Your other devices are unaffected. |
| Line 2 | Notifications set to Push arrive here. Your other devices are unaffected. | *(none)* |
| Button | Turn off | Turn off |
| Frame | bordered card, `bg-muted/50`, `p-4`, medium title, outline button | no frame, `py-2`, muted title, ghost button |

`aria-describedby` on the button still points at that line, so the press is described by the whole of it.

## Verification

- `pnpm check` — `Checked 3788 files`, no fixes applied.
- `pnpm --filter web test src/app/(app)/account` — `Test Files 6 passed`, `Tests 180 passed`.
- `pnpm --filter web messages:parity` — `de: ok`, `es: ok`.
- Not rendered in a browser: this is a copy and Tailwind-class change, verified by tests and by reading the classes.
- Pre-existing and unrelated: `pnpm --filter web typecheck` reports `task-detail-view.tsx(5,8): error TS2305: Module '"@sokosumi/utils"' has no exported member 'TaskAssigneeKind'`. The same error reproduces on a clean tree at `main`, and no file in this PR can affect it (stale workspace `dist` in the worktree).
