### PR TITLE
refactor(web): split the chat sidebar room list by responsibility

### DIFF
--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
@@ -23,10 +23,7 @@ import {
   rememberRoomRead,
 } from "@/components/chat/room-read-overlay";
 
-import {
-  getActiveRoomIdFromPathname,
-  useChatTabUnreadPresence,
-} from "./use-chat-tab-unread-presence";
+import { useChatTabUnreadPresence } from "./use-chat-tab-unread-presence";
 
 const listRoomsMock = vi.mocked(listOrganizationChatRoomsAction);
 
@@ -50,18 +47,6 @@ function Harness() {
     <div data-testid="presence" data-show={showUnreadDot ? "yes" : "no"} />
   );
 }
-
-describe("getActiveRoomIdFromPathname", () => {
-  it("extracts the room id from /chat/rooms/[id]", () => {
-    expect(getActiveRoomIdFromPathname("/chat/rooms/room-1")).toBe("room-1");
-  });
-
-  it("returns null outside room routes", () => {
-    expect(getActiveRoomIdFromPathname("/chat")).toBeNull();
-    expect(getActiveRoomIdFromPathname("/chat/something")).toBeNull();
-    expect(getActiveRoomIdFromPathname(null)).toBeNull();
-  });
-});
 
 describe("useChatTabUnreadPresence", () => {
   beforeEach(() => {

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { getActiveRoomIdFromPathname } from "@/components/chat/active-room-id";
 import { countChatRoomsWithUnreadAttention } from "@/components/chat/chat-unread-document-title";
 import { getLatestMembershipVisibleRoomsSnapshot } from "@/components/chat/membership-visible-rooms-store";
 import {
@@ -16,17 +17,6 @@ import {
 import type { ChatRoom } from "@/lib/clients/generated/core";
 
 const CHAT_TAB_UNREAD_POLL_MS = 15_000;
-
-export function getActiveRoomIdFromPathname(
-  pathname: string | null,
-): string | null {
-  if (!pathname?.startsWith("/chat/rooms/")) {
-    return null;
-  }
-
-  const roomId = pathname.split("/")[3];
-  return roomId || null;
-}
 
 function getInitialRoomsFromSessionSnapshot(): ChatRoom[] {
   const snapshot = getLatestMembershipVisibleRoomsSnapshot();

--- a/apps/web/src/components/chat/active-room-id.test.ts
+++ b/apps/web/src/components/chat/active-room-id.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { getActiveRoomIdFromPathname } from "./active-room-id";
+
+describe("getActiveRoomIdFromPathname", () => {
+  it("reads the room id from a chat room path", () => {
+    expect(getActiveRoomIdFromPathname("/chat/rooms/room-1")).toBe("room-1");
+  });
+
+  it("ignores anything after the room id", () => {
+    expect(getActiveRoomIdFromPathname("/chat/rooms/room-1/threads/t-9")).toBe(
+      "room-1",
+    );
+  });
+
+  it("returns null on the chat index, where no room is open", () => {
+    expect(getActiveRoomIdFromPathname("/chat")).toBeNull();
+  });
+
+  it("returns null for a path outside chat", () => {
+    expect(getActiveRoomIdFromPathname("/tasks/task-1")).toBeNull();
+  });
+
+  it("returns null when the room segment is empty", () => {
+    expect(getActiveRoomIdFromPathname("/chat/rooms/")).toBeNull();
+  });
+
+  it("returns null when there is no pathname yet", () => {
+    expect(getActiveRoomIdFromPathname(null)).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/active-room-id.ts
+++ b/apps/web/src/components/chat/active-room-id.ts
@@ -1,0 +1,17 @@
+/**
+ * The room the reader currently has open, read from the pathname.
+ *
+ * Chat room routes are `/chat/rooms/<roomId>`; every other path means no room
+ * is open. Sidebar attention chrome is suppressed on the active room, so a
+ * wrong answer here shows unread on a room the reader is looking at.
+ */
+export function getActiveRoomIdFromPathname(
+  pathname: string | null,
+): string | null {
+  if (!pathname?.startsWith("/chat/rooms/")) {
+    return null;
+  }
+
+  const roomId = pathname.split("/")[3];
+  return roomId || null;
+}

--- a/apps/web/src/components/chat/chat-membership-revoked-list-bridge.tsx
+++ b/apps/web/src/components/chat/chat-membership-revoked-list-bridge.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useChatMembershipRevokedControl } from "@/lib/ably/use-chat-membership-revoked-control";
+
+import { notifyOrganizationChatRoomsChanged } from "./organization-chat-events";
+
+/**
+ * List-mounted control-channel UI (SOK-746). Soft-removes membership-visible
+ * rooms when kicked even if the open-room Ably island is not mounted.
+ * Navigation/refresh lives only on the open-room bridge so both mounts never
+ * double `replace`/`refresh` for the same event.
+ */
+export function ChatMembershipRevokedListBridge({
+  currentUserId,
+}: {
+  currentUserId: string;
+}) {
+  useChatMembershipRevokedControl({
+    currentUserId,
+    onRevoked: (event) => {
+      notifyOrganizationChatRoomsChanged({ removedRoomId: event.roomId });
+    },
+  });
+
+  return null;
+}

--- a/apps/web/src/components/chat/chat-sidebar-section-header.tsx
+++ b/apps/web/src/components/chat/chat-sidebar-section-header.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+/**
+ * Collapsible section heading for the chat sidebar (Channels, External,
+ * Archived, Direct Messages).
+ *
+ * The trailing padding steps with how many action controls sit in the
+ * absolutely-positioned trailing slot, so a long section title truncates
+ * before it runs under them.
+ */
+export function ChatSidebarSectionHeader({
+  children,
+  isOpen,
+  createAction,
+  secondaryAction,
+}: {
+  children: ReactNode;
+  isOpen: boolean;
+  createAction?: ReactNode;
+  secondaryAction?: ReactNode;
+}) {
+  const trailingCount = (secondaryAction ? 1 : 0) + (createAction ? 1 : 0);
+
+  return (
+    <div className="group-data-[collapsible=icon]:hidden relative flex h-10 items-center gap-1 px-3 md:h-8">
+      <CollapsibleTrigger
+        className={cn(
+          "text-muted-foreground hover:text-foreground flex min-w-0 flex-1 items-center gap-1 rounded-md text-left text-base font-medium transition-colors md:text-xs",
+          trailingCount === 1 && "pr-9",
+          trailingCount >= 2 && "pr-16",
+          trailingCount === 0 && "md:pr-0",
+          trailingCount === 1 && "md:pr-8",
+          trailingCount >= 2 && "md:pr-14",
+        )}
+      >
+        <ChevronDown
+          aria-hidden
+          className={cn(
+            "size-4 shrink-0 transition-transform md:size-3",
+            !isOpen && "-rotate-90",
+          )}
+        />
+        <span className="truncate">{children}</span>
+      </CollapsibleTrigger>
+      {trailingCount > 0 ? (
+        <div className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center">
+          {secondaryAction}
+          {createAction}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -1,28 +1,20 @@
 "use client";
 
-import { ChevronDown, Ellipsis, Globe2, RotateCcw, Trash2 } from "lucide-react";
+import { Ellipsis, Globe2, RotateCcw, Trash2 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import {
-  type ReactNode,
-  useEffect,
-  useMemo,
-  useState,
-  useTransition,
-} from "react";
+import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 import {
   acceptChatRoomInvitationAction,
   declineChatRoomInvitationAction,
   deleteRoomAction,
-  listPendingChatRoomInvitationsAction,
   restoreRoomAction,
 } from "@/app/chat/actions";
 import { BrowseChannelsDialog } from "@/app/chat/components/browse-channels-dialog";
 import { CreateChannelDialog } from "@/app/chat/components/create-channel-dialog";
 import { CreateDirectDialog } from "@/app/chat/components/create-direct-dialog";
 import { getRoomDisplayName } from "@/app/chat/components/room-helpers";
-import { publishMembershipVisibleRooms } from "@/components/chat/membership-visible-rooms-store";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -34,11 +26,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
+import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -53,33 +41,21 @@ import {
 } from "@/components/ui/sidebar";
 import LazyAblyProvider from "@/contexts/lazy-ably-provider";
 import { useChatUnreadDocumentTitle } from "@/hooks/use-chat-unread-document-title";
-import { useChatMembershipRevokedControl } from "@/lib/ably/use-chat-membership-revoked-control";
 import type {
   ChatRoom,
   ChatRoomInvitation,
 } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
+import { getActiveRoomIdFromPathname } from "./active-room-id";
 import { ChannelDiscoverabilityIcon } from "./channel-discoverability-icon";
+import { ChatMembershipRevokedListBridge } from "./chat-membership-revoked-list-bridge";
 import { ChatRoomSidebarRow } from "./chat-room-sidebar-row";
+import { ChatSidebarSectionHeader } from "./chat-sidebar-section-header";
 import { countChatRoomsWithUnreadAttention } from "./chat-unread-document-title";
 import { DirectRoomAvatarStack } from "./direct-room-avatar-stack";
-import {
-  notifyOrganizationChatRoomsChanged,
-  ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
-  type OrganizationChatRoomsChangedDetail,
-} from "./organization-chat-events";
-import {
-  listOrganizationArchivedChatRoomsAction,
-  listOrganizationChatRoomsAction,
-} from "./organization-chat-list.actions";
+import { listOrganizationChatRoomsAction } from "./organization-chat-list.actions";
 import { partitionRoomsForSidebar } from "./partition-rooms-for-sidebar";
-import {
-  applyRoomReadOverlays,
-  forgetRoomRead,
-  rememberRoomRead,
-} from "./room-read-overlay";
-
-const ORGANIZATION_CHAT_POLL_MS = 15_000;
+import { useOrganizationChatRooms } from "./use-organization-chat-rooms";
 
 /** Stable empty default — inline `= []` is a new array every render and
  *  infinite-loops the render-time pendingInvitations sync (React #301). */
@@ -108,80 +84,6 @@ interface OrganizationChatListProps {
   paintOnly?: boolean;
 }
 
-function SectionHeader({
-  children,
-  isOpen,
-  createAction,
-  secondaryAction,
-}: {
-  children: ReactNode;
-  isOpen: boolean;
-  createAction?: ReactNode;
-  secondaryAction?: ReactNode;
-}) {
-  const trailingCount = (secondaryAction ? 1 : 0) + (createAction ? 1 : 0);
-
-  return (
-    <div className="group-data-[collapsible=icon]:hidden relative flex h-10 items-center gap-1 px-3 md:h-8">
-      <CollapsibleTrigger
-        className={cn(
-          "text-muted-foreground hover:text-foreground flex min-w-0 flex-1 items-center gap-1 rounded-md text-left text-base font-medium transition-colors md:text-xs",
-          trailingCount === 1 && "pr-9",
-          trailingCount >= 2 && "pr-16",
-          trailingCount === 0 && "md:pr-0",
-          trailingCount === 1 && "md:pr-8",
-          trailingCount >= 2 && "md:pr-14",
-        )}
-      >
-        <ChevronDown
-          aria-hidden
-          className={cn(
-            "size-4 shrink-0 transition-transform md:size-3",
-            !isOpen && "-rotate-90",
-          )}
-        />
-        <span className="truncate">{children}</span>
-      </CollapsibleTrigger>
-      {trailingCount > 0 ? (
-        <div className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center">
-          {secondaryAction}
-          {createAction}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function getActiveRoomIdFromPathname(pathname: string | null): string | null {
-  if (!pathname?.startsWith("/chat/rooms/")) {
-    return null;
-  }
-
-  const roomId = pathname.split("/")[3];
-  return roomId || null;
-}
-
-/**
- * List-mounted control-channel UI (SOK-746). Soft-removes membership-visible
- * rooms when kicked even if the open-room Ably island is not mounted.
- * Navigation/refresh lives only on the open-room bridge so both mounts never
- * double `replace`/`refresh` for the same event.
- */
-function ChatMembershipRevokedListBridge({
-  currentUserId,
-}: {
-  currentUserId: string;
-}) {
-  useChatMembershipRevokedControl({
-    currentUserId,
-    onRevoked: (event) => {
-      notifyOrganizationChatRoomsChanged({ removedRoomId: event.roomId });
-    },
-  });
-
-  return null;
-}
-
 export function OrganizationChatList({
   rooms,
   archivedRooms,
@@ -198,13 +100,23 @@ export function OrganizationChatList({
   const pathname = usePathname();
   const router = useRouter();
   const hasOrganization = Boolean(organizationId);
-  const [roomRows, setRoomRows] = useState(() => applyRoomReadOverlays(rooms));
-  const [archivedRows, setArchivedRows] = useState(archivedRooms);
-  const [pendingRows, setPendingRows] = useState(pendingInvitations);
-  const [prevRooms, setPrevRooms] = useState(rooms);
-  const [prevArchivedRooms, setPrevArchivedRooms] = useState(archivedRooms);
-  const [prevPendingInvitations, setPrevPendingInvitations] =
-    useState(pendingInvitations);
+  const {
+    roomRows,
+    archivedRows,
+    pendingRows,
+    setArchivedRows,
+    setPendingRows,
+    upsertRoomToTop,
+    replaceRoom,
+    replaceAllRooms,
+  } = useOrganizationChatRooms({
+    rooms,
+    archivedRooms,
+    pendingInvitations,
+    currentUserId,
+    organizationId,
+    paintOnly,
+  });
   const [channelSectionOpen, setChannelSectionOpen] = useState(true);
   const [archivedSectionOpen, setArchivedSectionOpen] = useState(false);
   const [directOpen, setDirectOpen] = useState(true);
@@ -234,188 +146,6 @@ export function OrganizationChatList({
       </LazyAblyProvider>
     ) : null;
 
-  // Replace local list when RSC props change (full membership-visible set).
-  if (rooms !== prevRooms) {
-    setPrevRooms(rooms);
-    setRoomRows(applyRoomReadOverlays(rooms));
-  }
-  if (archivedRooms !== prevArchivedRooms) {
-    setPrevArchivedRooms(archivedRooms);
-    setArchivedRows(archivedRooms);
-  }
-  if (pendingInvitations !== prevPendingInvitations) {
-    setPrevPendingInvitations(pendingInvitations);
-    setPendingRows(pendingInvitations);
-  }
-
-  useEffect(() => {
-    if (paintOnly) {
-      return;
-    }
-
-    let cancelled = false;
-
-    const refreshRooms = async () => {
-      const [activeResult, archivedResult, pendingResult] = await Promise.all([
-        listOrganizationChatRoomsAction(),
-        hasOrganization
-          ? listOrganizationArchivedChatRoomsAction()
-          : Promise.resolve({
-              ok: true as const,
-              value: {
-                rooms: [] as ChatRoom[],
-                nextCursor: null as string | null,
-              },
-            }),
-        listPendingChatRoomInvitationsAction(),
-      ]);
-      if (cancelled) {
-        return;
-      }
-      if (activeResult.ok) {
-        setRoomRows(applyRoomReadOverlays(activeResult.value.rooms));
-      }
-      if (archivedResult.ok) {
-        setArchivedRows(archivedResult.value.rooms);
-      }
-      if (pendingResult.ok) {
-        setPendingRows(pendingResult.value);
-      }
-    };
-
-    // Mobile sheet remounts the list with stale RSC props; refresh immediately
-    // so overlays can drop once Core confirms the mark-read.
-    void refreshRooms();
-
-    const intervalId = window.setInterval(
-      refreshRooms,
-      ORGANIZATION_CHAT_POLL_MS,
-    );
-    window.addEventListener("focus", refreshRooms);
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-      window.removeEventListener("focus", refreshRooms);
-    };
-  }, [hasOrganization, organizationId, paintOnly]);
-
-  useEffect(() => {
-    if (paintOnly) {
-      return;
-    }
-
-    const handleRoomRead = (event: Event) => {
-      const detail = (
-        event as CustomEvent<{ room?: ChatRoom; roomId?: string }>
-      ).detail;
-      if (!detail?.roomId) {
-        return;
-      }
-
-      if (detail.room) {
-        // Dual-baseline: leftover Participant Thread unread stays on the row.
-        rememberRoomRead(detail.room);
-      }
-
-      setRoomRows((current) =>
-        applyRoomReadOverlays(
-          current.map((room) =>
-            room.id === detail.roomId
-              ? (detail.room ?? {
-                  ...room,
-                  unreadCount: 0,
-                  unreadMentionCount: 0,
-                  markedUnread: false,
-                })
-              : room,
-          ),
-        ),
-      );
-    };
-
-    window.addEventListener("organization-chat-room-read", handleRoomRead);
-    return () => {
-      window.removeEventListener("organization-chat-room-read", handleRoomRead);
-    };
-  }, [paintOnly]);
-
-  useEffect(() => {
-    if (paintOnly) {
-      return;
-    }
-
-    let cancelled = false;
-
-    const handleRoomsChanged = (event: Event) => {
-      const detail = (event as CustomEvent<OrganizationChatRoomsChangedDetail>)
-        .detail;
-      const removedRoomId = detail?.removedRoomId;
-      if (removedRoomId) {
-        setRoomRows((current) =>
-          applyRoomReadOverlays(
-            current.filter((row) => row.id !== removedRoomId),
-          ),
-        );
-        setArchivedRows((current) =>
-          current.filter((row) => row.id !== removedRoomId),
-        );
-        return;
-      }
-
-      const room = detail?.room;
-      if (room) {
-        setRoomRows((current) => {
-          const without = current.filter((row) => row.id !== room.id);
-          return applyRoomReadOverlays([room, ...without]);
-        });
-        setArchivedRows((current) =>
-          current.filter((row) => row.id !== room.id),
-        );
-        return;
-      }
-
-      void Promise.all([
-        listOrganizationChatRoomsAction(),
-        hasOrganization
-          ? listOrganizationArchivedChatRoomsAction()
-          : Promise.resolve({
-              ok: true as const,
-              value: {
-                rooms: [] as ChatRoom[],
-                nextCursor: null as string | null,
-              },
-            }),
-        listPendingChatRoomInvitationsAction(),
-      ]).then(([activeResult, archivedResult, pendingResult]) => {
-        if (cancelled) {
-          return;
-        }
-        if (activeResult.ok) {
-          setRoomRows(applyRoomReadOverlays(activeResult.value.rooms));
-        }
-        if (archivedResult.ok) {
-          setArchivedRows(archivedResult.value.rooms);
-        }
-        if (pendingResult.ok) {
-          setPendingRows(pendingResult.value);
-        }
-      });
-    };
-
-    window.addEventListener(
-      ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
-      handleRoomsChanged,
-    );
-    return () => {
-      cancelled = true;
-      window.removeEventListener(
-        ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
-        handleRoomsChanged,
-      );
-    };
-  }, [hasOrganization, paintOnly]);
-
   function handleRestoreRoom(room: ChatRoom) {
     if (restoringRoomId || deletingRoomId) {
       return;
@@ -429,11 +159,7 @@ export function OrganizationChatList({
         return;
       }
       toast.success(tActions("restoreSuccess", { name: room.name }));
-      setArchivedRows((current) => current.filter((row) => row.id !== room.id));
-      setRoomRows((current) => {
-        const without = current.filter((row) => row.id !== result.value.id);
-        return applyRoomReadOverlays([result.value, ...without]);
-      });
+      upsertRoomToTop(result.value);
       router.push(`/chat/rooms/${result.value.id}`);
       router.refresh();
     });
@@ -459,17 +185,6 @@ export function OrganizationChatList({
     });
   }
 
-  function handleRoomUpdated(updated: ChatRoom) {
-    if (updated.markedUnread) {
-      forgetRoomRead(updated.id);
-    }
-    setRoomRows((current) =>
-      applyRoomReadOverlays(
-        current.map((room) => (room.id === updated.id ? updated : room)),
-      ),
-    );
-  }
-
   function handleAcceptInvitation(invitation: ChatRoomInvitation) {
     if (respondingInvitation) {
       return;
@@ -491,7 +206,7 @@ export function OrganizationChatList({
         current.filter((row) => row.id !== invitation.id),
       );
       if (roomsResult.ok) {
-        setRoomRows(applyRoomReadOverlays(roomsResult.value.rooms));
+        replaceAllRooms(roomsResult.value.rooms);
       }
       router.push(`/chat/rooms/${invitation.roomId}`);
       router.refresh();
@@ -523,13 +238,6 @@ export function OrganizationChatList({
     [roomRows],
   );
 
-  useEffect(() => {
-    if (paintOnly) {
-      return;
-    }
-    publishMembershipVisibleRooms(roomRows, organizationId, currentUserId);
-  }, [currentUserId, organizationId, paintOnly, roomRows]);
-
   const sortedArchivedChannels = useMemo(() => {
     return [...archivedRows].sort((a, b) =>
       a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
@@ -545,13 +253,13 @@ export function OrganizationChatList({
             open={channelSectionOpen}
             onOpenChange={setChannelSectionOpen}
           >
-            <SectionHeader
+            <ChatSidebarSectionHeader
               isOpen={channelSectionOpen}
               createAction={<CreateChannelDialog />}
               secondaryAction={<BrowseChannelsDialog />}
             >
               {t("title")}
-            </SectionHeader>
+            </ChatSidebarSectionHeader>
             <CollapsibleContent>
               <SidebarMenu className="gap-0">
                 {namedChannels.map((room) => (
@@ -566,7 +274,7 @@ export function OrganizationChatList({
                         discoverability={room.discoverability}
                       />
                     }
-                    onRoomUpdated={handleRoomUpdated}
+                    onRoomUpdated={replaceRoom}
                     dismissSheetOnNavigate={dismissSheetOnNavigate}
                   />
                 ))}
@@ -584,9 +292,9 @@ export function OrganizationChatList({
 
         {pendingRows.length > 0 || externalJoined.length > 0 ? (
           <Collapsible open={externalOpen} onOpenChange={setExternalOpen}>
-            <SectionHeader isOpen={externalOpen}>
+            <ChatSidebarSectionHeader isOpen={externalOpen}>
               {tExternal("title")}
-            </SectionHeader>
+            </ChatSidebarSectionHeader>
             <CollapsibleContent>
               <SidebarMenu className="gap-0">
                 {pendingRows.map((invitation) => {
@@ -665,7 +373,7 @@ export function OrganizationChatList({
                     leading={
                       <ChannelDiscoverabilityIcon discoverability="external" />
                     }
-                    onRoomUpdated={handleRoomUpdated}
+                    onRoomUpdated={replaceRoom}
                     dismissSheetOnNavigate={dismissSheetOnNavigate}
                   />
                 ))}
@@ -679,9 +387,9 @@ export function OrganizationChatList({
             open={archivedSectionOpen}
             onOpenChange={setArchivedSectionOpen}
           >
-            <SectionHeader isOpen={archivedSectionOpen}>
+            <ChatSidebarSectionHeader isOpen={archivedSectionOpen}>
               {t("archivedChannels")}
-            </SectionHeader>
+            </ChatSidebarSectionHeader>
             <CollapsibleContent>
               <SidebarMenu className="gap-0">
                 {sortedArchivedChannels.map((room) => {
@@ -837,12 +545,12 @@ export function OrganizationChatList({
             Personal workspace still mounts the picker with empty members
             (coworkers only).
           */}
-          <SectionHeader
+          <ChatSidebarSectionHeader
             isOpen={directOpen}
             createAction={<CreateDirectDialog />}
           >
             {t("directMessages")}
-          </SectionHeader>
+          </ChatSidebarSectionHeader>
           <CollapsibleContent>
             <SidebarMenu className="gap-0">
               {directMessages.map((room) => (
@@ -860,7 +568,7 @@ export function OrganizationChatList({
                       selectedRoomId={activeRoomId}
                     />
                   }
-                  onRoomUpdated={handleRoomUpdated}
+                  onRoomUpdated={replaceRoom}
                   dismissSheetOnNavigate={dismissSheetOnNavigate}
                 />
               ))}

--- a/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
@@ -1,0 +1,269 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  ChatRoom,
+  ChatRoomInvitation,
+} from "@/lib/clients/generated/core";
+
+import {
+  emptyListResult,
+  listPendingMock,
+  listRoomsMock,
+  makeRoom,
+  resetOrganizationChatListMocks,
+} from "./__tests__/organization-chat-list-harness";
+import { clearMembershipVisibleRoomsSnapshot } from "./membership-visible-rooms-store";
+import { ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT } from "./organization-chat-events";
+import { clearRoomReadOverlays, rememberRoomRead } from "./room-read-overlay";
+import { useOrganizationChatRooms } from "./use-organization-chat-rooms";
+
+const NO_ROOMS: ChatRoom[] = [];
+const NO_INVITATIONS: ChatRoomInvitation[] = [];
+
+function channel(id: string, overrides: Partial<ChatRoom> = {}): ChatRoom {
+  return makeRoom({ ...overrides, id, kind: "channel", myAccess: "member" });
+}
+
+interface MountOptions {
+  rooms?: ChatRoom[];
+  archivedRooms?: ChatRoom[];
+  paintOnly?: boolean;
+}
+
+/**
+ * The collections must keep the same identity across renders. The hook replaces
+ * its rows whenever a collection is a new reference, so a fresh `[]` literal per
+ * render would loop (React #301) — the hazard the list guards with its stable
+ * empty default.
+ */
+function mount({
+  rooms = NO_ROOMS,
+  archivedRooms = NO_ROOMS,
+  paintOnly = false,
+}: MountOptions = {}) {
+  return renderHook(
+    (props: { rooms: ChatRoom[]; archivedRooms: ChatRoom[] }) =>
+      useOrganizationChatRooms({
+        rooms: props.rooms,
+        archivedRooms: props.archivedRooms,
+        pendingInvitations: NO_INVITATIONS,
+        currentUserId: "user-1",
+        organizationId: "org-1",
+        paintOnly,
+      }),
+    { initialProps: { rooms, archivedRooms } },
+  );
+}
+
+describe("useOrganizationChatRooms", () => {
+  beforeEach(() => {
+    resetOrganizationChatListMocks();
+    clearRoomReadOverlays();
+  });
+
+  afterEach(() => {
+    clearMembershipVisibleRoomsSnapshot();
+  });
+
+  it("paints the rooms it was given without subscribing, when paintOnly", () => {
+    const rooms = [channel("paint-1")];
+    const { result } = mount({ rooms, paintOnly: true });
+
+    expect(result.current.roomRows.map((row) => row.id)).toEqual(["paint-1"]);
+    // Instant soft-nav (SOK-903) must not fetch, or the paint it exists to
+    // avoid is the paint it causes.
+    expect(listRoomsMock).not.toHaveBeenCalled();
+    expect(listPendingMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes from Core on mount, so a stale remount corrects itself", async () => {
+    listRoomsMock.mockResolvedValue(emptyListResult([channel("fetched-1")]));
+    const { result } = mount();
+
+    await waitFor(() => {
+      expect(result.current.roomRows.map((row) => row.id)).toEqual([
+        "fetched-1",
+      ]);
+    });
+  });
+
+  it("replaces the rows when new props arrive", () => {
+    const { result, rerender } = mount({
+      rooms: [channel("first")],
+      paintOnly: true,
+    });
+
+    expect(result.current.roomRows.map((row) => row.id)).toEqual(["first"]);
+
+    rerender({ rooms: [channel("second")], archivedRooms: NO_ROOMS });
+
+    expect(result.current.roomRows.map((row) => row.id)).toEqual(["second"]);
+  });
+
+  it("clears a room's unread when it reports itself read", async () => {
+    const rooms = [
+      channel("read-me", { unreadCount: 4, unreadMentionCount: 2 }),
+    ];
+    // The mount refresh replaces the rows, so the poll has to agree with the
+    // seed or it clears the very room under test.
+    listRoomsMock.mockResolvedValue(emptyListResult(rooms));
+    const { result } = mount({ rooms });
+
+    await waitFor(() => {
+      expect(result.current.roomRows).toHaveLength(1);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("organization-chat-room-read", {
+          detail: { roomId: "read-me" },
+        }),
+      );
+    });
+
+    const row = result.current.roomRows.find((r) => r.id === "read-me");
+    expect(row?.unreadCount).toBe(0);
+    expect(row?.unreadMentionCount).toBe(0);
+    expect(row?.markedUnread).toBe(false);
+  });
+
+  it("drops a room the control channel says the reader lost", async () => {
+    const rooms = [channel("kept"), channel("revoked")];
+    listRoomsMock.mockResolvedValue(emptyListResult(rooms));
+    const { result } = mount({ rooms });
+
+    await waitFor(() => {
+      expect(result.current.roomRows).toHaveLength(2);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT, {
+          detail: { removedRoomId: "revoked" },
+        }),
+      );
+    });
+
+    expect(result.current.roomRows.map((row) => row.id)).toEqual(["kept"]);
+  });
+
+  it("moves a room to the top and drops its archived copy in one step", () => {
+    const restored = channel("restored");
+    const { result } = mount({
+      rooms: [channel("other")],
+      archivedRooms: [restored],
+      paintOnly: true,
+    });
+
+    expect(result.current.archivedRows.map((row) => row.id)).toEqual([
+      "restored",
+    ]);
+
+    act(() => {
+      result.current.upsertRoomToTop(restored);
+    });
+
+    // A room is live or archived, never both.
+    expect(result.current.roomRows.map((row) => row.id)).toEqual([
+      "restored",
+      "other",
+    ]);
+    expect(result.current.archivedRows).toEqual([]);
+  });
+
+  it("replaces rather than duplicates a room it already holds", () => {
+    const room = channel("dupe");
+    const { result } = mount({
+      rooms: [room, channel("other")],
+      paintOnly: true,
+    });
+
+    act(() => {
+      result.current.upsertRoomToTop({ ...room, name: "renamed" });
+    });
+
+    expect(result.current.roomRows.map((row) => row.id)).toEqual([
+      "dupe",
+      "other",
+    ]);
+    expect(result.current.roomRows[0]?.name).toBe("renamed");
+  });
+
+  it("swaps one room for a newer copy without moving it", () => {
+    const room = channel("edited");
+    const { result } = mount({
+      rooms: [channel("first"), room, channel("last")],
+      paintOnly: true,
+    });
+
+    act(() => {
+      result.current.replaceRoom({ ...room, name: "renamed" });
+    });
+
+    expect(result.current.roomRows.map((row) => row.id)).toEqual([
+      "first",
+      "edited",
+      "last",
+    ]);
+    expect(result.current.roomRows[1]?.name).toBe("renamed");
+  });
+
+  it("keeps a room the reader just marked unread unread", () => {
+    const room = channel("marked");
+    const { result } = mount({ rooms: [room], paintOnly: true });
+
+    // The reader read the room first, so a read overlay is on file. Without
+    // dropping it, the overlay would paint the room read again on the spot.
+    rememberRoomRead(room);
+
+    act(() => {
+      result.current.replaceRoom({ ...room, markedUnread: true });
+    });
+
+    expect(result.current.roomRows[0]?.markedUnread).toBe(true);
+  });
+
+  it("replaces the whole live list with a freshly fetched one", () => {
+    const { result } = mount({
+      rooms: [channel("stale-1"), channel("stale-2")],
+      paintOnly: true,
+    });
+
+    act(() => {
+      result.current.replaceAllRooms([channel("fresh")]);
+    });
+
+    expect(result.current.roomRows.map((row) => row.id)).toEqual(["fresh"]);
+  });
+
+  it("reapplies the read overlay when it swaps one room", () => {
+    const room = channel("overlaid", { unreadCount: 5 });
+    const { result } = mount({ rooms: [room], paintOnly: true });
+
+    // The reader marked the room read. Core has not caught up, so the copy the
+    // list is handed still carries the old unread.
+    rememberRoomRead({ ...room, unreadCount: 0 });
+
+    act(() => {
+      result.current.replaceRoom({ ...room, name: "renamed" });
+    });
+
+    expect(result.current.roomRows[0]?.name).toBe("renamed");
+    expect(result.current.roomRows[0]?.unreadCount).toBe(0);
+  });
+
+  it("reapplies the read overlay when it replaces the whole list", () => {
+    const room = channel("overlaid", { unreadCount: 5 });
+    const { result } = mount({ rooms: [room], paintOnly: true });
+
+    rememberRoomRead({ ...room, unreadCount: 0 });
+
+    act(() => {
+      result.current.replaceAllRooms([room]);
+    });
+
+    // A stale fetch must not paint the room unread again.
+    expect(result.current.roomRows[0]?.unreadCount).toBe(0);
+  });
+});

--- a/apps/web/src/components/chat/use-organization-chat-rooms.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.ts
@@ -1,0 +1,310 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { listPendingChatRoomInvitationsAction } from "@/app/chat/actions";
+import type {
+  ChatRoom,
+  ChatRoomInvitation,
+} from "@/lib/clients/generated/core";
+
+import { publishMembershipVisibleRooms } from "./membership-visible-rooms-store";
+import {
+  ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
+  type OrganizationChatRoomsChangedDetail,
+} from "./organization-chat-events";
+import {
+  listOrganizationArchivedChatRoomsAction,
+  listOrganizationChatRoomsAction,
+} from "./organization-chat-list.actions";
+import {
+  applyRoomReadOverlays,
+  forgetRoomRead,
+  rememberRoomRead,
+} from "./room-read-overlay";
+
+const ORGANIZATION_CHAT_POLL_MS = 15_000;
+
+/**
+ * Fetch the three sidebar collections in one round trip.
+ *
+ * Without an organization there are no archived rooms to ask for, so that leg
+ * resolves empty rather than calling Core.
+ */
+async function fetchSidebarRoomData(hasOrganization: boolean) {
+  return Promise.all([
+    listOrganizationChatRoomsAction(),
+    hasOrganization
+      ? listOrganizationArchivedChatRoomsAction()
+      : Promise.resolve({
+          ok: true as const,
+          value: {
+            rooms: [] as ChatRoom[],
+            nextCursor: null as string | null,
+          },
+        }),
+    listPendingChatRoomInvitationsAction(),
+  ]);
+}
+
+type SidebarRoomData = Awaited<ReturnType<typeof fetchSidebarRoomData>>;
+
+interface UseOrganizationChatRoomsOptions {
+  rooms: ChatRoom[];
+  archivedRooms: ChatRoom[];
+  pendingInvitations: ChatRoomInvitation[];
+  currentUserId: string;
+  organizationId: string | null;
+  paintOnly: boolean;
+}
+
+/**
+ * Holds the chat sidebar's three room collections: the prop hand-off from RSC
+ * and every path that can change the rows behind the reader's back (polling,
+ * window focus, room-read, and the rooms-changed control event).
+ *
+ * Rendering and room actions live in the components. Room actions still write
+ * the archived and pending collections through the setters this returns; the
+ * live rows are the exception, because the read overlay has to be reapplied on
+ * every write and that rule stays here. `paintOnly` mounts (SOK-903 instant
+ * soft-nav) skip every subscription, so they paint the props they were given
+ * and nothing else.
+ *
+ * The live rows are published to the membership-visible store on every change.
+ * Chat surfaces that render without mounting the sidebar read them back from
+ * there, the tab-title unread count among them.
+ *
+ * The three collections must keep their identity across renders. A new array
+ * reference means new props, and the rows are replaced, so a caller passing a
+ * fresh `[]` literal per render loops (React #301). That is what the list's
+ * stable empty invitations default is for.
+ */
+export function useOrganizationChatRooms({
+  rooms,
+  archivedRooms,
+  pendingInvitations,
+  currentUserId,
+  organizationId,
+  paintOnly,
+}: UseOrganizationChatRoomsOptions) {
+  const hasOrganization = Boolean(organizationId);
+  const [roomRows, setRoomRows] = useState(() => applyRoomReadOverlays(rooms));
+  const [archivedRows, setArchivedRows] = useState(archivedRooms);
+  const [pendingRows, setPendingRows] = useState(pendingInvitations);
+  const [prevRooms, setPrevRooms] = useState(rooms);
+  const [prevArchivedRooms, setPrevArchivedRooms] = useState(archivedRooms);
+  const [prevPendingInvitations, setPrevPendingInvitations] =
+    useState(pendingInvitations);
+
+  // Replace local list when RSC props change (full membership-visible set).
+  if (rooms !== prevRooms) {
+    setPrevRooms(rooms);
+    setRoomRows(applyRoomReadOverlays(rooms));
+  }
+  if (archivedRooms !== prevArchivedRooms) {
+    setPrevArchivedRooms(archivedRooms);
+    setArchivedRows(archivedRooms);
+  }
+  if (pendingInvitations !== prevPendingInvitations) {
+    setPrevPendingInvitations(pendingInvitations);
+    setPendingRows(pendingInvitations);
+  }
+
+  /**
+   * Put a room at the top of the live list, replacing any row already there.
+   *
+   * The archived copy goes at the same time: a room is live or archived, never
+   * both, so the two collections cannot be updated apart without the room
+   * appearing twice.
+   */
+  const upsertRoomToTop = useCallback((room: ChatRoom) => {
+    setRoomRows((current) => {
+      const without = current.filter((row) => row.id !== room.id);
+      return applyRoomReadOverlays([room, ...without]);
+    });
+    setArchivedRows((current) => current.filter((row) => row.id !== room.id));
+  }, []);
+
+  /**
+   * Swap one room in the live list for a newer copy of itself.
+   *
+   * A room the reader just marked unread drops its read overlay first, so the
+   * overlay cannot immediately paint the room read again.
+   */
+  const replaceRoom = useCallback((updated: ChatRoom) => {
+    if (updated.markedUnread) {
+      forgetRoomRead(updated.id);
+    }
+    setRoomRows((current) =>
+      applyRoomReadOverlays(
+        current.map((room) => (room.id === updated.id ? updated : room)),
+      ),
+    );
+  }, []);
+
+  /** Replace the whole live list with a freshly fetched one. */
+  const replaceAllRooms = useCallback((rooms: ChatRoom[]) => {
+    setRoomRows(applyRoomReadOverlays(rooms));
+  }, []);
+
+  /**
+   * Write the collections one refresh returned, skipping the calls that failed.
+   *
+   * A half-failed refresh must leave the sections it could not reach as they
+   * were, or a reader watches a section they can still see go empty.
+   */
+  const applySidebarRoomData = useCallback(
+    ([activeResult, archivedResult, pendingResult]: SidebarRoomData) => {
+      if (activeResult.ok) {
+        replaceAllRooms(activeResult.value.rooms);
+      }
+      if (archivedResult.ok) {
+        setArchivedRows(archivedResult.value.rooms);
+      }
+      if (pendingResult.ok) {
+        setPendingRows(pendingResult.value);
+      }
+    },
+    [replaceAllRooms],
+  );
+
+  useEffect(() => {
+    if (paintOnly) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const refreshRooms = async () => {
+      const data = await fetchSidebarRoomData(hasOrganization);
+      if (cancelled) {
+        return;
+      }
+      applySidebarRoomData(data);
+    };
+
+    // Mobile sheet remounts the list with stale RSC props; refresh immediately
+    // so overlays can drop once Core confirms the mark-read.
+    void refreshRooms();
+
+    const intervalId = window.setInterval(
+      refreshRooms,
+      ORGANIZATION_CHAT_POLL_MS,
+    );
+    window.addEventListener("focus", refreshRooms);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshRooms);
+    };
+  }, [applySidebarRoomData, hasOrganization, organizationId, paintOnly]);
+
+  useEffect(() => {
+    if (paintOnly) {
+      return;
+    }
+
+    const handleRoomRead = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{ room?: ChatRoom; roomId?: string }>
+      ).detail;
+      if (!detail?.roomId) {
+        return;
+      }
+
+      if (detail.room) {
+        // Dual-baseline: leftover Participant Thread unread stays on the row.
+        rememberRoomRead(detail.room);
+      }
+
+      setRoomRows((current) =>
+        applyRoomReadOverlays(
+          current.map((room) =>
+            room.id === detail.roomId
+              ? (detail.room ?? {
+                  ...room,
+                  unreadCount: 0,
+                  unreadMentionCount: 0,
+                  markedUnread: false,
+                })
+              : room,
+          ),
+        ),
+      );
+    };
+
+    window.addEventListener("organization-chat-room-read", handleRoomRead);
+    return () => {
+      window.removeEventListener("organization-chat-room-read", handleRoomRead);
+    };
+  }, [paintOnly]);
+
+  useEffect(() => {
+    if (paintOnly) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const handleRoomsChanged = (event: Event) => {
+      const detail = (event as CustomEvent<OrganizationChatRoomsChangedDetail>)
+        .detail;
+      const removedRoomId = detail?.removedRoomId;
+      if (removedRoomId) {
+        setRoomRows((current) =>
+          applyRoomReadOverlays(
+            current.filter((row) => row.id !== removedRoomId),
+          ),
+        );
+        setArchivedRows((current) =>
+          current.filter((row) => row.id !== removedRoomId),
+        );
+        return;
+      }
+
+      const room = detail?.room;
+      if (room) {
+        upsertRoomToTop(room);
+        return;
+      }
+
+      void fetchSidebarRoomData(hasOrganization).then((data) => {
+        if (cancelled) {
+          return;
+        }
+        applySidebarRoomData(data);
+      });
+    };
+
+    window.addEventListener(
+      ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
+      handleRoomsChanged,
+    );
+    return () => {
+      cancelled = true;
+      window.removeEventListener(
+        ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
+        handleRoomsChanged,
+      );
+    };
+  }, [applySidebarRoomData, hasOrganization, paintOnly, upsertRoomToTop]);
+
+  useEffect(() => {
+    if (paintOnly) {
+      return;
+    }
+    publishMembershipVisibleRooms(roomRows, organizationId, currentUserId);
+  }, [currentUserId, organizationId, paintOnly, roomRows]);
+
+  return {
+    roomRows,
+    archivedRows,
+    pendingRows,
+    setArchivedRows,
+    setPendingRows,
+    upsertRoomToTop,
+    replaceRoom,
+    replaceAllRooms,
+  };
+}


### PR DESCRIPTION
## Why

`organization-chat-list.client.tsx` was 880 lines, over this repo's 750-line
ceiling. SOK-979 adds the sidebar control for the unread message count and
cannot land in a file that is already over the limit. Split first, so the easy
change stays easy.

Nothing a reader can see changes.

## What changed

Four responsibilities move out of the list component into their own files:

| New file | Responsibility |
| --- | --- |
| `use-organization-chat-rooms.ts` | Keeps the three sidebar collections true: RSC prop hand-off, polling and focus refresh, the room-read event, the rooms-changed control event, and the membership-visible publish. |
| `chat-sidebar-section-header.tsx` | Renders one collapsible section heading. |
| `chat-membership-revoked-list-bridge.tsx` | The list-mounted Ably control. |
| `active-room-id.ts` | Reads the open room from the pathname. |

Four duplications collapse in the process:

- The polling effect and the rooms-changed fallback each built the same
  three-call fetch, then wrote the three results the same way. They now share
  `fetchSidebarRoomData` and `applySidebarRoomData`.
- The rooms-changed branch and the restore action each prepended a room and
  dropped its archived copy. They now share `upsertRoomToTop`, so the live and
  archived collections cannot be updated apart.
- `getActiveRoomIdFromPathname` existed twice: once privately in this component
  and once exported from `use-chat-tab-unread-presence.ts`. `active-room-id.ts`
  is now its one owner and both callers read from it.

The room-read overlay is the hook's invariant, but two sites in the list
reapplied it by hand. Those become hook operations: `replaceRoom`, which drops
the read overlay of a room the reader just marked unread, and `replaceAllRooms`.
The hook no longer hands out `setRoomRows`.

`organization-chat-list.client.tsx` is now 588 lines. Every extracted file is
under 300.

## Reviewing this as a pure move

Two hunks are equivalent rather than literally identical, both deliberate:

1. `handleRestoreRoom` filtered the archived rows by the requested `room.id` and
   the live rows by `result.value.id`. `upsertRoomToTop` keys both on
   `result.value.id`. Same value: `restoreRoomAction(roomId)` returns
   `chatRoomService.restoreRoom(roomId)` for that id.
2. A one-line `handleRoomUpdated` wrapper is gone; `replaceRoom` is passed to
   `onRoomUpdated` directly. `ChatRoomSidebarRow` is not memoized, so the
   swap from a per-render function to a stable `useCallback` changes no renders.

Everything else is a move. Every effect dependency array, listener add/remove
pair, `cancelled` flag, `clearInterval`, and `paintOnly` guard is preserved.

## Tests

`active-room-id.ts` and `use-organization-chat-rooms.ts` were untested inside the
big file. They now have their own: 6 cases for the pathname reader, 12 for the
hook (paint-only, mount refresh, prop replacement, room-read clearing unread,
room removal, both `upsertRoomToTop` paths, `replaceRoom`, its marked-unread
rule, `replaceAllRooms`, and the read overlay on both replace paths).

Three of those are mutation-checked. Removing the `forgetRoomRead` guard, or
either `applyRoomReadOverlays` call, makes exactly one test fail each time.

No existing chat sidebar test was rewritten. One unrelated test file changed:
`use-chat-tab-unread-presence.test.tsx` loses its
`describe("getActiveRoomIdFromPathname")` block, because that helper and its
tests moved to `active-room-id`.

## Verification

- `pnpm check:write`
- `pnpm --filter web typecheck`
- `pnpm --filter web test`

## Linear

SOK-977, child of SOK-969. Blocks SOK-979.
