### PR TITLE
fix(web): keep production readers on the canonical host

### DIFF
--- a/apps/web/src/lib/canonical-host.test.ts
+++ b/apps/web/src/lib/canonical-host.test.ts
@@ -1,0 +1,228 @@
+import { createContext, runInContext } from "node:vm";
+
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { NOTIFICATION_SERVICE_WORKER_URL } from "@/lib/utils/notification-service-worker";
+
+import { handleNonCanonicalHost } from "./canonical-host";
+
+const MAINNET_PRODUCTION = {
+  vercelEnv: "production",
+  network: "Mainnet",
+} as const;
+
+/** A production deployment URL, the host this whole module exists for. */
+const DEPLOYMENT_HOST = "sokosumi-app-mainnet-od9mmtb7d.preview.sokosumi.com";
+
+function request(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+describe("handleNonCanonicalHost", () => {
+  it("sends a production deployment host to the canonical host, path and query intact", () => {
+    const response = handleNonCanonicalHost(
+      request(`https://${DEPLOYMENT_HOST}/chat/rooms/abc?tab=files`),
+      MAINNET_PRODUCTION,
+    );
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe(
+      "https://app.sokosumi.com/chat/rooms/abc?tab=files",
+    );
+  });
+
+  it("uses the Preprod domain on the Preprod network", () => {
+    const response = handleNonCanonicalHost(
+      request("https://sokosumi-app-preprod-od9mmtb7d.preview.sokosumi.com/"),
+      { vercelEnv: "production", network: "Preprod" },
+    );
+
+    expect(response?.headers.get("location")).toBe(
+      "https://preprod.sokosumi.com/",
+    );
+  });
+
+  it.each([
+    ["//evil.example/x?a=1", "https://app.sokosumi.com/evil.example/x?a=1"],
+    ["/\\/evil.example/x", "https://app.sokosumi.com/evil.example/x"],
+    ["////evil.example/", "https://app.sokosumi.com/evil.example/"],
+  ])(
+    "never sends %s off the canonical host",
+    (attackerPath, expectedLocation) => {
+      // A protocol-relative pathname resolved against the canonical URL keeps
+      // only the scheme, so the reader would land on the attacker's host.
+      const response = handleNonCanonicalHost(
+        request(`https://${DEPLOYMENT_HOST}${attackerPath}`),
+        MAINNET_PRODUCTION,
+      );
+
+      const location = response?.headers.get("location");
+      expect(location).toBe(expectedLocation);
+      expect(new URL(location ?? "").host).toBe("app.sokosumi.com");
+    },
+  );
+
+  it("leaves the canonical host alone", () => {
+    expect(
+      handleNonCanonicalHost(
+        request("https://app.sokosumi.com/chat"),
+        MAINNET_PRODUCTION,
+      ),
+    ).toBeNull();
+  });
+
+  it("leaves preview deployments alone, since that host is the only one they have", () => {
+    expect(
+      handleNonCanonicalHost(
+        request(
+          "https://sokosumi-app-mainnet-git-topic.preview.sokosumi.com/chat",
+        ),
+        { vercelEnv: "preview", network: "Mainnet" },
+      ),
+    ).toBeNull();
+  });
+
+  it("leaves local development alone", () => {
+    expect(
+      handleNonCanonicalHost(request("http://localhost:3000/chat"), {
+        vercelEnv: undefined,
+        network: "Mainnet",
+      }),
+    ).toBeNull();
+  });
+
+  it.each(["app.sokosumi.com.", "APP.SOKOSUMI.COM", "app.sokosumi.com:443"])(
+    "leaves %s alone, which is the canonical host written another way",
+    (host) => {
+      // A reader who types the fully qualified form would otherwise be served
+      // the unregistering worker on what is, to them, the app.
+      expect(
+        handleNonCanonicalHost(
+          request(`https://${host}${NOTIFICATION_SERVICE_WORKER_URL}`),
+          MAINNET_PRODUCTION,
+        ),
+      ).toBeNull();
+    },
+  );
+
+  it("leaves the other network's canonical host alone", () => {
+    // Read from the set of both canonical hosts rather than this deployment's
+    // own network, so a missing or wrong NETWORK cannot answer a canonical
+    // domain with a redirect to the other network.
+    expect(
+      handleNonCanonicalHost(request("https://preprod.sokosumi.com/chat"), {
+        vercelEnv: "production",
+        network: "Mainnet",
+      }),
+    ).toBeNull();
+  });
+
+  describe("the notification service worker", () => {
+    it("is served a script rather than a page", async () => {
+      const response = handleNonCanonicalHost(
+        request(`https://${DEPLOYMENT_HOST}${NOTIFICATION_SERVICE_WORKER_URL}`),
+        MAINNET_PRODUCTION,
+      );
+
+      expect(response?.status).toBe(200);
+      expect(response?.headers.get("content-type")).toContain("javascript");
+      expect(response?.headers.get("cache-control")).toBe("no-store");
+    });
+
+    it("is not redirected, which would fail the fetch and keep the old worker", () => {
+      const response = handleNonCanonicalHost(
+        request(`https://${DEPLOYMENT_HOST}${NOTIFICATION_SERVICE_WORKER_URL}`),
+        MAINNET_PRODUCTION,
+      );
+
+      expect(response?.headers.get("location")).toBeNull();
+    });
+
+    /**
+     * The worker ships as a string, so nothing compiles it. These run its
+     * source in a sandbox standing in for the service worker global and drive
+     * the real events, the way
+     * `lib/utils/__tests__/push-service-worker-display.test.ts` drives the
+     * worker in `public/`. A substring assertion would pass over a syntax
+     * error, a wrong event name, or a missing `waitUntil`.
+     */
+    async function runStaleWorker(
+      getSubscription: () => Promise<{
+        unsubscribe: () => Promise<boolean>;
+      } | null>,
+    ) {
+      const response = handleNonCanonicalHost(
+        request(`https://${DEPLOYMENT_HOST}${NOTIFICATION_SERVICE_WORKER_URL}`),
+        MAINNET_PRODUCTION,
+      );
+      const source = await response?.text();
+
+      const listeners = new Map<string, (event: unknown) => void>();
+      const unregister = vi.fn(async () => true);
+      const skipWaiting = vi.fn();
+      const consoleError = vi.fn();
+      const self = {
+        addEventListener: (type: string, listener: (event: unknown) => void) =>
+          listeners.set(type, listener),
+        skipWaiting,
+        registration: {
+          pushManager: { getSubscription },
+          unregister,
+        },
+      };
+
+      const context = createContext({ self, console: { error: consoleError } });
+      runInContext(source ?? "", context);
+
+      listeners.get("install")?.(undefined);
+
+      let activated: Promise<unknown> = Promise.resolve();
+      listeners.get("activate")?.({
+        waitUntil: (promise: Promise<unknown>) => {
+          activated = promise;
+        },
+      });
+      await activated;
+
+      return { unregister, skipWaiting, consoleError };
+    }
+
+    it("takes over at once, drops the subscription, then unregisters", async () => {
+      const unsubscribe = vi.fn(async () => true);
+      const { unregister, skipWaiting } = await runStaleWorker(async () => ({
+        unsubscribe,
+      }));
+
+      expect(skipWaiting).toHaveBeenCalled();
+      expect(unsubscribe).toHaveBeenCalled();
+      expect(unregister).toHaveBeenCalled();
+    });
+
+    it("unregisters when this browser held no subscription", async () => {
+      const { unregister } = await runStaleWorker(async () => null);
+
+      expect(unregister).toHaveBeenCalled();
+    });
+
+    it("unregisters even when the subscription cannot be dropped", async () => {
+      const { unregister, consoleError } = await runStaleWorker(() =>
+        Promise.reject(new Error("push service unreachable")),
+      );
+
+      // A subscription left on an origin with no worker reaches nothing, so
+      // letting go of the registration still ends the stale banners.
+      expect(consoleError).toHaveBeenCalled();
+      expect(unregister).toHaveBeenCalled();
+    });
+
+    it("is still served normally on the canonical host", () => {
+      expect(
+        handleNonCanonicalHost(
+          request(`https://app.sokosumi.com${NOTIFICATION_SERVICE_WORKER_URL}`),
+          MAINNET_PRODUCTION,
+        ),
+      ).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/lib/canonical-host.ts
+++ b/apps/web/src/lib/canonical-host.ts
@@ -1,0 +1,153 @@
+import { getCanonicalWebAppHost, getCanonicalWebAppUrl } from "@sokosumi/utils";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * Keep production readers on the canonical host.
+ *
+ * A production deployment answers on two hosts: `app.sokosumi.com`, and the
+ * per-deployment URL Vercel mints for it, whose hash changes with every
+ * deploy. Both serve the same app against the same database, and Better Auth
+ * trusts both, so a reader who arrives on the deployment URL is signed in and
+ * sees nothing wrong. What they cannot see is that the browser ties a push
+ * subscription to the origin that created it. Their notifications then come
+ * from a hostname that means nothing to them, and clicking one leads back to
+ * it rather than to the app.
+ *
+ * Preview deployments are left alone. Their per-branch host is the only host
+ * they have.
+ */
+
+/**
+ * Mirrors `NOTIFICATION_SERVICE_WORKER_URL`. Spelled out rather than imported
+ * for the reason `proxy.ts` spells it out: that module pulls in zod and the
+ * notification schema, and this runs on every request. `canonical-host.test.ts`
+ * builds the path from the constant, so a rename fails there.
+ */
+const NOTIFICATION_SERVICE_WORKER_PATH = "/ably-push-sw.js";
+
+/**
+ * The worker a stale origin is served in place of the notification worker.
+ *
+ * Redirecting the reader is not enough on its own. A subscription they made on
+ * this origin outlives their last visit, and the worker holding it keeps
+ * rendering banners that lead back here. Only code running on this origin can
+ * let go of it, so this replaces the real worker and does exactly that.
+ *
+ * The browser fetches a registered worker's script again on a page load in its
+ * scope (MDN, Using Service Workers), which is what the reader's next click on
+ * one of those banners causes. Finding a different script, it installs this
+ * one, which drops the push subscription and then the registration itself.
+ *
+ * Deliberately without a `push` listener: by the time this is installed the
+ * subscription is on its way out, and a listener would only be reached by a
+ * push that raced it.
+ */
+const STALE_ORIGIN_SERVICE_WORKER = `/*
+ * This deployment URL is not the canonical host for this app. The worker that
+ * was registered here is replaced by one that unregisters itself, so push
+ * notifications stop arriving from a hostname nobody recognises.
+ */
+self.addEventListener("install", () => self.skipWaiting());
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      try {
+        const subscription =
+          await self.registration.pushManager.getSubscription();
+        await subscription?.unsubscribe();
+      } catch (error) {
+        // Unregister anyway. A subscription left behind on an origin with no
+        // worker reaches nothing.
+        console.error("Could not drop the stale push subscription", error);
+      }
+
+      await self.registration.unregister();
+    })(),
+  );
+});
+`;
+
+export interface CanonicalHostParams {
+  vercelEnv: string | undefined;
+  network: "Mainnet" | "Preprod";
+}
+
+/**
+ * Every host the app is legitimately reached on, both networks.
+ *
+ * Read as a set rather than compared against this deployment's own network, so
+ * a `NETWORK` that is missing or wrong cannot answer `app.sokosumi.com` with a
+ * redirect to the other network. Such a host never reaches the wrong
+ * deployment anyway: it is aliased to one of them.
+ */
+const CANONICAL_HOSTS = new Set([
+  getCanonicalWebAppHost("Mainnet"),
+  getCanonicalWebAppHost("Preprod"),
+]);
+
+/**
+ * The request's host, in the form `CANONICAL_HOSTS` is written in.
+ *
+ * A fully qualified name ends in a dot, and `app.sokosumi.com.` is a host the
+ * reader can type. Left as it arrives it matches nothing here, and the reader
+ * would be served the unregistering worker on what is, to them, the app.
+ */
+function normalizeHost(host: string): string {
+  return host.endsWith(".") ? host.slice(0, -1) : host;
+}
+
+/** Whether this request reached a production deployment on the wrong host. */
+function isNonCanonicalProductionHost(
+  request: NextRequest,
+  params: CanonicalHostParams,
+): boolean {
+  if (params.vercelEnv !== "production") {
+    return false;
+  }
+
+  return !CANONICAL_HOSTS.has(normalizeHost(request.nextUrl.host));
+}
+
+/**
+ * The response a non-canonical production host owes this request, or null when
+ * the host is the canonical one and the request is nobody's business here.
+ */
+export function handleNonCanonicalHost(
+  request: NextRequest,
+  params: CanonicalHostParams,
+): NextResponse | null {
+  if (!isNonCanonicalProductionHost(request, params)) {
+    return null;
+  }
+
+  const { pathname } = request.nextUrl;
+
+  if (pathname === NOTIFICATION_SERVICE_WORKER_PATH) {
+    return new NextResponse(STALE_ORIGIN_SERVICE_WORKER, {
+      status: 200,
+      headers: {
+        "content-type": "text/javascript; charset=utf-8",
+        // The browser caps a worker script at 24 hours of caching on its own.
+        // Say it outright, so the reader's next visit cannot be answered from
+        // a copy of the script this one replaces.
+        "cache-control": "no-store",
+      },
+    });
+  }
+
+  const target = new URL(getCanonicalWebAppUrl(params.network));
+  // Assigned rather than resolved against the canonical URL as a base. A
+  // pathname of `//evil.example/x` is protocol-relative, so resolving it keeps
+  // only the scheme and sends the reader to the attacker's host. The leading
+  // separators are collapsed as well, because `//evil.example/x` on our own
+  // host is still a path nothing here serves.
+  target.pathname = `/${pathname.replace(/^[/\\]+/, "")}`;
+  target.search = request.nextUrl.search;
+
+  // Temporary, so no browser caches the rule. A deployment URL stops being
+  // reachable for smoke-testing either way, which is the cost of this
+  // redirect; a cached permanent one would keep costing it after a change of
+  // mind.
+  return NextResponse.redirect(target, 307);
+}

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -45,6 +45,27 @@ describe("proxy", () => {
     );
   });
 
+  it("redirects a production deployment host before it reads the session", async () => {
+    const { NextRequest } = await import("next/server");
+    const { proxy } = await import("./proxy");
+    getEnvSecretsMock.mockReturnValue({
+      MAINTENANCE_MODE: false,
+      NETWORK: "Mainnet",
+      VERCEL_ENV: "production",
+    });
+    const request = new NextRequest(
+      "https://sokosumi-app-mainnet-od9mmtb7d.preview.sokosumi.com/chat?room=abc",
+    );
+
+    const response = await proxy(request);
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe(
+      "https://app.sokosumi.com/chat?room=abc",
+    );
+    expect(getSessionCookieMock).not.toHaveBeenCalled();
+  });
+
   it("edge-redirects anonymous / to /signin with returnUrl without running the app shell", async () => {
     const { NextRequest } = await import("next/server");
     const { proxy } = await import("./proxy");

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -4,6 +4,7 @@ import { type NextRequest, NextResponse } from "next/server";
 
 import { applyDocumentSecurityHeaders } from "@/config/document-security-headers";
 import { getEnvSecrets } from "@/config/env.secrets";
+import { handleNonCanonicalHost } from "@/lib/canonical-host";
 import {
   applyPendingOrganizationJoinCookie,
   joinTokenFromJoinPath,
@@ -61,6 +62,17 @@ export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const searchParams = request.nextUrl.search;
   const env = getEnvSecrets();
+
+  // Before anything reads the session: a production reader on a deployment
+  // host is answered about the host, not about what they asked for.
+  const nonCanonicalHostResponse = handleNonCanonicalHost(request, {
+    vercelEnv: env.VERCEL_ENV,
+    network: env.NETWORK,
+  });
+  if (nonCanonicalHostResponse) {
+    return nonCanonicalHostResponse;
+  }
+
   const betterAuthCookiePrefix = resolveBetterAuthCookiePrefix({
     network: env.NETWORK,
     vercelEnv: env.VERCEL_ENV,


### PR DESCRIPTION
A production deployment answers on more than one host: app.sokosumi.com,
the per-deployment URL whose hash changes with every deploy, and the
project and branch aliases that track whatever is promoted. All of them
serve the same app against the same database, and Better Auth trusts them
all, so a reader who lands on one of the others stays there and sees
nothing wrong.

The browser ties a push subscription to the origin that created it. Those
readers get notifications from a hostname they do not recognise, and
clicking one leads back to it rather than to the app.

The proxy answers such a request about the host, before it reads the
session. A host that is canonical for either network is left alone, so a
missing or wrong NETWORK cannot answer app.sokosumi.com with a redirect to
preprod, and a host is compared with its fully qualified trailing dot
removed. Preview deployments are left alone as a whole: their hosts belong
to a deployment nothing else is reached on.

Redirecting does not reach a reader who already subscribed elsewhere, so
the notification worker path is served a worker that drops the push
subscription and unregisters itself. The browser re-fetches a registered
worker's script on a page load in its scope, which is what a click on one
of those banners causes.

Which readers that reaches depends on whether their host still serves the
current build. sha1 of /ably-push-sw.js, fetched from four hosts:

  app.sokosumi.com                                    bd4e2e473bc3
  sokosumi-app-mainnet.preview.sokosumi.com           bd4e2e473bc3
  sokosumi-app-mainnet-git-main.preview.sokosumi.com  bd4e2e473bc3
  sokosumi-app-mainnet-od9mmtb7d.preview.sokosumi.com 59e0f407556f

The first three are byte-identical, so the two aliases track the promoted
deployment and a reader subscribed on either is repaired once this ships.
A hash host is pinned to the one deployment that minted it. The hash hosts
readers are stranded on today were minted before this code, so it is never
served there, and only the reader's own browser or Ably can let go of that
subscription. `lib/ably/use-push-preference.ts` records that the client
cannot see whether a device is still subscribed to the notifications
channel on Ably's side, and names SOK-876 as owning that gap.

The redirect target is built by assigning the path to the canonical URL,
not by resolving it against one. A pathname of `//evil.example/x` is
protocol-relative, and resolving it would keep only the scheme and carry
the reader to a host the request named.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>