### PR TITLE
fix(chat): reconcile room attention with authoritative reads

### DIFF
--- a/apps/core/src/routes/v1/chats/invitations/[id]/accept/post.test.ts
+++ b/apps/core/src/routes/v1/chats/invitations/[id]/accept/post.test.ts
@@ -63,7 +63,7 @@ const ORG_ID = "org_1";
 
 const tx = {
   user: { findUnique: userFindUniqueMock },
-  chatRoom: { findUnique: roomFindUniqueMock },
+  chatRoom: { findUnique: roomFindUniqueMock, update: vi.fn() },
   chatRoomGuestInvitation: {
     findUnique: invitationFindUniqueMock,
     updateMany: invitationUpdateManyMock,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/[userId]/delete.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/[userId]/delete.test.ts
@@ -76,7 +76,7 @@ const MEMBERSHIP_MESSAGE = {
 };
 
 const tx = {
-  chatRoom: { findFirst: roomFindFirstMock },
+  chatRoom: { findFirst: roomFindFirstMock, update: vi.fn() },
   chatRoomUserMember: {
     findUnique: userMemberFindUniqueMock,
     deleteMany: userMemberDeleteManyMock,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.test.ts
@@ -95,6 +95,7 @@ const tx = {
   chatRoom: {
     findFirst: roomFindFirstMock,
     updateMany: roomUpdateManyMock,
+    update: vi.fn(),
   },
   chatRoomUserMember: {
     count: userMemberCountMock,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/post.test.ts
@@ -85,6 +85,7 @@ const tx = {
   chatRoom: {
     findFirst: roomFindFirstMock,
     findFirstOrThrow: roomFindFirstOrThrowMock,
+    update: vi.fn(),
   },
   chatRoomUserMember: {
     findUnique: userMemberFindUniqueMock,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
@@ -20,6 +20,7 @@ const {
   roomFindFirstMock,
   roomFindManyMock,
   roomUpdateMock,
+  roomFindUniqueOrThrowMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
   memberFindManyMock,
@@ -54,6 +55,7 @@ const {
   roomFindFirstMock: vi.fn(),
   roomFindManyMock: vi.fn(),
   roomUpdateMock: vi.fn(),
+  roomFindUniqueOrThrowMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
   memberFindManyMock: vi.fn(),
@@ -125,6 +127,7 @@ const tx = {
     findFirst: roomFindFirstMock,
     findMany: roomFindManyMock,
     update: roomUpdateMock,
+    findUniqueOrThrow: roomFindUniqueOrThrowMock,
   },
   organization: {
     findUnique: organizationFindUniqueMock,
@@ -293,6 +296,7 @@ beforeEach(() => {
   organizationFindUniqueMock.mockResolvedValue({ id: ORG_ID });
   memberFindUniqueMock.mockResolvedValue({ role: "member" });
   roomFindManyMock.mockResolvedValue([]);
+  roomFindUniqueOrThrowMock.mockResolvedValue(channelRoom());
   memberFindManyMock.mockImplementation(
     async ({ where }: { where: { userId: { in: string[] } } }) =>
       where.userId.in.map((userId) => ({ userId })),
@@ -345,12 +349,43 @@ beforeEach(() => {
 });
 
 describe("PATCH /chats/rooms/{id}", () => {
+  it("returns the room timestamp after membership messages are committed", async () => {
+    const existing = channelRoom();
+    const updated = channelRoom({
+      updatedAt: new Date("2026-09-07T10:00:00Z"),
+    });
+    const finalRoom = {
+      ...updated,
+      updatedAt: new Date("2026-09-07T10:00:01Z"),
+    };
+    roomFindFirstMock.mockResolvedValueOnce(existing);
+    roomUpdateMock
+      .mockResolvedValueOnce(updated)
+      .mockResolvedValueOnce(finalRoom);
+    roomFindUniqueOrThrowMock.mockResolvedValue(finalRoom);
+    userMemberDeleteManyMock.mockResolvedValue({ count: 0 });
+    userMemberCreateManyMock.mockResolvedValue({ count: 1 });
+    readStateDeleteManyMock.mockResolvedValue({ count: 0 });
+    readStateCreateManyMock.mockResolvedValue({ count: 1 });
+
+    const response = await createApp(userAuthContext).request(`/${ROOM_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ memberUserIds: [USER_ID, OTHER_USER_ID] }),
+    });
+    expect(response.status).toBe(200);
+    expect(messageCreateMock).toHaveBeenCalledTimes(1);
+    const body = await response.json();
+    expect(body.data.updatedAt).toBe(finalRoom.updatedAt.toISOString());
+  });
+
   it("allows a non-creator member to PATCH roster-only", async () => {
     const existing = channelRoom({ createdByUserId: OTHER_USER_ID });
     const updated = channelRoom({ createdByUserId: OTHER_USER_ID });
     roomFindFirstMock.mockResolvedValueOnce(existing);
     memberFindUniqueMock.mockResolvedValue({ role: "member" });
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
     userMemberCreateManyMock.mockResolvedValue({ count: 2 });
     readStateDeleteManyMock.mockResolvedValue({ count: 0 });
@@ -429,6 +464,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     roomFindFirstMock.mockResolvedValueOnce(existing);
     memberFindUniqueMock.mockResolvedValue({ role: "admin" });
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
 
     const app = createApp(userAuthContext);
     const response = await app.request(`/${ROOM_ID}`, {
@@ -469,6 +505,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     roomFindFirstMock.mockResolvedValueOnce(existing);
     memberFindUniqueMock.mockResolvedValue({ role: "admin" });
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
 
     const app = createApp(userAuthContext);
     const response = await app.request(`/${ROOM_ID}`, {
@@ -601,6 +638,7 @@ describe("PATCH /chats/rooms/{id}", () => {
       },
     ]);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
     userMemberCreateManyMock.mockResolvedValue({ count: 2 });
     readStateDeleteManyMock.mockResolvedValue({ count: 0 });
@@ -659,6 +697,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     const updated = channelRoom();
     roomFindFirstMock.mockResolvedValueOnce(existing);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 2 });
     userMemberCreateManyMock.mockResolvedValue({ count: 1 });
     readStateDeleteManyMock.mockResolvedValue({ count: 1 });
@@ -691,6 +730,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     const updated = channelRoom();
     roomFindFirstMock.mockResolvedValueOnce(existing);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
     userMemberCreateManyMock.mockResolvedValue({ count: 2 });
     readStateDeleteManyMock.mockResolvedValue({ count: 0 });
@@ -756,6 +796,7 @@ describe("PATCH /chats/rooms/{id}", () => {
       { id: keptCoworkerId, baseURL: "https://chat.example.com" },
     ]);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     failOpenMentionsMock.mockResolvedValue(["message_1"]);
     coworkerMemberDeleteManyMock.mockResolvedValue({ count: 1 });
     coworkerMemberCreateManyMock.mockResolvedValue({ count: 1 });
@@ -970,6 +1011,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     guestInvitationCountMock.mockResolvedValue(0);
     guestInviteLinkCountMock.mockResolvedValue(0);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
 
     const app = createApp(userAuthContext);
     const response = await app.request(`/${ROOM_ID}`, {
@@ -1015,6 +1057,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     roomFindFirstMock.mockResolvedValueOnce(existing);
     memberFindUniqueMock.mockResolvedValue({ role: "member" });
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
     userMemberFindManyMock.mockResolvedValue([{ userId: GUEST_ID }]);
     userMemberCreateManyMock.mockResolvedValue({ count: 2 });
@@ -1105,6 +1148,7 @@ describe("PATCH /chats/rooms/{id}", () => {
       },
     ]);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
     userMemberFindManyMock.mockResolvedValue([{ userId: GUEST_ID }]);
     userMemberCreateManyMock.mockResolvedValue({ count: 1 });
@@ -1210,6 +1254,7 @@ describe("PATCH /chats/rooms/{id}", () => {
       },
     ]);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
     userMemberFindManyMock.mockResolvedValue([{ userId: GUEST_ID }]);
     userMemberCreateManyMock.mockResolvedValue({ count: 1 });
@@ -1250,6 +1295,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     });
     roomFindFirstMock.mockResolvedValueOnce(existing);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
     userMemberUpdateManyMock.mockResolvedValue({ count: 1 });
     userMemberFindManyMock.mockResolvedValue([{ userId: GUEST_ID }]);
@@ -1304,6 +1350,7 @@ describe("PATCH /chats/rooms/{id}", () => {
       },
     ]);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     sokoBotMemberDeleteManyMock.mockResolvedValue({ count: 0 });
     sokoBotMemberCreateManyMock.mockResolvedValue({ count: 1 });
 
@@ -1375,6 +1422,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     const updated = channelRoom({ sokoBotMembers: [] });
     roomFindFirstMock.mockResolvedValueOnce(existing);
     roomUpdateMock.mockResolvedValueOnce(updated);
+    roomFindUniqueOrThrowMock.mockResolvedValue(updated);
     failOpenMentionsMock.mockResolvedValue(["message_1"]);
     sokoBotMemberDeleteManyMock.mockResolvedValue({ count: 1 });
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
@@ -512,16 +512,18 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             sokoBots: nextSokoBots,
           },
         });
-        const createdStatus = await recordChannelMembershipStatus(tx, {
-          roomId: existing.id,
-          roomKind: existing.kind,
-          changes,
-        });
-
         const room = await tx.chatRoom.update({
           where: { id: existing.id },
           data: updateData,
           include: chatRoomInclude,
+        });
+
+        // After the settings update: the helper's own updatedAt bump must be
+        // the last write, so the room row reflects the membership messages.
+        const createdStatus = await recordChannelMembershipStatus(tx, {
+          roomId: existing.id,
+          roomKind: existing.kind,
+          changes,
         });
 
         const removedUserIds = changes

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
@@ -534,7 +534,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           .map((change) => change.subject.id);
 
         return {
-          room,
+          room:
+            createdStatus.length > 0
+              ? await tx.chatRoom.findUniqueOrThrow({
+                  where: { id: room.id },
+                  include: chatRoomInclude,
+                })
+              : room,
           statusMessages: createdStatus,
           removedUserIds,
           mentionMessageIds,

--- a/apps/core/src/routes/v1/chats/rooms/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.test.ts
@@ -208,6 +208,24 @@ beforeEach(() => {
 });
 
 describe("GET /chats/rooms", () => {
+  it("returns the stored room timestamp when the latest message is older", async () => {
+    const room = guestRoomRow();
+    roomFindManyMock.mockResolvedValue([room]);
+    roomCountMock.mockResolvedValue(1);
+    messageGroupByMock.mockResolvedValue([
+      { roomId: room.id, _max: { createdAt: room.createdAt } },
+    ]);
+    queryRawUnsafeMock.mockResolvedValue([{ roomId: room.id, unreadCount: 1 }]);
+
+    const response = await createApp(ORG_ID).request("/");
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data[0]).toMatchObject({
+      updatedAt: room.updatedAt.toISOString(),
+      unreadCount: 1,
+    });
+  });
+
   it("lists rooms without opening an interactive transaction", async () => {
     const response = await createApp(ORG_ID).request("/");
 

--- a/apps/core/src/routes/v1/chats/rooms/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.ts
@@ -26,7 +26,6 @@ import { cursorPaginationQuerySchema } from "@/schemas/pagination.schema";
 
 import {
   chatRoomInclude,
-  getChatRoomLastMessageAts,
   getChatRoomPinnedMessageCounts,
   getChatRoomSidebarFlags,
   getChatRoomUnreadCounts,
@@ -211,7 +210,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const [
       unreadCounts,
       unreadMentionCounts,
-      lastMessageAts,
       sidebarFlags,
       pinnedMessageCounts,
       peerInActiveOrganizationFlags,
@@ -219,7 +217,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     ] = await Promise.all([
       getChatRoomUnreadCounts(roomIds, userId, prisma),
       getChatRoomUnreadMentionCounts(roomIds, userId, prisma),
-      getChatRoomLastMessageAts(roomIds, prisma),
       getChatRoomSidebarFlags(roomIds, userId, prisma),
       getChatRoomPinnedMessageCounts(roomIds, prisma),
       getPeerInActiveOrganizationFlags(rooms, userId, organizationId, prisma),
@@ -234,9 +231,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       organizations.map((org) => [org.id, org.name]),
     );
 
-    // Keep DB cursor order (`updatedAt` desc). Stream/message writes bump
-    // room.updatedAt; do not re-sort by lastMessageAts after `take` — that
-    // breaks cursor paging when membership exceeds one page.
+    // Message writes advance the stored timestamp used by both pagination
+    // and room read responses.
     const paginationMeta = createPaginationMeta(
       rooms,
       count,
@@ -253,7 +249,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           return mapChatRoom(room, userId, {
             unreadCount: unreadCounts.get(room.id) ?? 0,
             unreadMentionCount: unreadMentionCounts.get(room.id) ?? 0,
-            lastActivityAt: lastMessageAts.get(room.id) ?? room.updatedAt,
             starredAt: flags?.starredAt ?? null,
             pinnedMessageCount: pinnedMessageCounts.get(room.id) ?? 0,
             mutedAt: flags?.mutedAt ?? null,

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -748,36 +748,9 @@ export async function getChatRoomUnreadMentionCounts(
   );
 }
 
-/** Latest message time per room — used to order the sidebar by real activity. */
-export async function getChatRoomLastMessageAts(
-  roomIds: readonly string[],
-  tx: Prisma.TransactionClient,
-): Promise<Map<string, Date>> {
-  const uniqueRoomIds = normalizeUniqueStrings(roomIds);
-  if (uniqueRoomIds.length === 0) {
-    return new Map();
-  }
-
-  const groups = await tx.chatRoomMessage.groupBy({
-    by: ["roomId"],
-    where: { roomId: { in: uniqueRoomIds } },
-    _max: { createdAt: true },
-  });
-
-  return new Map(
-    groups.flatMap((group) =>
-      group._max.createdAt
-        ? ([[group.roomId, group._max.createdAt]] as const)
-        : [],
-    ),
-  );
-}
-
 export interface MapChatRoomAttentionOptions {
   unreadCount?: number;
   unreadMentionCount?: number;
-  /** Prefer latest message time when room.updatedAt lagged (legacy stream writes). */
-  lastActivityAt?: Date | null;
   starredAt?: Date | null;
   pinnedMessageCount?: number;
   mutedAt?: Date | null;
@@ -815,7 +788,6 @@ export function mapChatRoom(
   const {
     unreadCount = 0,
     unreadMentionCount = 0,
-    lastActivityAt,
     starredAt = null,
     pinnedMessageCount = 0,
     mutedAt = null,
@@ -840,7 +812,7 @@ export function mapChatRoom(
     ),
     createdByUserId: room.createdByUserId,
     createdAt: room.createdAt,
-    updatedAt: lastActivityAt ?? room.updatedAt,
+    updatedAt: room.updatedAt,
     unreadCount,
     unreadMentionCount,
     starredAt,
@@ -1067,7 +1039,6 @@ export async function mapChatRoomWithSidebarFlags(
   attention: {
     unreadCount?: number;
     unreadMentionCount?: number;
-    lastActivityAt?: Date | null;
     activeOrganizationId?: string | null;
   } = {},
 ) {
@@ -1087,7 +1058,6 @@ export async function mapChatRoomWithSidebarFlags(
   return mapChatRoom(room, userId, {
     unreadCount: attention.unreadCount ?? 0,
     unreadMentionCount: attention.unreadMentionCount ?? 0,
-    lastActivityAt: attention.lastActivityAt,
     starredAt: flags?.starredAt ?? null,
     pinnedMessageCount: pinnedMessageCounts.get(room.id) ?? 0,
     mutedAt: flags?.mutedAt ?? null,

--- a/apps/core/src/routes/v1/chats/rooms/membership-status.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/membership-status.test.ts
@@ -8,10 +8,14 @@ import {
 } from "./membership-status";
 
 const messageCreateMock = vi.fn();
+const roomUpdateMock = vi.fn();
 
 const tx = {
   chatRoomMessage: {
     create: messageCreateMock,
+  },
+  chatRoom: {
+    update: roomUpdateMock,
   },
 };
 
@@ -151,6 +155,31 @@ describe("recordChannelMembershipStatus", () => {
     expect(created).toHaveLength(2);
   });
 
+  it("bumps the room updatedAt once with the messages", async () => {
+    await recordChannelMembershipStatus(tx as never, {
+      roomId: "550e8400-e29b-41d4-a716-446655440000",
+      roomKind: "channel",
+      changes: [
+        {
+          action: "joined",
+          subject: { type: "user", id: "user_ada", name: "Ada" },
+        },
+        {
+          action: "left",
+          subject: { type: "coworker", id: "cow_1", name: "Bot" },
+        },
+      ],
+    });
+
+    // Membership messages count toward unreadCount; the sidebar read overlay
+    // only drops when the room row's updatedAt moves past its snapshot.
+    expect(roomUpdateMock).toHaveBeenCalledTimes(1);
+    expect(roomUpdateMock).toHaveBeenCalledWith({
+      where: { id: "550e8400-e29b-41d4-a716-446655440000" },
+      data: { updatedAt: expect.any(Date) },
+    });
+  });
+
   it("no-ops for directs and empty changes", async () => {
     expect(
       await recordChannelMembershipStatus(tx as never, {
@@ -172,6 +201,7 @@ describe("recordChannelMembershipStatus", () => {
       }),
     ).toEqual([]);
     expect(messageCreateMock).not.toHaveBeenCalled();
+    expect(roomUpdateMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/core/src/routes/v1/chats/rooms/membership-status.ts
+++ b/apps/core/src/routes/v1/chats/rooms/membership-status.ts
@@ -144,6 +144,11 @@ function membershipMetadata(
 /**
  * Persist one ChatRoomMessage per channel membership change in `tx`.
  * No-ops for non-channels and empty change lists. Callers publish after commit.
+ *
+ * Bumps the room's `updatedAt` with the messages: these rows count toward
+ * `unreadCount`, and the web read overlay drops only when the room row's
+ * `updatedAt` moves past the mark-read snapshot. Without the bump the sidebar
+ * repaints the room read and its unread never bolds.
  */
 export async function recordChannelMembershipStatus(
   tx: Prisma.TransactionClient,
@@ -167,6 +172,10 @@ export async function recordChannelMembershipStatus(
     });
     messages.push(message);
   }
+  await tx.chatRoom.update({
+    where: { id: args.roomId },
+    data: { updatedAt: new Date() },
+  });
   return messages;
 }
 

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
@@ -20,6 +20,7 @@ const {
   createCoworkerConversationMock,
   getSokosumiProviderMock,
   transactionUpdateManyMock,
+  transactionRoomUpdateMock,
   coworkerMemberFindUniqueMock,
   workspaceFindUniqueMock,
   coworkerFindFirstMock,
@@ -39,6 +40,7 @@ const {
   createCoworkerConversationMock: vi.fn(),
   getSokosumiProviderMock: vi.fn(),
   transactionUpdateManyMock: vi.fn(),
+  transactionRoomUpdateMock: vi.fn(),
   coworkerMemberFindUniqueMock: vi.fn(),
   workspaceFindUniqueMock: vi.fn(),
   coworkerFindFirstMock: vi.fn(),
@@ -86,7 +88,7 @@ vi.mock("@/lib/db/prisma", () => ({
           update: updateMock,
         },
         chatRoomCoworkerMember: { findUnique: coworkerMemberFindUniqueMock },
-        chatRoom: { update: vi.fn() },
+        chatRoom: { update: transactionRoomUpdateMock },
       }),
     ),
   },
@@ -855,6 +857,14 @@ describe("dispatchChatRoomMention claim", () => {
     expect(updateMock).toHaveBeenCalledWith({
       where: { id: MENTION_ID },
       data: { responseMessageId: "reply_1" },
+    });
+    // The placeholder counts toward unreadCount, so the room updatedAt must
+    // move with it or the sidebar read overlay keeps the room painted read.
+    // Two bumps: one with the placeholder create, one with the finalize.
+    expect(transactionRoomUpdateMock).toHaveBeenCalledTimes(2);
+    expect(transactionRoomUpdateMock).toHaveBeenCalledWith({
+      where: { id: "room_1" },
+      data: { updatedAt: expect.any(Date) },
     });
     expect(updateMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -207,6 +207,12 @@ async function publishMentionThoughtPlaceholder(params: {
       where: { id: params.mentionId },
       data: { responseMessageId: row.id },
     });
+    // The placeholder already counts toward unreadCount; without the bump the
+    // web read overlay keeps the room painted read until the final reply lands.
+    await tx.chatRoom.update({
+      where: { id: params.roomId },
+      data: { updatedAt: new Date() },
+    });
     return row;
   });
   try {

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
@@ -200,6 +200,41 @@ describe("authoritative tab attention", () => {
     listRoomsMock.mockReset();
   });
 
+  it("applies successful polls that take longer than the polling interval", async () => {
+    vi.useFakeTimers();
+    const responseDelayMs = 16_000;
+    listRoomsMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                value: {
+                  rooms: [room({ id: "slow-room", unreadCount: 4 })],
+                  nextCursor: null,
+                },
+              }),
+            responseDelayMs,
+          );
+        }),
+    );
+    const { unmount } = render(<Harness />);
+    try {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(listRoomsMock).toHaveBeenCalledTimes(5);
+      expect(screen.getByTestId("presence")).toHaveAttribute(
+        "data-show",
+        "yes",
+      );
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
+  });
+
   it("shows remote Mark unread at the same timestamp despite a local read snapshot", async () => {
     const readRoom = room({ id: "a" });
     rememberRoomRead(readRoom);

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
@@ -19,8 +19,10 @@ import {
 } from "@/components/chat/membership-visible-rooms-store";
 import { listOrganizationChatRoomsAction } from "@/components/chat/organization-chat-list.actions";
 import {
+  beginRoomAttentionChange,
   clearRoomReadOverlays,
   rememberRoomRead,
+  settleRoomAttentionChange,
 } from "@/components/chat/room-read-overlay";
 
 import { useChatTabUnreadPresence } from "./use-chat-tab-unread-presence";
@@ -186,6 +188,100 @@ describe("useChatTabUnreadPresence", () => {
       );
     });
 
+    expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "no");
+  });
+});
+
+describe("authoritative tab attention", () => {
+  beforeEach(() => {
+    mockPathname = "/chat";
+    clearRoomReadOverlays();
+    clearMembershipVisibleRoomsSnapshot();
+    listRoomsMock.mockReset();
+  });
+
+  it("shows remote Mark unread at the same timestamp despite a local read snapshot", async () => {
+    const readRoom = room({ id: "a" });
+    rememberRoomRead(readRoom);
+    listRoomsMock.mockResolvedValue({
+      ok: true,
+      value: { rooms: [{ ...readRoom, markedUnread: true }], nextCursor: null },
+    });
+    render(<Harness />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("presence")).toHaveAttribute(
+        "data-show",
+        "yes",
+      ),
+    );
+  });
+
+  it("clears the dot after remote Thread Look without changing room activity", async () => {
+    const unread = room({ id: "a", unreadCount: 2 });
+    rememberRoomRead(unread);
+    publishMembershipVisibleRooms([unread], "org-1", "user-1");
+    listRoomsMock.mockResolvedValue({
+      ok: true,
+      value: { rooms: [{ ...unread, unreadCount: 0 }], nextCursor: null },
+    });
+    render(<Harness />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "no"),
+    );
+  });
+
+  it("does not let an earlier refresh clear a newer unread dot", async () => {
+    const older =
+      Promise.withResolvers<
+        Awaited<ReturnType<typeof listOrganizationChatRoomsAction>>
+      >();
+    const newer =
+      Promise.withResolvers<
+        Awaited<ReturnType<typeof listOrganizationChatRoomsAction>>
+      >();
+    listRoomsMock
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+    render(<Harness />);
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await act(async () =>
+      newer.resolve({
+        ok: true,
+        value: { rooms: [room({ id: "a", unreadCount: 1 })], nextCursor: null },
+      }),
+    );
+    expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "yes");
+    await act(async () =>
+      older.resolve({
+        ok: true,
+        value: { rooms: [room({ id: "a" })], nextCursor: null },
+      }),
+    );
+    expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "yes");
+  });
+
+  it("protects a local read completed during a tab refresh", async () => {
+    const response =
+      Promise.withResolvers<
+        Awaited<ReturnType<typeof listOrganizationChatRoomsAction>>
+      >();
+    listRoomsMock.mockReturnValue(response.promise);
+    render(<Harness />);
+    const readRoom = room({ id: "a" });
+    const token = beginRoomAttentionChange(readRoom);
+    settleRoomAttentionChange(readRoom.id, token, readRoom);
+
+    await act(async () =>
+      response.resolve({
+        ok: true,
+        value: { rooms: [{ ...readRoom, unreadCount: 1 }], nextCursor: null },
+      }),
+    );
     expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "no");
   });
 });

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getActiveRoomIdFromPathname } from "@/components/chat/active-room-id";
 import { countChatRoomsWithUnreadAttention } from "@/components/chat/chat-unread-document-title";
 import { getLatestMembershipVisibleRoomsSnapshot } from "@/components/chat/membership-visible-rooms-store";
@@ -12,6 +12,8 @@ import {
 import { listOrganizationChatRoomsAction } from "@/components/chat/organization-chat-list.actions";
 import {
   applyRoomReadOverlays,
+  beginRoomAttentionRefresh,
+  reconcileRoomAttention,
   rememberRoomRead,
 } from "@/components/chat/room-read-overlay";
 import type { ChatRoom } from "@/lib/clients/generated/core";
@@ -32,6 +34,7 @@ interface UseChatTabUnreadPresenceResult {
 
 export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
   const pathname = usePathname();
+  const latestRefreshRef = useRef(0);
   const activeRoomId = getActiveRoomIdFromPathname(pathname);
   const [rooms, setRooms] = useState<ChatRoom[]>(
     getInitialRoomsFromSessionSnapshot,
@@ -44,11 +47,17 @@ export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
     let cancelled = false;
 
     const refreshRooms = async () => {
+      const requestRevision = beginRoomAttentionRefresh();
+      latestRefreshRef.current = requestRevision;
       const result = await listOrganizationChatRoomsAction();
-      if (cancelled || !result.ok) {
+      if (
+        cancelled ||
+        requestRevision !== latestRefreshRef.current ||
+        !result.ok
+      ) {
         return;
       }
-      setRooms(applyRoomReadOverlays(result.value.rooms));
+      setRooms(reconcileRoomAttention(result.value.rooms, requestRevision));
     };
 
     void refreshRooms();
@@ -81,16 +90,17 @@ export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
 
       setRooms((current) =>
         applyRoomReadOverlays(
-          current.map((room) =>
-            room.id === detail.roomId
-              ? (detail.room ?? {
-                  ...room,
-                  unreadCount: 0,
-                  unreadMentionCount: 0,
-                  markedUnread: false,
-                })
-              : room,
-          ),
+          current.map((room) => {
+            if (room.id !== detail.roomId) return room;
+            const updated = detail.room ?? {
+              ...room,
+              unreadCount: 0,
+              unreadMentionCount: 0,
+              markedUnread: false,
+            };
+            if (!detail.room) rememberRoomRead(updated);
+            return updated;
+          }),
         ),
       );
     };
@@ -126,11 +136,17 @@ export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
         return;
       }
 
+      const requestRevision = beginRoomAttentionRefresh();
+      latestRefreshRef.current = requestRevision;
       void listOrganizationChatRoomsAction().then((result) => {
-        if (cancelled || !result.ok) {
+        if (
+          cancelled ||
+          requestRevision !== latestRefreshRef.current ||
+          !result.ok
+        ) {
           return;
         }
-        setRooms(applyRoomReadOverlays(result.value.rooms));
+        setRooms(reconcileRoomAttention(result.value.rooms, requestRevision));
       });
     };
 

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
@@ -34,7 +34,7 @@ interface UseChatTabUnreadPresenceResult {
 
 export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
   const pathname = usePathname();
-  const latestRefreshRef = useRef(0);
+  const latestAppliedRefreshRef = useRef(0);
   const activeRoomId = getActiveRoomIdFromPathname(pathname);
   const [rooms, setRooms] = useState<ChatRoom[]>(
     getInitialRoomsFromSessionSnapshot,
@@ -48,15 +48,15 @@ export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
 
     const refreshRooms = async () => {
       const requestRevision = beginRoomAttentionRefresh();
-      latestRefreshRef.current = requestRevision;
       const result = await listOrganizationChatRoomsAction();
       if (
         cancelled ||
-        requestRevision !== latestRefreshRef.current ||
+        requestRevision < latestAppliedRefreshRef.current ||
         !result.ok
       ) {
         return;
       }
+      latestAppliedRefreshRef.current = requestRevision;
       setRooms(reconcileRoomAttention(result.value.rooms, requestRevision));
     };
 
@@ -137,15 +137,15 @@ export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
       }
 
       const requestRevision = beginRoomAttentionRefresh();
-      latestRefreshRef.current = requestRevision;
       void listOrganizationChatRoomsAction().then((result) => {
         if (
           cancelled ||
-          requestRevision !== latestRefreshRef.current ||
+          requestRevision < latestAppliedRefreshRef.current ||
           !result.ok
         ) {
           return;
         }
+        latestAppliedRefreshRef.current = requestRevision;
         setRooms(reconcileRoomAttention(result.value.rooms, requestRevision));
       });
     };

--- a/apps/web/src/components/chat/chat-room-sidebar-row.test.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   cloneElement,
@@ -264,6 +264,16 @@ vi.mock("@/components/ui/alert-dialog", () => {
 
 import { toast } from "sonner";
 import { ChatRoomSidebarRow } from "./chat-room-sidebar-row";
+import { markOrganizationChatRoomUnreadAction } from "./organization-chat-list.actions";
+import {
+  applyRoomReadOverlays,
+  beginRoomAttentionChange,
+  beginRoomAttentionRefresh,
+  clearRoomReadOverlays,
+  reconcileRoomAttention,
+  rememberRoomRead,
+  settleRoomAttentionChange,
+} from "./room-read-overlay";
 
 function makeUser(id: string, access: "member" | "guest" = "member") {
   return {
@@ -447,4 +457,106 @@ describe("ChatRoomSidebarRow leave menu", () => {
     expect(replaceMock).toHaveBeenCalledWith(CHAT_CHATS_LIST_PATH);
     expect(refreshMock).toHaveBeenCalled();
   });
+});
+
+describe("ChatRoomSidebarRow Mark unread", () => {
+  beforeEach(() => {
+    clearRoomReadOverlays();
+    vi.clearAllMocks();
+  });
+
+  it("supersedes a pending read and protects Mark unread while its action runs", async () => {
+    const original = makeRoom();
+    const oldRead = beginRoomAttentionChange(original);
+    const response =
+      Promise.withResolvers<
+        Awaited<ReturnType<typeof markOrganizationChatRoomUnreadAction>>
+      >();
+    vi.mocked(markOrganizationChatRoomUnreadAction).mockReturnValue(
+      response.promise,
+    );
+    const onRoomUpdated = vi.fn(rememberRoomRead);
+    render(
+      <ChatRoomSidebarRow
+        room={original}
+        href="/chat/rooms/room-1"
+        label="general"
+        isActive={false}
+        leading={<span>#</span>}
+        onRoomUpdated={onRoomUpdated}
+      />,
+    );
+    const user = await openRoomMenu();
+    await user.click(screen.getByRole("menuitem", { name: "Mark as unread" }));
+
+    expect(settleRoomAttentionChange(original.id, oldRead, original)).toBe(
+      false,
+    );
+    expect(
+      reconcileRoomAttention([original], beginRoomAttentionRefresh())[0]
+        ?.markedUnread,
+    ).toBe(true);
+    await act(async () =>
+      response.resolve({
+        ok: true,
+        value: { ...original, markedUnread: true },
+      }),
+    );
+    expect(applyRoomReadOverlays([original])[0]?.markedUnread).toBe(true);
+  });
+
+  it.each(["failed result", "rejected request"])(
+    "restores attention after a %s",
+    async (failure) => {
+      const original = makeRoom();
+      const response =
+        Promise.withResolvers<
+          Awaited<ReturnType<typeof markOrganizationChatRoomUnreadAction>>
+        >();
+      vi.mocked(markOrganizationChatRoomUnreadAction).mockReturnValue(
+        response.promise,
+      );
+      const onRoomUpdated = vi.fn(rememberRoomRead);
+      render(
+        <ChatRoomSidebarRow
+          room={original}
+          href="/chat/rooms/room-1"
+          label="general"
+          isActive={false}
+          leading={<span>#</span>}
+          onRoomUpdated={onRoomUpdated}
+        />,
+      );
+      const user = await openRoomMenu();
+      await user.click(
+        screen.getByRole("menuitem", { name: "Mark as unread" }),
+      );
+      const staleRequest = beginRoomAttentionRefresh();
+      await act(async () => {
+        if (failure === "failed result") {
+          response.resolve({
+            ok: false,
+            error: { code: "INTERNAL_SERVER_ERROR", message: "fail" },
+          });
+        } else {
+          response.reject(new Error("network unavailable"));
+        }
+      });
+
+      expect(onRoomUpdated).toHaveBeenLastCalledWith(original);
+      expect(
+        applyRoomReadOverlays([{ ...original, markedUnread: true }])[0]
+          ?.markedUnread,
+      ).toBe(false);
+      expect(
+        reconcileRoomAttention(
+          [{ ...original, markedUnread: true }],
+          staleRequest,
+        )[0]?.markedUnread,
+      ).toBe(false);
+      expect(toast.error).toHaveBeenCalledWith(
+        "Could not update this chat. Try again.",
+      );
+    },
+  );
 });

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -28,6 +28,10 @@ import {
 } from "@/components/chat/organization-chat-list.actions";
 import { resolveRoomAttention } from "@/components/chat/room-attention";
 import {
+  beginRoomAttentionChange,
+  settleRoomAttentionChange,
+} from "@/components/chat/room-read-overlay";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -126,17 +130,36 @@ export function ChatRoomSidebarRow({
     ) => Promise<OrganizationChatListActionResult<ChatRoom>>,
     optimisticRoom?: ChatRoom,
   ) {
+    const attentionToken =
+      action === markOrganizationChatRoomUnreadAction && optimisticRoom
+        ? beginRoomAttentionChange(optimisticRoom)
+        : null;
     if (optimisticRoom) {
       onRoomUpdated(optimisticRoom);
     }
-    startTransition(async () => {
-      const result = await action(room.id);
-      if (!result.ok) {
-        onRoomUpdated(room);
-        toast.error(tActions("actionFailed"));
-        return;
+
+    function applyResult(updatedRoom: ChatRoom): boolean {
+      if (
+        attentionToken !== null &&
+        !settleRoomAttentionChange(room.id, attentionToken, updatedRoom)
+      ) {
+        return false;
       }
-      onRoomUpdated(result.value);
+      onRoomUpdated(updatedRoom);
+      return true;
+    }
+
+    startTransition(async () => {
+      try {
+        const result = await action(room.id);
+        if (!result.ok) {
+          if (applyResult(room)) toast.error(tActions("actionFailed"));
+          return;
+        }
+        applyResult(result.value);
+      } catch {
+        if (applyResult(room)) toast.error(tActions("actionFailed"));
+      }
     });
   }
 

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -55,6 +55,7 @@ import { countChatRoomsWithUnreadAttention } from "./chat-unread-document-title"
 import { DirectRoomAvatarStack } from "./direct-room-avatar-stack";
 import { listOrganizationChatRoomsAction } from "./organization-chat-list.actions";
 import { partitionRoomsForSidebar } from "./partition-rooms-for-sidebar";
+import { beginRoomAttentionRefresh } from "./room-read-overlay";
 import { useOrganizationChatRooms } from "./use-organization-chat-rooms";
 
 /** Stable empty default — inline `= []` is a new array every render and
@@ -200,13 +201,14 @@ export function OrganizationChatList({
       toast.success(tExternal("acceptSuccess", { name: invitation.roomName }));
       // Drop pending and upsert rooms in the same tick so External does not
       // unmount between the last invite and the joined guest room.
+      const requestRevision = beginRoomAttentionRefresh();
       const roomsResult = await listOrganizationChatRoomsAction();
       setRespondingInvitation(null);
       setPendingRows((current) =>
         current.filter((row) => row.id !== invitation.id),
       );
       if (roomsResult.ok) {
-        replaceAllRooms(roomsResult.value.rooms);
+        replaceAllRooms(roomsResult.value.rooms, requestRevision);
       }
       router.push(`/chat/rooms/${invitation.roomId}`);
       router.refresh();

--- a/apps/web/src/components/chat/room-read-overlay.test.ts
+++ b/apps/web/src/components/chat/room-read-overlay.test.ts
@@ -2,9 +2,13 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   applyRoomReadOverlays,
+  beginRoomAttentionChange,
+  beginRoomAttentionRefresh,
   clearRoomReadOverlays,
   forgetRoomRead,
+  reconcileRoomAttention,
   rememberRoomRead,
+  settleRoomAttentionChange,
 } from "./room-read-overlay";
 
 function room(overrides: {
@@ -244,6 +248,86 @@ describe("room-read-overlay", () => {
     expect(remounted[0]).toMatchObject({
       unreadCount: 4,
       unreadMentionCount: 1,
+    });
+  });
+});
+
+describe("authoritative room attention", () => {
+  it("accepts Mark unread and Thread Look without new room activity", () => {
+    rememberRoomRead(room({ unreadCount: 2 }));
+    const request = beginRoomAttentionRefresh();
+    const fresh = room({ unreadCount: 0, markedUnread: true });
+
+    expect(reconcileRoomAttention([fresh], request)).toEqual([fresh]);
+    expect(applyRoomReadOverlays([room({ unreadCount: 5 })])[0]).toMatchObject({
+      unreadCount: 0,
+      markedUnread: true,
+    });
+  });
+
+  it("keeps a pending read when a fetch starts after the optimistic clear", () => {
+    const token = beginRoomAttentionChange(room({ unreadCount: 0 }));
+    const request = beginRoomAttentionRefresh();
+    // A second listener sees the same optimistic event.
+    rememberRoomRead(room({ unreadCount: 0 }));
+
+    expect(
+      reconcileRoomAttention([room({ unreadCount: 5 })], request)[0],
+    ).toMatchObject({ unreadCount: 0 });
+    expect(
+      settleRoomAttentionChange("room-1", token, room({ unreadCount: 2 })),
+    ).toBe(true);
+    expect(applyRoomReadOverlays([room({ unreadCount: 5 })])[0]).toMatchObject({
+      unreadCount: 2,
+    });
+  });
+
+  it("protects a read that starts and settles during an older fetch", () => {
+    const request = beginRoomAttentionRefresh();
+    const token = beginRoomAttentionChange(room({}));
+    settleRoomAttentionChange("room-1", token, room({ unreadCount: 2 }));
+
+    expect(
+      reconcileRoomAttention([room({ unreadCount: 5 })], request)[0],
+    ).toMatchObject({ unreadCount: 2 });
+    const laterRequest = beginRoomAttentionRefresh();
+    expect(
+      reconcileRoomAttention([room({ unreadCount: 1 })], laterRequest)[0],
+    ).toMatchObject({ unreadCount: 1 });
+  });
+
+  it("rejects a superseded read result and permits another room's fetch", () => {
+    const oldToken = beginRoomAttentionChange(room({}));
+    const token = beginRoomAttentionChange(room({ unreadCount: 2 }));
+    expect(settleRoomAttentionChange("room-1", oldToken, room({}))).toBe(false);
+    const otherRoom = room({ id: "room-2", unreadCount: 3 });
+    expect(
+      reconcileRoomAttention([otherRoom], beginRoomAttentionRefresh()),
+    ).toEqual([otherRoom]);
+    expect(
+      settleRoomAttentionChange("room-1", token, room({ unreadCount: 2 })),
+    ).toBe(true);
+  });
+
+  it("releases failed reads so the next server response can restore unread", () => {
+    const token = beginRoomAttentionChange(room({}));
+    expect(settleRoomAttentionChange("room-1", token, null)).toBe(true);
+    const unread = room({ unreadCount: 5 });
+    expect(
+      reconcileRoomAttention([unread], beginRoomAttentionRefresh()),
+    ).toEqual([unread]);
+  });
+
+  it("keeps the latest attention when another consumer finishes an older fetch", () => {
+    const olderRequest = beginRoomAttentionRefresh();
+    const newerRequest = beginRoomAttentionRefresh();
+    reconcileRoomAttention([room({ unreadCount: 1 })], newerRequest);
+
+    expect(reconcileRoomAttention([room({})], olderRequest)[0]).toMatchObject({
+      unreadCount: 1,
+    });
+    expect(applyRoomReadOverlays([room({})])[0]).toMatchObject({
+      unreadCount: 1,
     });
   });
 });

--- a/apps/web/src/components/chat/room-read-overlay.ts
+++ b/apps/web/src/components/chat/room-read-overlay.ts
@@ -1,25 +1,11 @@
-/**
- * Session memory for rooms this client has marked read.
- *
- * Mobile Chats unmounts the list while a room is open. Remount hydrates from
- * stale RSC unread. Overlay survives unmount and is reapplied on every list
- * hydrate/poll. Stores post-read attention (including leftover Participant
- * Thread unread), not only a full clear.
- */
-
+/** Session attention snapshots protect remounts from stale server props. */
 interface RoomReadOverlay {
-  /** Room `updatedAt` at mark-read time. Newer activity invalidates the overlay. */
   updatedAtMs: number;
   unreadCount: number;
   unreadMentionCount: number;
   markedUnread: boolean;
-}
-
-const overlaysByRoomId = new Map<string, RoomReadOverlay>();
-
-function toUpdatedAtMs(updatedAt: string | Date): number {
-  const ms = new Date(updatedAt).getTime();
-  return Number.isFinite(ms) ? ms : 0;
+  revision: number;
+  pendingToken: number | null;
 }
 
 interface RoomAttentionFields {
@@ -30,13 +16,71 @@ interface RoomAttentionFields {
   markedUnread: boolean;
 }
 
-export function rememberRoomRead(room: RoomAttentionFields): void {
+const overlaysByRoomId = new Map<string, RoomReadOverlay>();
+let revision = 0;
+
+function toUpdatedAtMs(updatedAt: string | Date): number {
+  const ms = new Date(updatedAt).getTime();
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+function storeAttention(
+  room: RoomAttentionFields,
+  nextRevision: number,
+  pendingToken: number | null = null,
+): void {
   overlaysByRoomId.set(room.id, {
     updatedAtMs: toUpdatedAtMs(room.updatedAt),
     unreadCount: room.unreadCount,
     unreadMentionCount: room.unreadMentionCount,
     markedUnread: room.markedUnread,
+    revision: nextRevision,
+    pendingToken,
   });
+}
+
+function applyAttention<T extends RoomAttentionFields>(
+  room: T,
+  overlay: RoomReadOverlay,
+): T {
+  return {
+    ...room,
+    unreadCount: overlay.unreadCount,
+    unreadMentionCount: overlay.unreadMentionCount,
+    markedUnread: overlay.markedUnread,
+  };
+}
+
+/** Event listeners may repeat an optimistic snapshot without settling it. */
+export function rememberRoomRead(room: RoomAttentionFields): void {
+  storeAttention(
+    room,
+    ++revision,
+    overlaysByRoomId.get(room.id)?.pendingToken ?? null,
+  );
+}
+
+export function beginRoomAttentionChange(room: RoomAttentionFields): number {
+  const token = ++revision;
+  storeAttention(room, token, token);
+  return token;
+}
+
+/** A replaced operation cannot restore or settle a newer read. */
+export function settleRoomAttentionChange(
+  roomId: string,
+  token: number,
+  room: RoomAttentionFields | null,
+): boolean {
+  if (overlaysByRoomId.get(roomId)?.pendingToken !== token) {
+    return false;
+  }
+  if (room) {
+    storeAttention(room, ++revision);
+  } else {
+    forgetRoomRead(roomId);
+  }
+  return true;
 }
 
 export function forgetRoomRead(roomId: string): void {
@@ -47,36 +91,45 @@ export function clearRoomReadOverlays(): void {
   overlaysByRoomId.clear();
 }
 
+/** Capture before fetching, so a read started during that fetch still wins. */
+export function beginRoomAttentionRefresh(): number {
+  return ++revision;
+}
+
 /**
- * Reapply post-read attention when the incoming list is stale (same or older
- * `updatedAt`). Newer activity or an explicit forget drops the overlay. A
- * matching fully-clear row must not drop it — a later stale fetch still needs
- * the overlay.
+ * Fresh results can change attention without changing room activity, such as
+ * Mark unread or Thread Look in another tab. Keep their attention for remounts.
  */
+export function reconcileRoomAttention<T extends RoomAttentionFields>(
+  rooms: readonly T[],
+  requestRevision: number,
+): T[] {
+  return rooms.map((room) => {
+    const overlay = overlaysByRoomId.get(room.id);
+    if (
+      overlay &&
+      (overlay.pendingToken !== null || overlay.revision > requestRevision)
+    ) {
+      return applyAttention(room, overlay);
+    }
+    storeAttention(room, requestRevision);
+    return room;
+  });
+}
+
+/** Apply only to hydration and local snapshots, never authoritative fetches. */
 export function applyRoomReadOverlays<T extends RoomAttentionFields>(
   rooms: readonly T[],
 ): T[] {
-  if (overlaysByRoomId.size === 0) {
-    return rooms as T[];
-  }
-
   return rooms.map((room) => {
     const overlay = overlaysByRoomId.get(room.id);
-    if (!overlay) {
+    if (
+      !overlay ||
+      (overlay.pendingToken === null &&
+        toUpdatedAtMs(room.updatedAt) > overlay.updatedAtMs)
+    ) {
       return room;
     }
-
-    const incomingUpdatedAtMs = toUpdatedAtMs(room.updatedAt);
-    if (incomingUpdatedAtMs > overlay.updatedAtMs) {
-      overlaysByRoomId.delete(room.id);
-      return room;
-    }
-
-    return {
-      ...room,
-      unreadCount: overlay.unreadCount,
-      unreadMentionCount: overlay.unreadMentionCount,
-      markedUnread: overlay.markedUnread,
-    };
+    return applyAttention(room, overlay);
   });
 }

--- a/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   ChatRoom,
@@ -282,6 +282,32 @@ describe("authoritative sidebar refresh", () => {
   beforeEach(() => {
     resetOrganizationChatListMocks();
     clearRoomReadOverlays();
+  });
+
+  it("applies successful polls that take longer than the polling interval", async () => {
+    vi.useFakeTimers();
+    const original = channel("slow-room");
+    const responseDelayMs = 16_000;
+    listRoomsMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(
+            () => resolve(emptyListResult([{ ...original, unreadCount: 4 }])),
+            responseDelayMs,
+          );
+        }),
+    );
+    const { result, unmount } = mount({ rooms: [original] });
+    try {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(listRoomsMock).toHaveBeenCalledTimes(5);
+      expect(result.current.roomRows[0]?.unreadCount).toBe(4);
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
   });
 
   it("accepts remote Mark unread at the same timestamp and retains it on remount", async () => {

--- a/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
@@ -15,7 +15,13 @@ import {
 } from "./__tests__/organization-chat-list-harness";
 import { clearMembershipVisibleRoomsSnapshot } from "./membership-visible-rooms-store";
 import { ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT } from "./organization-chat-events";
-import { clearRoomReadOverlays, rememberRoomRead } from "./room-read-overlay";
+import {
+  beginRoomAttentionChange,
+  beginRoomAttentionRefresh,
+  clearRoomReadOverlays,
+  rememberRoomRead,
+  settleRoomAttentionChange,
+} from "./room-read-overlay";
 import { useOrganizationChatRooms } from "./use-organization-chat-rooms";
 
 const NO_ROOMS: ChatRoom[] = [];
@@ -231,7 +237,10 @@ describe("useOrganizationChatRooms", () => {
     });
 
     act(() => {
-      result.current.replaceAllRooms([channel("fresh")]);
+      result.current.replaceAllRooms(
+        [channel("fresh")],
+        beginRoomAttentionRefresh(),
+      );
     });
 
     expect(result.current.roomRows.map((row) => row.id)).toEqual(["fresh"]);
@@ -253,17 +262,121 @@ describe("useOrganizationChatRooms", () => {
     expect(result.current.roomRows[0]?.unreadCount).toBe(0);
   });
 
-  it("reapplies the read overlay when it replaces the whole list", () => {
+  it("reapplies a read that completed after a list fetch started", () => {
     const room = channel("overlaid", { unreadCount: 5 });
     const { result } = mount({ rooms: [room], paintOnly: true });
 
+    const request = beginRoomAttentionRefresh();
     rememberRoomRead({ ...room, unreadCount: 0 });
 
     act(() => {
-      result.current.replaceAllRooms([room]);
+      result.current.replaceAllRooms([room], request);
     });
 
     // A stale fetch must not paint the room unread again.
     expect(result.current.roomRows[0]?.unreadCount).toBe(0);
+  });
+});
+
+describe("authoritative sidebar refresh", () => {
+  beforeEach(() => {
+    resetOrganizationChatListMocks();
+    clearRoomReadOverlays();
+  });
+
+  it("accepts remote Mark unread at the same timestamp and retains it on remount", async () => {
+    const original = channel("room");
+    rememberRoomRead(original);
+    listRoomsMock.mockResolvedValue(
+      emptyListResult([{ ...original, markedUnread: true }]),
+    );
+    const { result, rerender } = mount({ rooms: [original] });
+
+    await waitFor(() =>
+      expect(result.current.roomRows[0]?.markedUnread).toBe(true),
+    );
+    rerender({ rooms: [{ ...original }], archivedRooms: NO_ROOMS });
+    expect(result.current.roomRows[0]?.markedUnread).toBe(true);
+  });
+
+  it("accepts a remote Thread Look count decrease without new activity", async () => {
+    const original = channel("room", { unreadCount: 2 });
+    rememberRoomRead(original);
+    listRoomsMock.mockResolvedValue(
+      emptyListResult([{ ...original, unreadCount: 0 }]),
+    );
+    const { result } = mount({ rooms: [original] });
+
+    await waitFor(() =>
+      expect(result.current.roomRows[0]?.unreadCount).toBe(0),
+    );
+  });
+
+  it("keeps a newer refresh when an earlier request finishes last", async () => {
+    const original = channel("room");
+    const older = Promise.withResolvers<ReturnType<typeof emptyListResult>>();
+    const newer = Promise.withResolvers<ReturnType<typeof emptyListResult>>();
+    listRoomsMock
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+    const { result } = mount({ rooms: [original] });
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(listRoomsMock).toHaveBeenCalledTimes(2);
+
+    await act(async () =>
+      newer.resolve(emptyListResult([{ ...original, unreadCount: 1 }])),
+    );
+    expect(result.current.roomRows[0]?.unreadCount).toBe(1);
+    await act(async () => older.resolve(emptyListResult([original])));
+    expect(result.current.roomRows[0]?.unreadCount).toBe(1);
+  });
+
+  it("keeps the joined room when an invitation refresh overtakes a pending poll", async () => {
+    const pendingPoll =
+      Promise.withResolvers<ReturnType<typeof emptyListResult>>();
+    listRoomsMock.mockReturnValue(pendingPoll.promise);
+    const { result } = mount();
+    const joined = channel("joined");
+    act(() => {
+      result.current.replaceAllRooms([joined], beginRoomAttentionRefresh());
+    });
+
+    await act(async () => pendingPoll.resolve(emptyListResult()));
+    expect(result.current.roomRows.map((room) => room.id)).toEqual(["joined"]);
+  });
+
+  it("protects a read completed while the mount fetch was in flight", async () => {
+    const original = channel("room", { unreadCount: 5 });
+    const response =
+      Promise.withResolvers<ReturnType<typeof emptyListResult>>();
+    listRoomsMock.mockReturnValue(response.promise);
+    const { result } = mount({ rooms: [original] });
+    const readRoom = { ...original, unreadCount: 2 };
+    const token = beginRoomAttentionChange(readRoom);
+    settleRoomAttentionChange(original.id, token, readRoom);
+
+    await act(async () => response.resolve(emptyListResult([original])));
+    expect(result.current.roomRows[0]?.unreadCount).toBe(2);
+  });
+
+  it("keeps pending reads across polling and accepts the next fetch after completion", async () => {
+    const original = channel("room", { unreadCount: 5 });
+    const readRoom = { ...original, unreadCount: 0 };
+    const token = beginRoomAttentionChange(readRoom);
+    listRoomsMock.mockResolvedValue(emptyListResult([original]));
+    const { result } = mount({ rooms: [original] });
+    await act(async () => undefined);
+    expect(result.current.roomRows[0]?.unreadCount).toBe(0);
+
+    settleRoomAttentionChange(original.id, token, readRoom);
+    listRoomsMock.mockResolvedValue(
+      emptyListResult([{ ...original, unreadCount: 1 }]),
+    );
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(result.current.roomRows[0]?.unreadCount).toBe(1);
   });
 });

--- a/apps/web/src/components/chat/use-organization-chat-rooms.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.ts
@@ -89,7 +89,7 @@ export function useOrganizationChatRooms({
   paintOnly,
 }: UseOrganizationChatRoomsOptions) {
   const hasOrganization = Boolean(organizationId);
-  const latestRefreshRef = useRef(0);
+  const latestAppliedRefreshRef = useRef(0);
   const [roomRows, setRoomRows] = useState(() => applyRoomReadOverlays(rooms));
   const [archivedRows, setArchivedRows] = useState(archivedRooms);
   const [pendingRows, setPendingRows] = useState(pendingInvitations);
@@ -147,8 +147,8 @@ export function useOrganizationChatRooms({
   /** Replace the whole live list with a freshly fetched one. */
   const replaceAllRooms = useCallback(
     (rooms: ChatRoom[], requestRevision: number) => {
-      if (requestRevision < latestRefreshRef.current) return;
-      latestRefreshRef.current = requestRevision;
+      if (requestRevision < latestAppliedRefreshRef.current) return;
+      latestAppliedRefreshRef.current = requestRevision;
       setRoomRows(reconcileRoomAttention(rooms, requestRevision));
     },
     [],
@@ -165,6 +165,10 @@ export function useOrganizationChatRooms({
       [activeResult, archivedResult, pendingResult]: SidebarRoomData,
       requestRevision: number,
     ) => {
+      if (requestRevision < latestAppliedRefreshRef.current) return;
+      if (activeResult.ok || archivedResult.ok || pendingResult.ok) {
+        latestAppliedRefreshRef.current = requestRevision;
+      }
       if (activeResult.ok) {
         replaceAllRooms(activeResult.value.rooms, requestRevision);
       }
@@ -187,9 +191,8 @@ export function useOrganizationChatRooms({
 
     const refreshRooms = async () => {
       const requestRevision = beginRoomAttentionRefresh();
-      latestRefreshRef.current = requestRevision;
       const data = await fetchSidebarRoomData(hasOrganization);
-      if (cancelled || requestRevision !== latestRefreshRef.current) {
+      if (cancelled || requestRevision < latestAppliedRefreshRef.current) {
         return;
       }
       applySidebarRoomData(data, requestRevision);
@@ -283,9 +286,8 @@ export function useOrganizationChatRooms({
       }
 
       const requestRevision = beginRoomAttentionRefresh();
-      latestRefreshRef.current = requestRevision;
       void fetchSidebarRoomData(hasOrganization).then((data) => {
-        if (cancelled || requestRevision !== latestRefreshRef.current) {
+        if (cancelled || requestRevision < latestAppliedRefreshRef.current) {
           return;
         }
         applySidebarRoomData(data, requestRevision);

--- a/apps/web/src/components/chat/use-organization-chat-rooms.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { listPendingChatRoomInvitationsAction } from "@/app/chat/actions";
 import type {
@@ -19,7 +19,8 @@ import {
 } from "./organization-chat-list.actions";
 import {
   applyRoomReadOverlays,
-  forgetRoomRead,
+  beginRoomAttentionRefresh,
+  reconcileRoomAttention,
   rememberRoomRead,
 } from "./room-read-overlay";
 
@@ -88,6 +89,7 @@ export function useOrganizationChatRooms({
   paintOnly,
 }: UseOrganizationChatRoomsOptions) {
   const hasOrganization = Boolean(organizationId);
+  const latestRefreshRef = useRef(0);
   const [roomRows, setRoomRows] = useState(() => applyRoomReadOverlays(rooms));
   const [archivedRows, setArchivedRows] = useState(archivedRooms);
   const [pendingRows, setPendingRows] = useState(pendingInvitations);
@@ -128,12 +130,12 @@ export function useOrganizationChatRooms({
   /**
    * Swap one room in the live list for a newer copy of itself.
    *
-   * A room the reader just marked unread drops its read overlay first, so the
-   * overlay cannot immediately paint the room read again.
+   * Mark unread retains the new attention for a later remount with stale
+   * props. The action caller owns its pending operation and rollback.
    */
   const replaceRoom = useCallback((updated: ChatRoom) => {
     if (updated.markedUnread) {
-      forgetRoomRead(updated.id);
+      rememberRoomRead(updated);
     }
     setRoomRows((current) =>
       applyRoomReadOverlays(
@@ -143,9 +145,14 @@ export function useOrganizationChatRooms({
   }, []);
 
   /** Replace the whole live list with a freshly fetched one. */
-  const replaceAllRooms = useCallback((rooms: ChatRoom[]) => {
-    setRoomRows(applyRoomReadOverlays(rooms));
-  }, []);
+  const replaceAllRooms = useCallback(
+    (rooms: ChatRoom[], requestRevision: number) => {
+      if (requestRevision < latestRefreshRef.current) return;
+      latestRefreshRef.current = requestRevision;
+      setRoomRows(reconcileRoomAttention(rooms, requestRevision));
+    },
+    [],
+  );
 
   /**
    * Write the collections one refresh returned, skipping the calls that failed.
@@ -154,9 +161,12 @@ export function useOrganizationChatRooms({
    * were, or a reader watches a section they can still see go empty.
    */
   const applySidebarRoomData = useCallback(
-    ([activeResult, archivedResult, pendingResult]: SidebarRoomData) => {
+    (
+      [activeResult, archivedResult, pendingResult]: SidebarRoomData,
+      requestRevision: number,
+    ) => {
       if (activeResult.ok) {
-        replaceAllRooms(activeResult.value.rooms);
+        replaceAllRooms(activeResult.value.rooms, requestRevision);
       }
       if (archivedResult.ok) {
         setArchivedRows(archivedResult.value.rooms);
@@ -176,15 +186,17 @@ export function useOrganizationChatRooms({
     let cancelled = false;
 
     const refreshRooms = async () => {
+      const requestRevision = beginRoomAttentionRefresh();
+      latestRefreshRef.current = requestRevision;
       const data = await fetchSidebarRoomData(hasOrganization);
-      if (cancelled) {
+      if (cancelled || requestRevision !== latestRefreshRef.current) {
         return;
       }
-      applySidebarRoomData(data);
+      applySidebarRoomData(data, requestRevision);
     };
 
     // Mobile sheet remounts the list with stale RSC props; refresh immediately
-    // so overlays can drop once Core confirms the mark-read.
+    // so Core can replace attention from earlier visits and other tabs.
     void refreshRooms();
 
     const intervalId = window.setInterval(
@@ -220,16 +232,17 @@ export function useOrganizationChatRooms({
 
       setRoomRows((current) =>
         applyRoomReadOverlays(
-          current.map((room) =>
-            room.id === detail.roomId
-              ? (detail.room ?? {
-                  ...room,
-                  unreadCount: 0,
-                  unreadMentionCount: 0,
-                  markedUnread: false,
-                })
-              : room,
-          ),
+          current.map((room) => {
+            if (room.id !== detail.roomId) return room;
+            const updated = detail.room ?? {
+              ...room,
+              unreadCount: 0,
+              unreadMentionCount: 0,
+              markedUnread: false,
+            };
+            if (!detail.room) rememberRoomRead(updated);
+            return updated;
+          }),
         ),
       );
     };
@@ -269,11 +282,13 @@ export function useOrganizationChatRooms({
         return;
       }
 
+      const requestRevision = beginRoomAttentionRefresh();
+      latestRefreshRef.current = requestRevision;
       void fetchSidebarRoomData(hasOrganization).then((data) => {
-        if (cancelled) {
+        if (cancelled || requestRevision !== latestRefreshRef.current) {
           return;
         }
-        applySidebarRoomData(data);
+        applySidebarRoomData(data, requestRevision);
       });
     };
 


### PR DESCRIPTION
VERIFIED: Fresh room lists can update unread attention without a new room timestamp. This fixes remote Mark unread and Thread Look changes. Pending local actions and newer refreshes retain priority. See `apps/web/src/components/chat/room-read-overlay.ts` and `use-organization-chat-rooms.ts`.

VERIFIED: Room list and membership PATCH responses now use the stored `room.updatedAt`. Membership status and Thought placeholder writes advance that timestamp in the same transaction. See `apps/core/src/routes/v1/chats/rooms/get.ts` and `[id]/patch.ts`.

Validation (local):
- VERIFIED: Core list, PATCH, and helper suites: `Tests 135 passed (135)`.
- VERIFIED: Reverting only the timestamp source changes kept the regression tests collected and produced `2 failed | 39 skipped (41)`.
- VERIFIED: Combined Web chat suite: `Test Files 54 passed (54)`, `Tests 385 passed (385)`.
- VERIFIED: `pnpm precommit`: `19 successful, 19 total`.

The dependent PRs cover hidden-tab reads and completed streaming responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved room activity timestamps so updates to settings and membership status are reflected consistently.
  - Improved unread and read-state handling across polling, refreshes, invitations, and multiple tabs.
  - Prevented stale refreshes from overwriting newer unread or read changes.
  - Marking a room as unread now updates immediately and restores the previous state with an error notification if the request fails.
  - Room lists now preserve unread counts when activity timestamps differ from the latest message time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->