### PR TITLE
fix(projects): align workspace column and mobile memory order

### DIFF
--- a/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
@@ -153,6 +153,12 @@ describe("ProjectDetailPage", () => {
     expect(screen.getByTestId("brand-card")).toBeInTheDocument();
     expect(screen.getByTestId("memory-stat")).toBeInTheDocument();
     expect(screen.getByTestId("needs-attention-section")).toBeInTheDocument();
+    const memory = screen.getByTestId("memory-stat");
+    const needsAttention = screen.getByTestId("needs-attention-section");
+    expect(
+      memory.compareDocumentPosition(needsAttention) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(container.innerHTML).not.toContain(
       "bg-muted/30 border-border/50 rounded-none border p-4",
     );
@@ -160,8 +166,15 @@ describe("ProjectDetailPage", () => {
       "App.Projects.Detail.modules.title",
     );
     expect(workspaceHeading).toBeInTheDocument();
-    expect(workspaceHeading.closest("section")?.className).toContain("px-4");
-    expect(workspaceHeading.closest("section")?.className).toContain("md:px-0");
+    const workspaceSection = workspaceHeading.closest("section");
+    expect(workspaceSection?.className).toContain("space-y-3");
+    expect(workspaceSection?.className).toContain("xl:col-span-2");
+    expect(workspaceSection?.className).not.toContain("px-4");
+    expect(workspaceSection?.className).not.toContain("md:px-0");
+    const overviewGrid = workspaceSection?.parentElement;
+    expect(overviewGrid?.className).toContain("grid");
+    expect(overviewGrid?.className).toContain("xl:grid-cols-3");
+    expect((container.firstChild as HTMLElement).childElementCount).toBe(1);
     expect(container.querySelectorAll('[aria-disabled="true"]')).toHaveLength(
       6,
     );

--- a/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
@@ -173,7 +173,7 @@ describe("ProjectDetailPage", () => {
     expect(workspaceSection?.className).not.toContain("md:px-0");
     const overviewGrid = workspaceSection?.parentElement;
     expect(overviewGrid?.className).toContain("grid");
-    expect(overviewGrid?.className).toContain("px-2");
+    expect(overviewGrid?.className).toContain("px-4");
     expect(overviewGrid?.className).toContain("md:px-0");
     expect(overviewGrid?.className).toContain("xl:grid-cols-3");
     expect((container.firstChild as HTMLElement).childElementCount).toBe(1);

--- a/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
@@ -156,9 +156,13 @@ describe("ProjectDetailPage", () => {
     const memory = screen.getByTestId("memory-stat");
     const needsAttention = screen.getByTestId("needs-attention-section");
     expect(
-      memory.compareDocumentPosition(needsAttention) &
+      needsAttention.compareDocumentPosition(memory) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    expect(needsAttention.parentElement?.className).toContain("order-4");
+    expect(needsAttention.parentElement?.className).toContain("xl:order-3");
+    expect(memory.parentElement?.className).toContain("order-3");
+    expect(memory.parentElement?.className).toContain("xl:order-4");
     expect(container.innerHTML).not.toContain(
       "bg-muted/30 border-border/50 rounded-none border p-4",
     );
@@ -169,6 +173,12 @@ describe("ProjectDetailPage", () => {
     const workspaceSection = workspaceHeading.closest("section");
     expect(workspaceSection?.className).toContain("space-y-3");
     expect(workspaceSection?.className).toContain("xl:col-span-2");
+    expect(workspaceSection?.querySelector(".grid")?.className).toContain(
+      "md:grid-cols-4",
+    );
+    expect(workspaceSection?.querySelector(".grid")?.className).not.toContain(
+      "xl:grid-cols-7",
+    );
     expect(workspaceSection?.className).not.toContain("px-4");
     expect(workspaceSection?.className).not.toContain("md:px-0");
     const overviewGrid = workspaceSection?.parentElement;

--- a/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
@@ -173,6 +173,8 @@ describe("ProjectDetailPage", () => {
     expect(workspaceSection?.className).not.toContain("md:px-0");
     const overviewGrid = workspaceSection?.parentElement;
     expect(overviewGrid?.className).toContain("grid");
+    expect(overviewGrid?.className).toContain("px-2");
+    expect(overviewGrid?.className).toContain("md:px-0");
     expect(overviewGrid?.className).toContain("xl:grid-cols-3");
     expect((container.firstChild as HTMLElement).childElementCount).toBe(1);
     expect(container.querySelectorAll('[aria-disabled="true"]')).toHaveLength(

--- a/apps/web/src/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.tsx
@@ -91,7 +91,7 @@ export default async function ProjectDetailPage({
           initialDesignMd={project.designMd}
           websiteUrl={project.websiteUrl}
         >
-          <div className="mt-6 grid grid-cols-1 gap-8 xl:grid-cols-3">
+          <div className="mt-6 grid grid-cols-1 gap-8 px-2 md:px-0 xl:grid-cols-3">
             <div className="order-1 xl:order-1 xl:col-span-2">
               <ProjectBriefing
                 title={t("briefing")}

--- a/apps/web/src/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.tsx
@@ -92,7 +92,7 @@ export default async function ProjectDetailPage({
           websiteUrl={project.websiteUrl}
         >
           <div className="mt-6 grid grid-cols-1 gap-8 xl:grid-cols-3">
-            <div className="xl:col-span-2">
+            <div className="order-1 xl:order-1 xl:col-span-2">
               <ProjectBriefing
                 title={t("briefing")}
                 briefing={project.briefing}
@@ -104,14 +104,26 @@ export default async function ProjectDetailPage({
               />
             </div>
 
-            <ProjectBrandCard
-              projectId={project.id}
-              projectName={project.name}
-              logo={project.logo}
-              websiteUrl={project.websiteUrl}
-            />
+            <div className="order-2 xl:order-2">
+              <ProjectBrandCard
+                projectId={project.id}
+                projectName={project.name}
+                logo={project.logo}
+                websiteUrl={project.websiteUrl}
+              />
+            </div>
 
-            <div className="xl:col-span-2">
+            <div className="order-3 xl:order-4">
+              <ProjectMemoryRow
+                projectId={project.id}
+                contextMd={project.contextMd}
+                contextMdUpdating={project.contextMdUpdating}
+                memoryEnabled={project.memoryEnabled}
+                memoryModel={project.memoryModel}
+              />
+            </div>
+
+            <div className="order-4 xl:order-3 xl:col-span-2">
               <ProjectNeedsAttentionSection
                 projectId={project.id}
                 taskCount={attention.taskCount}
@@ -136,65 +148,59 @@ export default async function ProjectDetailPage({
               />
             </div>
 
-            <ProjectMemoryRow
-              projectId={project.id}
-              contextMd={project.contextMd}
-              contextMdUpdating={project.contextMdUpdating}
-              memoryEnabled={project.memoryEnabled}
-              memoryModel={project.memoryModel}
-            />
+            <section
+              className={`order-5 xl:order-5 xl:col-span-2 ${PROJECTS_DETAIL_WORKSPACE_CLASS}`}
+            >
+              <h2 className="text-muted-foreground text-xs font-medium">
+                {t("modules.title")}
+              </h2>
+              <ProjectModuleTiles
+                calendarHref={
+                  isBetaAccessEmail(session?.user.email)
+                    ? `/projects/${project.id}/calendar`
+                    : undefined
+                }
+                projectId={project.id}
+                labels={{
+                  calendar: {
+                    title: t("modules.calendar.title"),
+                    description: t("modules.calendar.description"),
+                  },
+                  comingSoon: t("modules.comingSoon"),
+                  seo: {
+                    title: t("modules.seo.title"),
+                    description: t("modules.seo.description"),
+                  },
+                  socialMedia: {
+                    title: t("modules.socialMedia.title"),
+                    description: t("modules.socialMedia.description"),
+                  },
+                  email: {
+                    title: t("modules.email.title"),
+                    description: t("modules.email.description"),
+                  },
+                  paidAdvertising: {
+                    title: t("modules.paidAdvertising.title"),
+                    description: t("modules.paidAdvertising.description"),
+                  },
+                  content: {
+                    title: t("modules.content.title"),
+                    description: t("modules.content.description"),
+                  },
+                  pr: {
+                    title: t("modules.pr.title"),
+                    description: t("modules.pr.description"),
+                  },
+                  fileBrowser: {
+                    title: t("modules.fileBrowser.title"),
+                    description: t("modules.fileBrowser.description"),
+                  },
+                }}
+              />
+            </section>
           </div>
         </ProjectBrandProvider>
       </div>
-
-      <section className={PROJECTS_DETAIL_WORKSPACE_CLASS}>
-        <h2 className="text-muted-foreground text-xs font-medium">
-          {t("modules.title")}
-        </h2>
-        <ProjectModuleTiles
-          calendarHref={
-            isBetaAccessEmail(session?.user.email)
-              ? `/projects/${project.id}/calendar`
-              : undefined
-          }
-          projectId={project.id}
-          labels={{
-            calendar: {
-              title: t("modules.calendar.title"),
-              description: t("modules.calendar.description"),
-            },
-            comingSoon: t("modules.comingSoon"),
-            seo: {
-              title: t("modules.seo.title"),
-              description: t("modules.seo.description"),
-            },
-            socialMedia: {
-              title: t("modules.socialMedia.title"),
-              description: t("modules.socialMedia.description"),
-            },
-            email: {
-              title: t("modules.email.title"),
-              description: t("modules.email.description"),
-            },
-            paidAdvertising: {
-              title: t("modules.paidAdvertising.title"),
-              description: t("modules.paidAdvertising.description"),
-            },
-            content: {
-              title: t("modules.content.title"),
-              description: t("modules.content.description"),
-            },
-            pr: {
-              title: t("modules.pr.title"),
-              description: t("modules.pr.description"),
-            },
-            fileBrowser: {
-              title: t("modules.fileBrowser.title"),
-              description: t("modules.fileBrowser.description"),
-            },
-          }}
-        />
-      </section>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.tsx
@@ -91,7 +91,7 @@ export default async function ProjectDetailPage({
           initialDesignMd={project.designMd}
           websiteUrl={project.websiteUrl}
         >
-          <div className="mt-6 grid grid-cols-1 gap-8 px-2 md:px-0 xl:grid-cols-3">
+          <div className="mt-6 grid grid-cols-1 gap-8 px-4 md:px-0 xl:grid-cols-3">
             <div className="order-1 xl:order-1 xl:col-span-2">
               <ProjectBriefing
                 title={t("briefing")}

--- a/apps/web/src/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.tsx
@@ -113,16 +113,6 @@ export default async function ProjectDetailPage({
               />
             </div>
 
-            <div className="order-3 xl:order-4">
-              <ProjectMemoryRow
-                projectId={project.id}
-                contextMd={project.contextMd}
-                contextMdUpdating={project.contextMdUpdating}
-                memoryEnabled={project.memoryEnabled}
-                memoryModel={project.memoryModel}
-              />
-            </div>
-
             <div className="order-4 xl:order-3 xl:col-span-2">
               <ProjectNeedsAttentionSection
                 projectId={project.id}
@@ -145,6 +135,16 @@ export default async function ProjectDetailPage({
                   taskStatus: taskStatusLabels,
                   locale,
                 }}
+              />
+            </div>
+
+            <div className="order-3 xl:order-4">
+              <ProjectMemoryRow
+                projectId={project.id}
+                contextMd={project.contextMd}
+                contextMdUpdating={project.contextMdUpdating}
+                memoryEnabled={project.memoryEnabled}
+                memoryModel={project.memoryModel}
               />
             </div>
 

--- a/apps/web/src/app/(app)/projects/components/project-module-tiles.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-module-tiles.test.tsx
@@ -39,6 +39,12 @@ describe("ProjectModuleTiles", () => {
       />,
     );
 
+    expect(container.firstElementChild?.className).toContain("grid-cols-2");
+    expect(container.firstElementChild?.className).toContain("md:grid-cols-4");
+    expect(container.firstElementChild?.className).not.toContain(
+      "xl:grid-cols-7",
+    );
+
     const headings = [...container.querySelectorAll("h3")].map(
       (heading) => heading.textContent,
     );

--- a/apps/web/src/app/(app)/projects/components/project-module-tiles.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-module-tiles.tsx
@@ -63,11 +63,7 @@ export function ProjectModuleTiles({
   projectId,
 }: ProjectModuleTilesProps) {
   return (
-    <div
-      className={`grid grid-cols-2 gap-4 md:grid-cols-4 ${
-        calendarHref ? "xl:grid-cols-4" : "xl:grid-cols-7"
-      }`}
-    >
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
       {calendarHref ? (
         <Link
           aria-label={labels.calendar.title}

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
@@ -131,6 +131,11 @@ describe("ProjectNeedsAttentionSection", () => {
     expect(screen.getByTestId("job-status")).toHaveTextContent(
       SokosumiJobStatus.PAYMENT_FAILED,
     );
+
+    const listBox = screen
+      .getByTestId("project-needs-attention")
+      .querySelector(":scope > div:last-child");
+    expect(listBox).toHaveClass("-mx-4", "md:mx-0");
   });
 
   it("shows empty copy when there are no attention items", () => {
@@ -147,5 +152,10 @@ describe("ProjectNeedsAttentionSection", () => {
     expect(
       screen.getByText("Nothing needs your attention right now."),
     ).toBeInTheDocument();
+
+    const listBox = screen
+      .getByTestId("project-needs-attention")
+      .querySelector(":scope > div:last-child");
+    expect(listBox).toHaveClass("-mx-4", "md:mx-0");
   });
 });

--- a/apps/web/src/app/(app)/projects/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/constants.test.ts
@@ -34,11 +34,12 @@ describe("projects list CLS layout constants", () => {
     expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:rounded-xl");
   });
 
-  it("exports detail list layout without negative horizontal margin", () => {
+  it("exports detail list layout with mobile bleed out of overview px-4", () => {
     expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("bg-muted/30");
     expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("md:rounded-xl");
     expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("md:border");
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).not.toContain("-mx-4");
+    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("-mx-4");
+    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("md:mx-0");
     expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).not.toContain("-mx-6");
   });
 });

--- a/apps/web/src/app/(app)/projects/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/constants.test.ts
@@ -53,7 +53,7 @@ describe("projects mobile padding shells", () => {
     expect(PROJECTS_PAGE_SHELL_CLASS).not.toContain("calc(100%");
   });
 
-  it("detail shell cancels main p-4 on both edges; workspace keeps mobile px-4", () => {
+  it("detail shell cancels main p-4 on both edges; workspace shares overview grid rhythm", () => {
     const shell = PROJECTS_DETAIL_SHELL_CLASS.split(/\s+/);
     const workspace = PROJECTS_DETAIL_WORKSPACE_CLASS.split(/\s+/);
 
@@ -66,8 +66,7 @@ describe("projects mobile padding shells", () => {
     expect(shell).not.toContain("px-2");
 
     expect(PROJECTS_DETAIL_TOP_CLASS).toBe("w-full");
-    expect(workspace).toContain("px-4");
-    expect(workspace).toContain("md:px-0");
+    expect(workspace).toEqual(["space-y-3"]);
   });
 });
 

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -26,9 +26,9 @@ export const PROJECTS_DETAIL_SHELL_CLASS =
 export const PROJECTS_DETAIL_TOP_CLASS = "w-full";
 
 /**
- * Workspace modules (`modules.title`): mobile px-4 horizontal pad.
+ * Workspace modules (`modules.title`): stacks heading + tiles in the overview grid.
  */
-export const PROJECTS_DETAIL_WORKSPACE_CLASS = "mt-6 space-y-3 px-4 md:px-0";
+export const PROJECTS_DETAIL_WORKSPACE_CLASS = "space-y-3";
 
 /**
  * Shared list card min-height for Instant skeleton, loaded list, and empty state

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -46,11 +46,12 @@ export const PROJECTS_BROWSE_LAYOUT_CLASS =
   "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
 
 /**
- * Detail overview list box (Tasks / Jobs). Same fill/radius/border as browse,
- * but no `-mx-*`: detail shell already cancels main p-4 and top is full-bleed.
+ * Detail overview list box (Needs attention / Tasks / Jobs). Same fill/radius/border
+ * as browse. Overview grid is `px-4` on mobile, so `-mx-4 md:mx-0` reaches the
+ * viewport edge; desktop stays in the column.
  */
 export const PROJECTS_DETAIL_LIST_LAYOUT_CLASS =
-  "bg-muted/30 border-border/50 overflow-hidden rounded-none border-0 md:rounded-xl md:border";
+  "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
 
 /**
  * Inner divide wrapper for browse rows. Shared by live list and Instant skeleton.

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -45,11 +45,6 @@ export const PROJECTS_LIST_CARD_MIN_H_CLASS = "min-h-[320px]";
 export const PROJECTS_BROWSE_LAYOUT_CLASS =
   "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
 
-/**
- * Detail overview list box (Needs attention / Tasks / Jobs). Same fill/radius/border
- * as browse. Overview grid is `px-4` on mobile, so `-mx-4 md:mx-0` reaches the
- * viewport edge; desktop stays in the column.
- */
 export const PROJECTS_DETAIL_LIST_LAYOUT_CLASS =
   "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Project detail put Workspace tiles full-width under the overview and stacked Memory after Needs attention on mobile. Follow-up feedback also needed mobile overview gutters, a 4-column Workspace cap, and an edge-to-edge Needs attention empty state and list. Codex then asked for xl keyboard order to match that grid.

## Scope

- Move Workspace into the overview `xl:grid-cols-3` as `xl:col-span-2`.
- Overview DOM follows the xl grid: Briefing, Brand, Needs attention, Memory, Workspace. `order-3` / `order-4` still put Memory above Needs on mobile. xl tab order matches the visual columns.
- Overview grid uses `px-4 md:px-0` so Briefing through Workspace match the header gutter after the shell cancels main `p-4`.
- `PROJECTS_DETAIL_LIST_LAYOUT_CLASS` uses `-mx-4 md:mx-0` so the Needs attention empty state and list reach the viewport on mobile. The heading, pills, and View all links stay inset.
- `ProjectModuleTiles` is `grid-cols-2 md:grid-cols-4` (drop `xl:grid-cols-7`).
- Layout contract tests updated.

## Tradeoffs

Mobile visual order still uses CSS `order`. Keyboard order on small viewports follows the xl source order (Needs before Memory). Desktop keyboard users hit the longer Needs attention list first.

## Blast Radius

Project detail overview layout, Workspace tile density, and overview tab order.

## Verification

- `pnpm --filter web test` on page, constants, needs-attention, and module tiles tests.
- Live UI: mobile Briefing label at 16px; Needs attention box flush with the viewport; desktop Briefing/Needs/Workspace at x≈264, Brand/Memory at x≈1033; Workspace tiles max 4 cols.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57b30602-1695-4d1d-b0d0-1002ddfed8b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57b30602-1695-4d1d-b0d0-1002ddfed8b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated project detail layouts with more consistent responsive spacing and section ordering.
  * Improved mobile presentation by allowing detail lists and attention sections to extend edge to edge.
  * Standardized project module tiles to use two columns on mobile and four columns at medium screen sizes.
  * Refined workspace and module grid layouts for improved desktop alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->