### PR TITLE
fix(core): build production web links on the canonical host

### DIFF
--- a/apps/core/README.md
+++ b/apps/core/README.md
@@ -65,7 +65,7 @@ Configuration is validated at startup with Zod (`src/config/env.ts`). Copy `apps
 
 | Variable | Purpose |
 | -------- | ------- |
-| `WEB_APP_BASE_URL` | Defaults to `http://localhost:3000`. Used by `getWebAppBaseUrl()` (with Vercel [related projects](https://vercel.com/docs/monorepos#related-projects) when deployed) so Core knows the browser origin for the web app |
+| `WEB_APP_BASE_URL` | Defaults to `http://localhost:3000`. Read by `getWebAppBaseUrl()` outside Vercel, so Core knows the browser origin for the web app. On Vercel Preview it is the fallback behind the [related project](https://vercel.com/docs/monorepos#related-projects) branch host. Ignored on Vercel Production, which answers with the network's canonical domain (`@sokosumi/utils` `getCanonicalWebAppUrl`) so a link never carries a per-deployment host |
 | `VERCEL_ENV` | Optional. `preview` \| `production` \| `development` — set on Vercel |
 | `VERCEL_URL` | Optional. Current deployment hostname/URL on Vercel (often set automatically) |
 | `VERCEL_BRANCH_URL` | Optional. Stable branch URL on Vercel Preview |

--- a/apps/core/src/config/env.test.ts
+++ b/apps/core/src/config/env.test.ts
@@ -63,6 +63,108 @@ describe("resolveWebRelatedProjectFallbackHost", () => {
   });
 });
 
+describe("getWebAppBaseUrl", () => {
+  /**
+   * `getEnv` caches the parsed environment at module scope, so each case gets
+   * a fresh module rather than a shared one that froze the first case's
+   * values.
+   */
+  async function loadWebAppBaseUrl(
+    caseOverrides: Record<string, string | undefined>,
+  ): Promise<string> {
+    // A deployed environment rejects the suite's in-memory Soko Bot adapter,
+    // and a rejected environment exits the process before any URL is read.
+    const overrides = {
+      SOKO_BOT_RUNTIME_ADAPTER: "in-process",
+      ...caseOverrides,
+    };
+    const previous = Object.fromEntries(
+      Object.keys(overrides).map((key) => [key, process.env[key]]),
+    );
+
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+
+    try {
+      vi.resetModules();
+      const { getWebAppBaseUrl } = await import("./env.js");
+      return getWebAppBaseUrl();
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      vi.resetModules();
+    }
+  }
+
+  it.each([
+    ["Mainnet", "https://app.sokosumi.com"],
+    ["Preprod", "https://preprod.sokosumi.com"],
+  ])(
+    "answers the canonical %s domain on Vercel production",
+    async (network, expected) => {
+      await expect(
+        loadWebAppBaseUrl({ NETWORK: network, VERCEL_ENV: "production" }),
+      ).resolves.toBe(expected);
+    },
+  );
+
+  it("ignores the related project on production, whatever it reports", async () => {
+    // The bug: `withRelatedProject` falls back to `production.url`, the
+    // per-deployment host whose hash changes with every web deploy. A reader
+    // who follows such a link keeps the app on that origin, and the browser
+    // ties their push subscription to it.
+    await expect(
+      loadWebAppBaseUrl({
+        NETWORK: "Mainnet",
+        VERCEL_ENV: "production",
+        VERCEL_RELATED_PROJECTS: JSON.stringify([
+          {
+            project: { id: "prj_test", name: "sokosumi-app-mainnet" },
+            production: {
+              url: "sokosumi-app-mainnet-od9mmtb7d.preview.sokosumi.com",
+            },
+            preview: {},
+          },
+        ]),
+      }),
+    ).resolves.toBe("https://app.sokosumi.com");
+  });
+
+  it("still asks the related project on Vercel preview", async () => {
+    await expect(
+      loadWebAppBaseUrl({
+        NETWORK: "Mainnet",
+        VERCEL_ENV: "preview",
+        VERCEL_RELATED_PROJECTS: JSON.stringify([
+          {
+            project: { id: "prj_test", name: "sokosumi-app-mainnet" },
+            production: {},
+            preview: {
+              branch: "sokosumi-app-mainnet-git-topic.preview.sokosumi.com",
+            },
+          },
+        ]),
+      }),
+    ).resolves.toBe(
+      "https://sokosumi-app-mainnet-git-topic.preview.sokosumi.com",
+    );
+  });
+
+  it("uses the configured URL when there is no Vercel environment", async () => {
+    await expect(
+      loadWebAppBaseUrl({
+        VERCEL_ENV: undefined,
+        VERCEL_RELATED_PROJECTS: undefined,
+        WEB_APP_BASE_URL: "http://localhost:3000",
+      }),
+    ).resolves.toBe("http://localhost:3000");
+  });
+});
+
 describe("Soko Bot deployment environment", () => {
   it.each([
     ["Node production", { NODE_ENV: "production" }],

--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -1,5 +1,8 @@
 import { z } from "@hono/zod-openapi";
-import { resolveBetterAuthPublicBaseUrl } from "@sokosumi/utils";
+import {
+  getCanonicalWebAppUrl,
+  resolveBetterAuthPublicBaseUrl,
+} from "@sokosumi/utils";
 import { withRelatedProject } from "@vercel/related-projects";
 import { v4 as uuidv4 } from "uuid";
 
@@ -352,11 +355,27 @@ export function getEnv(): EnvConfig {
 
 /**
  * Web app base URL (used for Better Auth trusted origin, redirects, and links).
- * On Vercel, uses the related web project deployment URL when core's
- * relatedProjects point to the web app; otherwise uses WEB_APP_BASE_URL.
+ *
+ * On Vercel Production the answer is the network's canonical domain, and the
+ * related project is not consulted at all. `withRelatedProject` returns the
+ * related project's production alias only when Vercel populates one, and falls
+ * back to its `production.url`: the per-deployment host, whose hash changes
+ * with every web deploy. Links Core hands out live longer than one deploy, and
+ * a reader who follows one onto that host keeps the app there. The browser
+ * scopes a push subscription to the origin that created it, so their
+ * notifications then arrive from, and lead back to, a deployment URL.
+ *
+ * Everywhere else the related project still answers: on Vercel Preview it is
+ * the only source that knows the sibling branch deployment, and locally it is
+ * absent so `WEB_APP_BASE_URL` answers as before.
  */
 export function getWebAppBaseUrl(): string {
   const env = getEnv();
+
+  if (env.VERCEL_ENV === "production") {
+    return getCanonicalWebAppUrl(env.NETWORK);
+  }
+
   return withRelatedProject({
     projectName: getWebRelatedProjectName(env.NETWORK),
     defaultHost: resolveWebRelatedProjectFallbackHost({

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -28,6 +28,7 @@ import { authTranslations } from "@sokosumi/masumi/auth";
 import {
   betterAuthOrganizationAdditionalFields,
   betterAuthUserAdditionalFields,
+  getCanonicalWebAppUrl,
   getEmailLocale,
   OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
   OAUTH_PROVIDER_SCOPES,
@@ -451,8 +452,10 @@ export const auth = betterAuth({
   },
   trustedOrigins: Array.from(
     new Set([
-      "https://app.sokosumi.com",
-      "https://preprod.sokosumi.com",
+      // Both networks, whichever one this deployment serves: a Preprod Core
+      // still answers a Mainnet origin during a cutover.
+      getCanonicalWebAppUrl("Mainnet"),
+      getCanonicalWebAppUrl("Preprod"),
       webAppBaseUrl,
       "https://*.preview.sokosumi.com", // Vercel preview deployment suffix
       ...(env.NODE_ENV === "development"


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>