### PR TITLE
feat(utils): add the canonical web app URL per network

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -419,6 +419,10 @@ export {
   isOwnedVendorLogoUrl,
 } from "./vendor-logo-path.js";
 export {
+  getCanonicalWebAppHost,
+  getCanonicalWebAppUrl,
+} from "./web-app-url.js";
+export {
   buildWebhookFailureContext,
   DEFAULT_WEBHOOK_TIMEOUT_MS,
   MAX_REPORTED_WEBHOOK_BODY_LENGTH,

--- a/packages/utils/src/web-app-url.test.ts
+++ b/packages/utils/src/web-app-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getCanonicalWebAppHost,
+  getCanonicalWebAppUrl,
+} from "./web-app-url.js";
+
+describe("getCanonicalWebAppUrl", () => {
+  it("answers the production domain per network", () => {
+    expect(getCanonicalWebAppUrl("Mainnet")).toBe("https://app.sokosumi.com");
+    expect(getCanonicalWebAppUrl("Preprod")).toBe(
+      "https://preprod.sokosumi.com",
+    );
+  });
+
+  it("has no trailing slash to collapse when a path is appended", () => {
+    for (const network of ["Mainnet", "Preprod"] as const) {
+      expect(getCanonicalWebAppUrl(network).endsWith("/")).toBe(false);
+    }
+  });
+});
+
+describe("getCanonicalWebAppHost", () => {
+  it("drops the scheme so it compares against a request Host header", () => {
+    expect(getCanonicalWebAppHost("Mainnet")).toBe("app.sokosumi.com");
+    expect(getCanonicalWebAppHost("Preprod")).toBe("preprod.sokosumi.com");
+  });
+});

--- a/packages/utils/src/web-app-url.ts
+++ b/packages/utils/src/web-app-url.ts
@@ -1,0 +1,30 @@
+/**
+ * The web app host a deployed environment is reached on.
+ *
+ * Every environment answers on two hosts: its canonical domain, and the
+ * per-deployment URL Vercel mints for the deployment behind it. Both serve the
+ * same app from the same database, so a reader who arrives on the deployment
+ * URL is signed in and sees nothing wrong. What they cannot see is that the
+ * browser scopes a push subscription to the origin that created it, so their
+ * notifications now belong to a host whose name changes with the next deploy.
+ *
+ * One canonical answer per network, so a link Core writes and a redirect the
+ * web app serves cannot disagree about where the app lives.
+ */
+
+type SokosumiNetwork = "Mainnet" | "Preprod";
+
+const CANONICAL_WEB_APP_URLS: Record<SokosumiNetwork, string> = {
+  Mainnet: "https://app.sokosumi.com",
+  Preprod: "https://preprod.sokosumi.com",
+};
+
+/** The canonical origin the network's web app is reached on, no trailing slash. */
+export function getCanonicalWebAppUrl(network: SokosumiNetwork): string {
+  return CANONICAL_WEB_APP_URLS[network];
+}
+
+/** The canonical host, for comparing against an incoming request's `Host`. */
+export function getCanonicalWebAppHost(network: SokosumiNetwork): string {
+  return new URL(getCanonicalWebAppUrl(network)).host;
+}


### PR DESCRIPTION
Both Core and the web app need one answer for where a network's web app
lives. Core writes invite and checkout links with it; the web app needs it
to recognise a request that arrived on a non-canonical host.

Core already hardcoded the same two domains in its Better Auth trusted
origins, and the web app hardcoded the Mainnet one in its site config, so
the fact was stated three times and could disagree with itself.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>