### PR TITLE
chore(skills): add sentry-cli skill

### DIFF
--- a/.agents/skills/sentry-cli/SKILL.md
+++ b/.agents/skills/sentry-cli/SKILL.md
@@ -1,0 +1,697 @@
+---
+name: sentry-cli
+version: 0.44.1
+description: Guide for using the Sentry CLI to interact with Sentry from the command line. Use when the user asks about viewing issues, events, projects, organizations, making API calls, or authenticating with Sentry via CLI.
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Sentry CLI Usage Guide
+
+Help users interact with Sentry from the command line using the `sentry` CLI.
+
+> **Core rule for agents: just run the command.** The `sentry` CLI auto-detects your org and project (from `.sentryclirc`, DSNs in `.env`/source, and the directory name), so **do not** list organizations and then list their projects to work out which one this checkout maps to — that manual discovery only duplicates work the CLI already does on every command. Pass an explicit `<org>/<project>` only when the CLI reports it can't detect the target or picks the wrong one.
+
+## Agent Guidance
+
+Best practices and operational guidance for AI coding agents using the Sentry CLI.
+
+### Key Principles
+
+- **Just run the command** — the CLI handles authentication and org/project detection automatically. Don't pre-authenticate or look up org/project before running commands. The CLI prompts for login if needed.
+- **Prefer CLI commands over raw API calls** — the CLI has dedicated commands for most tasks. Reach for `sentry issue view`, `sentry issue list`, `sentry trace view`, etc. before constructing API calls manually or fetching external documentation.
+- **Use `sentry schema` to explore the API** — if you need to discover API endpoints, run `sentry schema` to browse interactively or `sentry schema <resource>` to search. This is faster than fetching OpenAPI specs externally.
+- **Use `sentry issue view <id>` to investigate issues** — when asked about a specific issue (e.g., `CLI-G5`, `PROJECT-123`), use `sentry issue view` directly.
+- **Use `--json` for machine-readable output** — pipe through `jq` for filtering. Human-readable output includes formatting that is hard to parse.
+- **The CLI auto-detects org/project — don't discover it yourself** — most commands work without explicit targets by checking `.sentryclirc` config files, scanning for DSNs in `.env` files and source code, and matching directory names. Do **not** run `sentry org list` and then `sentry project list` to figure out which project this checkout belongs to — that manual fan-out just replicates the detection the CLI already runs on every command. Only specify `<org>/<project>` when the CLI reports it can't detect the target or detects the wrong one.
+
+### Design Principles
+
+The `sentry` CLI follows conventions from well-known tools — if you're familiar with them, that knowledge transfers directly:
+
+- **`gh` (GitHub CLI) conventions**: The `sentry` CLI uses the same `<noun> <verb>` command pattern (e.g., `sentry issue list`, `sentry org view`). Flags follow `gh` conventions: `--json` for machine-readable output, `--fields` to select specific fields, `-w`/`--web` to open in browser, `-q`/`--query` for filtering, `-n`/`--limit` for result count.
+- **`sentry api` mimics `curl`**: The `sentry api` command provides direct API access with a `curl`-like interface — `--method` for HTTP method, `--data` for request body, `--header` for custom headers. It handles authentication automatically. If you know how to call a REST API with `curl`, the same patterns apply.
+
+### Context Window Tips
+
+- Use `--json --fields` to select specific fields and reduce output size. Run `<command> --help` to see available fields. Example: `sentry issue list --json --fields shortId,title,priority,level,status`
+- Use `--json` when piping output between commands or processing programmatically
+- Use `--limit` to cap the number of results (default is usually 10–100)
+- Prefer `sentry issue view PROJECT-123` over listing and filtering manually
+- Use `sentry api` for endpoints not covered by dedicated commands
+
+### Safety Rules
+
+- Always confirm with the user before running destructive commands: `project delete`, `trial start`
+- For mutations, verify the org/project context looks correct in the command output before proceeding with further changes
+- Never store or log authentication tokens — the CLI manages credentials automatically
+- If the CLI reports the wrong org/project, override with explicit `<org>/<project>` arguments
+
+### Exit Codes
+
+The CLI uses semantic exit codes. Key ranges for agents:
+
+| Range | Meaning | Agent Action |
+|-------|---------|-------------|
+| 0 | Success | Proceed normally |
+| 10–19 | Auth error | Prompt user to run `sentry auth login` |
+| 20–29 | Input error | Check command arguments and retry |
+| 30–39 | API error | Retry or report to user |
+| 40–49 | Feature unavailable | Inform user about plan/settings |
+| 50–59 | Operation error | Report to user |
+| 60–69 | Command-specific | Check stderr for details |
+
+See [Exit Codes](/exit-codes/) for the complete reference.
+
+### Workflow Patterns
+
+#### Investigate an Issue
+
+```bash
+# 1. Find the issue (auto-detects org/project from DSN or config)
+sentry issue list --query "is:unresolved" --limit 5
+
+# 2. Get details. For agents, prefer --json — it includes the full issue plus
+# the latest event under `event`, so you get everything in one call.
+sentry issue view PROJECT-123 --json
+
+# 3. Get AI root cause analysis
+sentry issue explain PROJECT-123
+
+# 4. Get a fix plan
+sentry issue plan PROJECT-123
+```
+
+`sentry issue view <SHORT-ID> --json` is the fastest way to get an agent up to
+speed on an issue. Select just the fields you need with `--fields` instead of
+consuming the whole payload — the latest event's `request` entry can carry live
+session data (cookies, headers, body), so extract named fields rather than
+dumping the entire object:
+
+```bash
+# Top-level issue fields
+sentry issue view PROJECT-123 --json --fields shortId,title,culprit,count,userCount,permalink
+
+# Named fields from the latest event — avoids pulling the full request/session blob
+sentry issue view PROJECT-123 --json --fields event.id,event.title,event.dateCreated
+
+# Just the request URL and method (not the whole request entry). Event data
+# lives under event.entries[], each tagged with a `type` and `data` payload.
+sentry issue view PROJECT-123 --json | jq '.event.entries[] | select(.type == "request") | .data | {url, method}'
+```
+
+#### Explore Traces and Performance
+
+```bash
+# 1. List recent traces (auto-detects org/project)
+sentry trace list --limit 5
+
+# 2. View a specific trace with span tree
+sentry trace view abc123def456...
+
+# 3. View spans for a trace
+sentry span list abc123def456...
+
+# 4. View logs associated with a trace
+sentry trace logs abc123def456...
+```
+
+#### Stream Logs
+
+```bash
+# Stream logs in real-time (auto-detects org/project)
+sentry log list --follow
+
+# Filter logs by severity
+sentry log list --query "severity:error"
+```
+
+#### Capture Events Locally (Spotlight)
+
+```bash
+# Run the app with the local server auto-enabled; tail errors/traces/logs.
+# No DSN needed — with no DSN, events go ONLY to the local server (nothing
+# reaches the user's Sentry org, no production quota). With a DSN set, the
+# SDK sends to both.
+sentry local run -- npm run dev          # or: python manage.py runserver, etc.
+
+# Watch only AI/agent (gen_ai, mcp) spans while iterating on an agent.
+sentry local -f ai
+
+# Server-side SDKs read SENTRY_SPOTLIGHT automatically. The CLI also injects
+# the URL under every framework client prefix (NEXT_PUBLIC_, VITE_, PUBLIC_,
+# NUXT_PUBLIC_, REACT_APP_, VUE_APP_, GATSBY_). Until the browser SDK reads
+# these automatically (getsentry/sentry-javascript#18198), reference the var
+# matching your framework in the client config:
+# Sentry.init({ spotlight: process.env.NEXT_PUBLIC_SENTRY_SPOTLIGHT ?? false })
+```
+
+#### Explore the API Schema
+
+```bash
+# Browse all API resource categories
+sentry schema
+
+# Search for endpoints related to a resource
+sentry schema issues
+
+# Get details about a specific endpoint
+sentry schema "GET /api/0/organizations/{organization_id_or_slug}/issues/"
+```
+
+#### Manage Releases
+
+```bash
+# Create a release — version must match Sentry.init({ release }) exactly
+sentry release create my-org/1.0.0 --project my-project
+
+# Associate commits via repository integration (needs local git checkout)
+sentry release set-commits my-org/1.0.0 --auto
+
+# Or read commits from local git history (no integration needed)
+sentry release set-commits my-org/1.0.0 --local
+
+# Mark the release as finalized
+sentry release finalize my-org/1.0.0
+
+# Record a production deploy
+sentry release deploy my-org/1.0.0 production
+```
+
+**Key details:**
+- The positional is `<org-slug>/<version>`. In `sentry release create sentry/1.0.0`, `sentry` is the org and `1.0.0` is the version — the slash separates org from version, it is not part of the version string.
+- The **version** must match the `release` value in `Sentry.init()`. If your SDK uses `"1.0.0"`, the command must use `org/1.0.0`.
+- `--auto` requires a Sentry repository integration (GitHub/GitLab/Bitbucket) **and** a local git checkout. It matches your `origin` remote against Sentry's repo list. Without a checkout, use `--local`.
+- With no flag, `set-commits` tries `--auto` first and falls back to `--local` on failure.
+
+#### Arbitrary API Access
+
+```bash
+# GET request (default)
+sentry api /api/0/organizations/my-org/
+
+# POST request with data
+sentry api /api/0/organizations/my-org/projects/ --method POST --data '{"name":"new-project","platform":"python"}'
+```
+
+### Dashboard Layout
+
+Sentry dashboards use a **6-column grid**. When adding widgets, aim to fill complete rows (widths should sum to 6).
+
+Display types with default sizes:
+
+| Display Type | Width | Height | Category | Notes |
+|---|---|---|---|---|
+| `big_number` | 2 | 1 | common | Compact KPI — place 3 per row (2+2+2=6) |
+| `line` | 3 | 2 | common | Half-width chart — place 2 per row (3+3=6) |
+| `area` | 3 | 2 | common | Half-width chart — place 2 per row |
+| `bar` | 3 | 2 | common | Half-width chart — place 2 per row |
+| `table` | 6 | 2 | common | Full-width — always takes its own row |
+| `stacked_area` | 3 | 2 | specialized | Stacked area chart |
+| `top_n` | 3 | 2 | specialized | Top N ranked list |
+| `categorical_bar` | 3 | 2 | specialized | Categorical bar chart |
+| `text` | 3 | 2 | specialized | Static text/markdown widget |
+| `details` | 3 | 2 | internal | Detail view |
+| `wheel` | 3 | 2 | internal | Pie/wheel chart |
+| `rage_and_dead_clicks` | 3 | 2 | internal | Rage/dead click visualization |
+| `server_tree` | 3 | 2 | internal | Hierarchical tree display |
+| `agents_traces_table` | 3 | 2 | internal | Agents traces table |
+
+Use **common** types for general dashboards. Use **specialized** only when specifically requested. Avoid **internal** types unless the user explicitly asks.
+
+Available datasets: `spans` (default), `errors`, `transactions`, `metrics`, `issue`, `logs`. Run `sentry dashboard widget --help` for dataset descriptions, query formats, and examples.
+
+**Row-filling examples:**
+
+```bash
+# 3 KPIs filling one row (2+2+2 = 6)
+sentry dashboard widget add <dashboard> "Error Count" --display big_number --query count
+sentry dashboard widget add <dashboard> "P95 Duration" --display big_number --query p95:span.duration
+sentry dashboard widget add <dashboard> "Throughput" --display big_number --query epm
+
+# 2 charts filling one row (3+3 = 6)
+sentry dashboard widget add <dashboard> "Errors Over Time" --display line --query count
+sentry dashboard widget add <dashboard> "Latency Over Time" --display line --query p95:span.duration
+
+# Full-width table (6 = 6)
+sentry dashboard widget add <dashboard> "Top Endpoints" --display table \
+  --query count --query p95:span.duration \
+  --group-by transaction --sort -count --limit 10
+```
+
+### Quick Reference
+
+#### Time filtering
+
+Use `--period` (alias: `-t`) to filter by time window:
+
+```bash
+sentry trace list --period 1h
+sentry span list --period 24h
+sentry span list -t 7d
+```
+
+#### Scoping to an org or project
+
+Org and project are positional arguments following `gh` CLI conventions:
+
+```bash
+sentry trace list my-org/my-project
+sentry issue list my-org/my-project
+sentry span list my-org/my-project/abc123def456...
+```
+
+#### Listing spans in a trace
+
+Pass the trace ID as a positional argument to `span list`:
+
+```bash
+sentry span list abc123def456...
+sentry span list my-org/my-project/abc123def456...
+```
+
+#### Dataset names for the Events API
+
+When querying the Events API (directly or via `sentry api`), valid dataset values are: `spans`, `logs`, `errors`, `tracemetrics`, `profile_functions`, and `uptime_results`.
+
+### Common Mistakes
+
+- **Wrong issue ID format**: Use `PROJECT-123` (short ID), not the numeric ID `123456789`. The short ID includes the project prefix.
+- **Pre-authenticating unnecessarily**: Don't run `sentry auth login` before every command. The CLI detects missing/expired auth and prompts automatically. Only run `sentry auth login` if you need to switch accounts.
+- **Missing `--json` for piping**: Human-readable output includes formatting. Use `--json` when parsing output programmatically.
+- **Specifying org/project when not needed**: Auto-detection resolves org/project from `.sentryclirc` config files, DSNs, env vars, and directory names. Let it work first — only add `<org>/<project>` if the CLI says it can't detect the target or detects the wrong one.
+- **Manually discovering the project before running a command**: Don't list the orgs you belong to, then list every project in each, to match the local checkout to a project — the CLI already does exactly this resolution internally on each command. Skip the fan-out and run the command directly; correct the target afterwards only if the output shows the wrong org/project.
+- **Confusing `--query` syntax**: The `--query` flag uses Sentry search syntax (e.g., `is:unresolved`, `assigned:me`), not free text search.
+- **Not using `--web`**: View commands support `-w`/`--web` to open the resource in the browser — useful for sharing links.
+- **Fetching API schemas instead of using the CLI**: Prefer `sentry schema` to browse the API and `sentry api` to make requests — the CLI handles authentication and endpoint resolution, so there's rarely a need to download OpenAPI specs separately.
+- **Release version mismatch**: The `org/version` positional is `<org-slug>/<version>`, where `org/` is the org, not part of the version. `sentry release create sentry/1.0.0` creates version `1.0.0` in org `sentry`. If your `Sentry.init()` uses `release: "1.0.0"`, this is correct. Don't double-prefix like `sentry/myapp/1.0.0`.
+- **Running `set-commits --auto` without a git checkout**: `--auto` needs a local git repo to discover the origin remote URL and HEAD commit. In CI, ensure `actions/checkout` with `fetch-depth: 0` runs before `set-commits --auto`.
+- **Using `sentry api` when CLI commands suffice**: `sentry issue list --json` and `sentry issue view --json` already include `shortId`, `title`, `count`, `userCount`, `priority`, `level`, `status`, `permalink`, and other fields at the top level. When using `--fields` to select specific fields like `count` or `userCount`, the CLI automatically ensures these fields are present in the API response. Use `--fields` to select specific fields and `--help` to see all available fields. Only fall back to `sentry api` for data the CLI doesn't expose.
+
+## Prerequisites
+
+The CLI must be installed and authenticated before use.
+
+### Installation
+
+```bash
+curl https://cli.sentry.dev/install -fsS | bash
+curl https://cli.sentry.dev/install -fsS | bash -s -- --version nightly
+
+# Or install via npm/pnpm/bun
+npm install -g sentry
+```
+
+### Authentication
+
+```bash
+sentry auth
+sentry auth --token YOUR_SENTRY_API_TOKEN
+sentry auth status
+sentry auth logout
+```
+
+## Command Reference
+
+### Auth
+
+Authenticate with Sentry
+
+- `sentry auth login` — Authenticate with Sentry
+- `sentry auth logout` — Log out of Sentry
+- `sentry auth refresh` — Refresh your OAuth access token
+- `sentry auth status` — View authentication status
+- `sentry auth token` — Print the stored authentication token
+- `sentry auth whoami` — Show the currently authenticated identity
+
+→ Full flags and examples: `references/auth.md`
+
+### Org
+
+Work with Sentry organizations
+
+- `sentry org list` — List organizations
+- `sentry org view <org>` — View details of an organization
+
+→ Full flags and examples: `references/org.md`
+
+### Project
+
+Work with Sentry projects
+
+- `sentry project create [<org>/]<name>:<platform>...` — Create one or more projects
+- `sentry project delete <org/project>` — Delete a project
+- `sentry project list <org/project>` — List projects
+- `sentry project view <org/project>` — View details of a project
+
+→ Full flags and examples: `references/project.md`
+
+### Issue
+
+Manage Sentry issues
+
+- `sentry issue list <org/project>` — List issues in a project
+- `sentry issue events <issue>` — List events for a specific issue
+- `sentry issue explain <issue>` — Analyze an issue's root cause using Seer AI
+- `sentry issue plan <issue>` — Generate a solution plan using Seer AI
+- `sentry issue view <issue>` — View details of a specific issue
+- `sentry issue resolve <issue>` — Mark an issue as resolved
+- `sentry issue unresolve <issue>` — Reopen a resolved issue
+- `sentry issue archive <issue>` — Archive (ignore) an issue
+- `sentry issue merge <issue...>` — Merge 2+ issues into a single canonical group
+
+→ Full flags and examples: `references/issue.md`
+
+### Event
+
+View, list, and send Sentry events
+
+- `sentry event view <org/project/event-id...>` — View details of one or more events
+- `sentry event list <issue>` — List events for an issue
+- `sentry event send <args...>` — Send a Sentry event
+
+→ Full flags and examples: `references/event.md`
+
+### API
+
+Make an authenticated API request
+
+- `sentry api <endpoint>` — Make an authenticated API request
+
+→ Full flags and examples: `references/api.md`
+
+### Alert
+
+Manage Sentry alert rules
+
+- `sentry alert issues list <org/project>` — List issue alert rules
+- `sentry alert issues view <org/project/rule-id-or-name>` — View an issue alert rule
+- `sentry alert issues create <target>` — Create an issue alert rule
+- `sentry alert issues delete <org/project/rule-id-or-name>` — Delete an issue alert rule
+- `sentry alert issues edit <org/project/rule-id-or-name>` — Edit an issue alert rule
+- `sentry alert metrics list <target>` — List metric alert rules
+- `sentry alert metrics view <org/rule-id-or-name>` — View a metric alert rule
+- `sentry alert metrics create <org>` — Create a metric alert rule
+- `sentry alert metrics delete <org/rule-id-or-name>` — Delete a metric alert rule
+- `sentry alert metrics edit <org/rule-id-or-name>` — Edit a metric alert rule
+
+→ Full flags and examples: `references/alert.md`
+
+### Build
+
+Manage mobile build artifacts
+
+- `sentry build upload <path...>` — Upload builds to a project
+- `sentry build download <build-id>` — Download a build artifact
+
+→ Full flags and examples: `references/build.md`
+
+### CLI
+
+CLI-related commands
+
+- `sentry cli completion <shell>` — Print the shell completion script
+- `sentry cli defaults <key value...>` — View and manage default settings
+- `sentry cli feedback <message...>` — Send feedback about the CLI
+- `sentry cli fix` — Diagnose and repair CLI database issues
+- `sentry cli import` — Import settings from legacy .sentryclirc files
+- `sentry cli setup` — Configure shell integration
+- `sentry cli uninstall` — Uninstall Sentry CLI
+- `sentry cli upgrade <version>` — Update the Sentry CLI to the latest version
+
+→ Full flags and examples: `references/cli.md`
+
+### Code-mappings
+
+Manage code mappings for stack trace linking
+
+- `sentry code-mappings upload <path>` — Upload code mappings for stack trace linking
+
+→ Full flags and examples: `references/code-mappings.md`
+
+### Agent-conversation
+
+List and view agent conversations
+
+- `sentry agent-conversation list <org>` — List recent agent conversations
+- `sentry agent-conversation view <org/conversation-id>` — View an agent conversation transcript
+
+→ Full flags and examples: `references/agent-conversation.md`
+
+### Dart-symbol-map
+
+Work with Dart/Flutter symbol maps
+
+- `sentry dart-symbol-map upload <path>` — Upload a Dart/Flutter symbol map to Sentry
+
+→ Full flags and examples: `references/dart-symbol-map.md`
+
+### Debug-files
+
+Work with debug information files
+
+- `sentry debug-files check <path>` — Inspect a debug information file
+- `sentry debug-files find <id...>` — Locate debug files for given debug identifiers
+- `sentry debug-files upload <path...>` — Upload debug information files to Sentry
+- `sentry debug-files print-sources <path>` — List the source files a debug file references
+- `sentry debug-files bundle-sources <path>` — Bundle a debug file's source files for source context
+- `sentry debug-files bundle-jvm <path>` — Create a JVM source bundle for source context
+
+→ Full flags and examples: `references/debug-files.md`
+
+### Dashboard
+
+Manage Sentry dashboards
+
+- `sentry dashboard list <org/title-filter...>` — List dashboards
+- `sentry dashboard view <org/project/dashboard...>` — View a dashboard
+- `sentry dashboard create <org/project/title...>` — Create a dashboard
+- `sentry dashboard widget add <org/project/dashboard/title...>` — Add a widget to a dashboard
+- `sentry dashboard widget edit <org/project/dashboard...>` — Edit a widget in a dashboard
+- `sentry dashboard widget delete <org/project/dashboard...>` — Delete a widget from a dashboard
+- `sentry dashboard revisions <org/dashboard...>` — List dashboard revisions
+- `sentry dashboard restore <org/dashboard...>` — Restore a dashboard revision
+
+→ Full flags and examples: `references/dashboard.md`
+
+### Docs
+
+Search and query current Sentry documentation
+
+- `sentry docs list <keywords...>` — Find Sentry documentation pages by keyword
+- `sentry docs query <question...>` — Ask a cited question about Sentry documentation
+
+→ Full flags and examples: `references/docs.md`
+
+### Platform
+
+List valid Sentry platform identifiers
+
+- `sentry platform list` — List all valid Sentry platform identifiers
+
+→ Full flags and examples: `references/platform.md`
+
+### Proguard
+
+Work with ProGuard/R8 mapping files
+
+- `sentry proguard upload <path...>` — Upload ProGuard/R8 mapping files to Sentry
+- `sentry proguard uuid <path>` — Compute the UUID for a ProGuard mapping file
+
+→ Full flags and examples: `references/proguard.md`
+
+### React-native
+
+Upload React Native sourcemaps from build steps
+
+- `sentry react-native gradle` — Upload a React Native bundle + sourcemap (Gradle build step)
+- `sentry react-native xcode <script-arg...>` — Upload React Native sourcemaps (Xcode build step)
+
+→ Full flags and examples: `references/react-native.md`
+
+### Replay
+
+Search and inspect Session Replays
+
+- `sentry replay list <org/project>` — List recent Session Replays
+- `sentry replay view <replay-id-or-url...>` — View a Session Replay
+
+→ Full flags and examples: `references/replay.md`
+
+### Release
+
+Work with Sentry releases
+
+- `sentry release list <org/project>` — List releases with adoption and health metrics
+- `sentry release view <org/version>` — View release details with health metrics
+- `sentry release create <org/version>` — Create a release
+- `sentry release finalize <org/version>` — Finalize a release
+- `sentry release delete <org/version>` — Delete a release
+- `sentry release archive <org/version>` — Archive a release
+- `sentry release restore <org/version>` — Restore an archived release
+- `sentry release deploy <org/version> <environment> <name>` — Create a deploy for a release
+- `sentry release deploys <org/version>` — List deploys for a release
+- `sentry release set-commits <org/version>` — Set commits for a release
+- `sentry release propose-version` — Propose a release version
+
+→ Full flags and examples: `references/release.md`
+
+### Repo
+
+Work with Sentry repositories
+
+- `sentry repo list <org/project>` — List repositories
+
+→ Full flags and examples: `references/repo.md`
+
+### Team
+
+Work with Sentry teams
+
+- `sentry team list <org/project>` — List teams
+
+→ Full flags and examples: `references/team.md`
+
+### Explore
+
+Query aggregate event data (Explore)
+
+- `sentry explore <target>` — Query aggregate event data (Explore)
+
+→ Full flags and examples: `references/explore.md`
+
+### Feedback
+
+Search and inspect User Feedback
+
+- `sentry feedback list <org/project>` — List and search User Feedback
+- `sentry feedback view <feedback>` — View a User Feedback item
+
+→ Full flags and examples: `references/feedback.md`
+
+### Log
+
+View Sentry logs
+
+- `sentry log list <org/project-or-trace-id...>` — List logs from a project
+- `sentry log view <org/project/log-id...>` — View details of one or more log entries
+
+→ Full flags and examples: `references/log.md`
+
+### Monitor
+
+Work with Sentry cron monitors
+
+- `sentry monitor run <monitor-slug command...>` — Wrap a command with cron monitor check-ins
+- `sentry monitor list <org/project>` — List cron monitors
+
+→ Full flags and examples: `references/monitor.md`
+
+### Snapshots
+
+Manage and compare snapshots
+
+- `sentry snapshots diff <base-dir> <head-dir>` — Compare two directories of snapshot images
+- `sentry snapshots download` — Download baseline snapshot images
+- `sentry snapshots upload <path>` — Upload snapshots to a project
+
+→ Full flags and examples: `references/snapshots.md`
+
+### Sourcemap
+
+Manage sourcemaps
+
+- `sentry sourcemap inject <directory>` — Inject debug IDs into JavaScript files and sourcemaps
+- `sentry sourcemap upload <directory>` — Upload sourcemaps to Sentry
+- `sentry sourcemap resolve <directory>` — Resolve and report sourcemap linkage for JavaScript files
+
+→ Full flags and examples: `references/sourcemap.md`
+
+### Span
+
+List and view spans in projects or traces
+
+- `sentry span list <org/project/trace-id...>` — List spans in a project or trace
+- `sentry span view <trace-id/span-id...>` — View details of specific spans
+
+→ Full flags and examples: `references/span.md`
+
+### Trace
+
+View distributed traces
+
+- `sentry trace list <org/project>` — List recent traces in a project
+- `sentry trace view <org/project/trace-id...>` — View details of a specific trace
+- `sentry trace logs <org/project/trace-id...>` — View logs associated with a trace
+
+→ Full flags and examples: `references/trace.md`
+
+### Trial
+
+Manage product trials
+
+- `sentry trial list <org>` — List product trials
+- `sentry trial start <name> <org>` — Start a product trial
+
+→ Full flags and examples: `references/trial.md`
+
+### Init
+
+Initialize Sentry in your project (experimental)
+
+- `sentry init <target> <directory>` — Initialize Sentry in your project (experimental)
+
+→ Full flags and examples: `references/init.md`
+
+### Info
+
+Print configuration and verify authentication
+
+- `sentry info` — Print configuration and verify authentication
+
+→ Full flags and examples: `references/info.md`
+
+### Local
+
+Sentry for local development
+
+- `sentry local serve` — Start the local dev server and tail events
+- `sentry local run <command...>` — Run a command with the local dev server enabled
+
+→ Full flags and examples: `references/local.md`
+
+### Schema
+
+Browse the Sentry API schema
+
+- `sentry schema <resource...>` — Browse the Sentry API schema
+
+→ Full flags and examples: `references/schema.md`
+
+## Global Options
+
+All commands support the following global options:
+
+- `--help` - Show help for the command
+- `--version` - Show CLI version
+- `--log-level <level>` - Set log verbosity (`error`, `warn`, `log`, `info`, `debug`, `trace`). Overrides `SENTRY_LOG_LEVEL`
+- `--verbose` - Shorthand for `--log-level debug`
+
+## Output Formats
+
+### JSON Output
+
+Most list and view commands support `--json` flag for JSON output, making it easy to integrate with other tools:
+
+```bash
+sentry org list --json | jq '.[] | .slug'
+```
+
+### Opening in Browser
+
+View commands support `-w` or `--web` flag to open the resource in your browser:
+
+```bash
+sentry issue view PROJ-123 -w
+```

--- a/.agents/skills/sentry-cli/references/agent-conversation.md
+++ b/.agents/skills/sentry-cli/references/agent-conversation.md
@@ -1,0 +1,83 @@
+---
+name: sentry-cli-agent-conversation
+version: 0.44.1
+description: List and view agent conversations
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Agent-conversation Commands
+
+List and view agent conversations
+
+### `sentry agent-conversation list <org>`
+
+List recent agent conversations
+
+**Flags:**
+- `-n, --limit <value> - Number of conversations (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conversationId` | string |  |
+| `title` | string \| null |  |
+| `flow` | array |  |
+| `errors` | number |  |
+| `llmCalls` | number |  |
+| `toolCalls` | number |  |
+| `totalTokens` | number |  |
+| `totalCost` | number |  |
+| `startTimestamp` | number |  |
+| `endTimestamp` | number |  |
+| `traceCount` | number |  |
+| `traceIds` | array |  |
+| `firstInput` | string \| null |  |
+| `lastOutput` | string \| null |  |
+| `user` | object \| null |  |
+| `toolNames` | array |  |
+| `toolErrors` | number |  |
+
+**Examples:**
+
+```bash
+# List recent agent conversations
+sentry agent-conversation list
+
+# Explicit organization
+sentry agent-conversation list my-org
+
+# Show more, last 24 hours
+sentry agent-conversation list --limit 50 --period 24h
+
+# Filter conversations
+sentry agent-conversation list -q "has:errors"
+
+# Paginate through results
+sentry agent-conversation list my-org -c next
+```
+
+### `sentry agent-conversation view <org/conversation-id>`
+
+View an agent conversation transcript
+
+**Flags:**
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# View full transcript
+sentry agent-conversation view my-org conv-123
+
+# JSON output
+sentry agent-conversation view my-org conv-123 --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/alert.md
+++ b/.agents/skills/sentry-cli/references/alert.md
@@ -1,0 +1,218 @@
+---
+name: sentry-cli-alert
+version: 0.44.1
+description: Manage Sentry alert rules
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Alert Commands
+
+Manage Sentry alert rules
+
+### `sentry alert issues list <org/project>`
+
+List issue alert rules
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-n, --limit <value> - Maximum number of issue alert rules to list - (default: "25")`
+- `-q, --query <value> - Filter rules by name`
+- `-c, --cursor <value> - Pagination cursor (use "next" for next page, "prev" for previous)`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# List issue alert rules for a project
+sentry alert issues list my-org/my-project
+
+# Filter rules by name
+sentry alert issues list my-org/my-project --query "spike"
+```
+
+### `sentry alert issues view <org/project/rule-id-or-name>`
+
+View an issue alert rule
+
+**Flags:**
+- `-w, --web - Open issue alert rules page in browser`
+
+**Examples:**
+
+```bash
+# View by ID
+sentry alert issues view my-org/my-project/12345
+
+# View by name
+sentry alert issues view my-org/my-project/"Error Spike"
+```
+
+### `sentry alert issues create <target>`
+
+Create an issue alert rule
+
+**Flags:**
+- `--name <value> - Rule name`
+- `-c, --condition <value>... - Condition object JSON (repeatable, or pass one JSON array)`
+- `-a, --action <value>... - Action object JSON (repeatable, or pass one JSON array)`
+- `--frequency <value> - Frequency in minutes (default: 30) - (default: 30)`
+- `--environment <value> - Environment filter`
+- `--filter <value>... - Filter object JSON (repeatable, or pass one JSON array)`
+- `-m, --filter-match <value> - Filter match mode: all or any`
+- `--owner <value> - Owner (team:user style value accepted by Sentry API)`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Create an issue alert rule with inline JSON condition/action
+sentry alert issues create my-org/my-project \
+  --name "Error Spike" \
+  --condition '{"type":"first_seen_event","comparison":true,"conditionResult":true}' \
+  --action '{"type":"email","data":{},"config":{"targetType":"team","targetIdentifier":"1"}}'
+```
+
+### `sentry alert issues delete <org/project/rule-id-or-name>`
+
+Delete an issue alert rule
+
+**Flags:**
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Delete with preview
+sentry alert issues delete my-org/my-project/12345 --dry-run
+```
+
+### `sentry alert issues edit <org/project/rule-id-or-name>`
+
+Edit an issue alert rule
+
+**Flags:**
+- `--name <value> - New rule name`
+- `--status <value> - Rule status: active or disabled`
+- `-c, --condition <value>... - Condition object JSON (repeatable, or pass one JSON array)`
+- `-a, --action <value>... - Action object JSON (repeatable, or pass one JSON array)`
+- `--frequency <value> - Frequency in minutes`
+- `--environment <value> - Environment value (pass empty string to clear)`
+- `--filter <value>... - Filter object JSON (repeatable, or pass one JSON array)`
+- `-m, --filter-match <value> - Filter match mode: all or any`
+- `--owner <value> - Owner value (pass empty string to clear)`
+
+**Examples:**
+
+```bash
+# Edit issue alert name/status
+sentry alert issues edit my-org/my-project/12345 --name "Prod Error Spike" --status disabled
+```
+
+### `sentry alert metrics list <target>`
+
+List metric alert rules
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-n, --limit <value> - Maximum number of metric alert rules to list - (default: "25")`
+- `-q, --query <value> - Filter rules by name`
+- `-c, --cursor <value> - Pagination cursor (use "next" for next page, "prev" for previous)`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# List metric alert rules for an organization
+sentry alert metrics list my-org/
+```
+
+### `sentry alert metrics view <org/rule-id-or-name>`
+
+View a metric alert rule
+
+**Flags:**
+- `-w, --web - Open metric alert rules page in browser`
+
+**Examples:**
+
+```bash
+# View by ID
+sentry alert metrics view my-org/67890
+
+# View by name
+sentry alert metrics view my-org/"P95 latency alert"
+```
+
+### `sentry alert metrics create <org>`
+
+Create a metric alert rule
+
+**Flags:**
+- `--name <value> - Rule name`
+- `--query <value> - Metric query filter string`
+- `--aggregate <value> - Aggregate expression (for example count(), p95(transaction.duration))`
+- `--dataset <value> - Dataset: errors (error-events), transactions (transaction-like), sessions, events, spans, metrics`
+- `--time-window <value> - Evaluation window in minutes`
+- `-t, --trigger <value>... - Trigger object JSON (repeatable, or pass one JSON array)`
+- `-p, --project <value>... - Project slug filter (repeatable or comma-separated)`
+- `--environment <value> - Environment filter`
+- `--owner <value> - Owner value accepted by Sentry API`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Create an organization metric alert rule
+sentry alert metrics create my-org \
+  --name "P95 Latency" \
+  --query "environment:prod" \
+  --aggregate "p95(transaction.duration)" \
+  --dataset transactions \
+  --time-window 5 \
+  --trigger '{"alertThreshold":500,"actions":[{"id":"sentry.mail.actions.NotifyEmailAction","targetType":"Team","targetIdentifier":1}]}'
+```
+
+### `sentry alert metrics delete <org/rule-id-or-name>`
+
+Delete a metric alert rule
+
+**Flags:**
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Delete without prompt
+sentry alert metrics delete my-org/67890 --yes
+```
+
+### `sentry alert metrics edit <org/rule-id-or-name>`
+
+Edit a metric alert rule
+
+**Flags:**
+- `--name <value> - New rule name`
+- `--status <value> - active or disabled`
+- `--query <value> - Metric query filter`
+- `--aggregate <value> - Aggregate expression`
+- `--dataset <value> - Dataset: errors (error-events), transactions (transaction-like), sessions, events, spans, metrics`
+- `--time-window <value> - Evaluation window in minutes`
+- `-t, --trigger <value>... - Trigger object JSON (repeatable, or pass one JSON array)`
+- `-p, --project <value>... - Project slug filter (repeatable or comma-separated)`
+- `--environment <value> - Environment value (pass empty string to clear)`
+- `--owner <value> - Owner value (pass empty string to clear)`
+
+**Examples:**
+
+```bash
+# Edit metric alert query/window
+sentry alert metrics edit my-org/67890 --query "environment:prod event.type:error" --time-window 15
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/api.md
+++ b/.agents/skills/sentry-cli/references/api.md
@@ -1,0 +1,71 @@
+---
+name: sentry-cli-api
+version: 0.44.1
+description: Make an authenticated API request
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# API Commands
+
+Make an authenticated API request
+
+### `sentry api <endpoint>`
+
+Make an authenticated API request
+
+**Flags:**
+- `-X, --method <value> - The HTTP method for the request - (default: "GET")`
+- `-d, --data <value> - Inline JSON body for the request (like curl -d)`
+- `-F, --field <value>... - Add a typed parameter (key=value, key[sub]=value, key[]=value)`
+- `-f, --raw-field <value>... - Add a string parameter without JSON parsing`
+- `-H, --header <value>... - Add a HTTP request header in key:value format`
+- `--input <value> - The file to use as body for the HTTP request (use "-" to read from standard input)`
+- `--silent - Do not print the response body`
+- `--verbose - Include full HTTP request and response in the output`
+- `-n, --dry-run - Show the resolved request without sending it`
+
+**Examples:**
+
+```bash
+# List organizations
+sentry api organizations/
+
+# Get a specific issue
+sentry api issues/123456789/
+
+# Create a release
+sentry api organizations/my-org/releases/ \
+  -X POST -F version=1.0.0
+
+# With inline JSON body
+sentry api issues/123456789/ \
+  -X POST -d '{"status": "resolved"}'
+
+# Update an issue status
+sentry api issues/123456789/ \
+  -X PUT -F status=resolved
+
+# Assign an issue
+sentry api issues/123456789/ \
+  -X PUT --field assignedTo="user@example.com"
+
+sentry api projects/my-org/my-project/ -X DELETE
+
+# Add custom headers
+sentry api organizations/ -H "X-Custom: value"
+
+# Read body from a file
+sentry api projects/my-org/my-project/releases/ -X POST --input release.json
+
+# Verbose mode (shows full HTTP request/response)
+sentry api organizations/ --verbose
+
+# Preview the request without sending
+sentry api organizations/ --dry-run
+
+sentry api "projects/my-org/my-project/events/EVENT_ID/attachments/ATTACHMENT_ID/?download=1" > screenshot.png
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/auth.md
+++ b/.agents/skills/sentry-cli/references/auth.md
@@ -1,0 +1,106 @@
+---
+name: sentry-cli-auth
+version: 0.44.1
+description: Authenticate with Sentry
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Auth Commands
+
+Authenticate with Sentry
+
+### `sentry auth login`
+
+Authenticate with Sentry
+
+**Flags:**
+- `--token <value> - Authenticate using an API token instead of OAuth`
+- `--timeout <value> - Timeout for OAuth flow in seconds (default: 900) - (default: "900")`
+- `--force - Re-authenticate without prompting`
+- `--url <value> - Sentry instance URL to authenticate against (e.g. https://sentry.example.com). Required for self-hosted; defaults to SaaS (https://sentry.io).`
+- `--read-only - Request only read-only OAuth scopes (project:read, org:read, event:read, member:read, team:read). Useful for handing tokens to AI agents or CI jobs that should not be able to mutate Sentry state.`
+- `-s, --scope <value>... - Request specific OAuth scopes (repeatable, comma-separated). E.g. --scope project:read --scope org:read. Overrides the default scope set.`
+
+**Examples:**
+
+```bash
+sentry auth
+
+sentry auth --token YOUR_SENTRY_API_TOKEN
+
+sentry auth --read-only
+
+sentry auth --scope project:read --scope org:read
+sentry auth --scope project:read,event:read
+
+sentry auth --url https://sentry.example.com
+SENTRY_URL=https://sentry.example.com sentry auth
+
+sentry auth --token YOUR_TOKEN --url https://sentry.example.com
+```
+
+### `sentry auth logout`
+
+Log out of Sentry
+
+**Examples:**
+
+```bash
+sentry auth logout
+```
+
+### `sentry auth refresh`
+
+Refresh your OAuth access token
+
+**Flags:**
+- `--force - Force refresh even if the access token is still valid`
+- `--read-only - Re-authenticate with read-only OAuth scopes (project:read, org:read, event:read, member:read, team:read)`
+- `-s, --scope <value>... - Re-authenticate with specific OAuth scopes (repeatable, comma-separated). E.g. --scope project:read --scope org:read`
+
+**Examples:**
+
+```bash
+sentry auth refresh
+```
+
+### `sentry auth status`
+
+View authentication status
+
+**Flags:**
+- `--show-token - Show the stored token (masked by default)`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+sentry auth status
+
+# Show the raw token
+sentry auth status --show-token
+
+# View current user
+sentry auth whoami
+```
+
+### `sentry auth token`
+
+Print the stored authentication token
+
+**Examples:**
+
+```bash
+sentry auth token
+```
+
+### `sentry auth whoami`
+
+Show the currently authenticated identity
+
+**Flags:**
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/build.md
+++ b/.agents/skills/sentry-cli/references/build.md
@@ -1,0 +1,69 @@
+---
+name: sentry-cli-build
+version: 0.44.1
+description: Manage mobile build artifacts
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Build Commands
+
+Manage mobile build artifacts
+
+### `sentry build upload <path...>`
+
+Upload builds to a project
+
+**Flags:**
+- `--build-configuration <value> - Build configuration for the upload (defaults to the current version)`
+- `--release-notes <value> - Release notes for the build`
+- `--install-group <value>... - Install group(s) for this build (repeatable); builds sharing a group show updates for each other`
+- `--head-sha <value> - VCS commit SHA (defaults to the current commit)`
+- `--base-sha <value> - VCS base commit SHA (defaults to the merge-base with the base ref)`
+- `--vcs-provider <value> - VCS provider (defaults to the current remote's provider)`
+- `--head-repo-name <value> - Head repository name, e.g. owner/repo (defaults to the current)`
+- `--base-repo-name <value> - Base repository name, e.g. owner/repo (for forks)`
+- `--head-ref <value> - Head branch/reference (defaults to the current branch)`
+- `--base-ref <value> - Base branch/reference (defaults to the merge-base tracking ref)`
+- `--pr-number <value> - Pull request number (auto-detected in pull_request GitHub Actions runs)`
+- `--force-git-metadata - Force collecting git metadata even outside CI (conflicts with --no-git-metadata)`
+- `--no-git-metadata - Disable automatic git metadata collection`
+
+### `sentry build download <build-id>`
+
+Download a build artifact
+
+**Flags:**
+- `-o, --output <value> - Output path (default: preprod_artifact_<build-id>.<ext> in the current directory)`
+
+**Examples:**
+
+```bash
+# Upload an Android build (APK or AAB) for size analysis
+sentry build upload ./app-release.apk
+
+# Upload an iOS build (XCArchive directory or IPA)
+sentry build upload ./MyApp.xcarchive
+sentry build upload ./MyApp.ipa
+
+# Upload with a build configuration and release notes
+sentry build upload ./app.aab --build-configuration Release --release-notes "Nightly"
+
+# Tag a build with install groups (repeatable)
+sentry build upload ./app.aab --install-group qa --install-group beta
+
+# Attach explicit git metadata (otherwise auto-collected in CI)
+sentry build upload ./app.aab --head-sha "$GIT_SHA" --pr-number 42 --base-ref main
+
+# Download a build artifact by ID
+sentry build download 1234567890
+
+# Download to a specific path
+sentry build download 1234567890 --output ./app.ipa
+
+# Output the result as JSON
+sentry build download 1234567890 --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/cli.md
+++ b/.agents/skills/sentry-cli/references/cli.md
@@ -1,0 +1,207 @@
+---
+name: sentry-cli-cli
+version: 0.44.1
+description: CLI-related commands
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# CLI Commands
+
+CLI-related commands
+
+### `sentry cli completion <shell>`
+
+Print the shell completion script
+
+**Examples:**
+
+```bash
+# Print completions for your current shell (auto-detected from $SHELL)
+sentry cli completion
+
+# Generate for a specific shell
+sentry cli completion zsh > ~/.local/share/zsh/site-functions/_sentry
+eval "$(sentry cli completion bash)"
+sentry cli completion fish > ~/.config/fish/completions/sentry.fish
+```
+
+### `sentry cli defaults <key value...>`
+
+View and manage default settings
+
+**Flags:**
+- `--clear - Clear the specified default, or all defaults if no key is given`
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+
+**Examples:**
+
+```bash
+# Show all current defaults
+sentry cli defaults
+
+# Set default organization
+sentry cli defaults org my-org
+
+# Set default project
+sentry cli defaults project my-project
+
+# Set default Sentry URL (self-hosted)
+sentry cli defaults url https://sentry.example.com
+
+# Set custom HTTP headers (self-hosted, e.g. for IAP/proxies)
+sentry cli defaults headers "X-IAP: token"
+
+# Set a custom CA certificate (self-hosted, behind a TLS proxy)
+sentry cli defaults ca-cert /path/to/ca.pem
+
+# Disable telemetry
+sentry cli defaults telemetry off
+
+# Clear a single default
+sentry cli defaults org --clear
+
+# Clear all defaults
+sentry cli defaults --clear
+```
+
+### `sentry cli feedback <message...>`
+
+Send feedback about the CLI
+
+**Examples:**
+
+```bash
+# Send positive feedback
+sentry cli feedback i love this tool
+
+# Report an issue
+sentry cli feedback the issue view is confusing
+```
+
+### `sentry cli fix`
+
+Diagnose and repair CLI database issues
+
+**Flags:**
+- `--dry-run - Show what would be fixed without making changes`
+
+**Examples:**
+
+```bash
+sentry cli fix
+```
+
+### `sentry cli import`
+
+Import settings from legacy .sentryclirc files
+
+**Flags:**
+- `-y, --yes - Skip confirmation prompt`
+- `-n, --dry-run - Show what would happen without making changes`
+- `--url <value> - Explicitly trust this URL (bypasses same-file trust check)`
+- `--skip-validation - Skip token validation against the Sentry API`
+
+**Examples:**
+
+```bash
+# Auto-detect and import .sentryclirc
+sentry cli import
+
+# Preview what would be imported
+sentry cli import --dry-run
+
+# Skip confirmation prompt
+sentry cli import --yes
+
+# Explicitly trust a self-hosted URL
+sentry cli import --url https://sentry.example.com
+
+# Skip API validation of the imported token
+sentry cli import --skip-validation
+```
+
+### `sentry cli setup`
+
+Configure shell integration
+
+**Flags:**
+- `--install - Install the binary from a temp location to the system path`
+- `--method <value> - Installation method (curl, npm, pnpm, bun, yarn)`
+- `--channel <value> - Release channel to persist (stable or nightly)`
+- `--no-modify-path - Skip PATH modification`
+- `--no-completions - Skip shell completion installation`
+- `--no-agent-skills - Skip agent skill installation for AI coding assistants`
+- `--quiet - Suppress output (for scripted usage)`
+
+**Examples:**
+
+```bash
+# Run full setup (PATH, completions, agent skills)
+sentry cli setup
+
+# Skip agent skill installation
+sentry cli setup --no-agent-skills
+
+# Skip PATH and completion modifications
+sentry cli setup --no-modify-path --no-completions
+```
+
+### `sentry cli uninstall`
+
+Uninstall Sentry CLI
+
+**Flags:**
+- `--keep-config - Keep the config directory (~/.sentry) and auth tokens`
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Show what would be removed (dry run)
+sentry cli uninstall --dry-run
+
+# Uninstall, keeping config directory
+sentry cli uninstall --yes --keep-config
+
+# Full uninstall with confirmation
+sentry cli uninstall
+```
+
+### `sentry cli upgrade <version>`
+
+Update the Sentry CLI to the latest version
+
+**Flags:**
+- `--check - Check for updates without installing`
+- `--force - Force upgrade even if already on the latest version`
+- `--offline - Upgrade using only cached version info and patches (no network)`
+- `--no-agent-skills - Skip agent skill installation for AI coding assistants`
+- `--method <value> - Installation method to use (curl, brew, npm, pnpm, bun, yarn)`
+
+**Examples:**
+
+```bash
+sentry cli upgrade --check
+
+# Upgrade to latest stable
+sentry cli upgrade
+
+# Upgrade to a specific version
+sentry cli upgrade 0.5.0
+
+# Force re-download
+sentry cli upgrade --force
+
+# Switch to nightly builds
+sentry cli upgrade nightly
+
+# Switch back to stable
+sentry cli upgrade stable
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/code-mappings.md
+++ b/.agents/skills/sentry-cli/references/code-mappings.md
@@ -1,0 +1,38 @@
+---
+name: sentry-cli-code-mappings
+version: 0.44.1
+description: Manage code mappings for stack trace linking
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Code-mappings Commands
+
+Manage code mappings for stack trace linking
+
+### `sentry code-mappings upload <path>`
+
+Upload code mappings for stack trace linking
+
+**Flags:**
+- `--repo <value> - Repository name (e.g., owner/repo). Auto-detected from git remote if omitted.`
+- `--default-branch <value> - Default branch name. Auto-detected from git remote HEAD if omitted.`
+
+**Examples:**
+
+```bash
+# Upload code mappings from a JSON file
+sentry code-mappings upload mappings.json
+
+# Specify repository explicitly
+sentry code-mappings upload mappings.json --repo owner/repo
+
+# Specify repository and default branch
+sentry code-mappings upload mappings.json --repo owner/repo --default-branch develop
+
+# Output as JSON
+sentry code-mappings upload mappings.json --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/dart-symbol-map.md
+++ b/.agents/skills/sentry-cli/references/dart-symbol-map.md
@@ -1,0 +1,35 @@
+---
+name: sentry-cli-dart-symbol-map
+version: 0.44.1
+description: Work with Dart/Flutter symbol maps
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Dart-symbol-map Commands
+
+Work with Dart/Flutter symbol maps
+
+### `sentry dart-symbol-map upload <path>`
+
+Upload a Dart/Flutter symbol map to Sentry
+
+**Flags:**
+- `-d, --debug-id <value> - Debug ID (UUID) from the companion native debug file`
+- `--no-upload - Validate the file without uploading (dry-run)`
+
+**Examples:**
+
+```bash
+# Upload a dart symbol map with a debug ID
+sentry dart-symbol-map upload --debug-id 12345678-1234-1234-1234-123456789abc mapping.json
+
+# Validate without uploading
+sentry dart-symbol-map upload --debug-id 12345678-1234-1234-1234-123456789abc mapping.json --no-upload
+
+# Output as JSON
+sentry dart-symbol-map upload --debug-id 12345678-1234-1234-1234-123456789abc mapping.json --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/dashboard.md
+++ b/.agents/skills/sentry-cli/references/dashboard.md
@@ -1,0 +1,211 @@
+---
+name: sentry-cli-dashboard
+version: 0.44.1
+description: Manage Sentry dashboards
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Dashboard Commands
+
+Manage Sentry dashboards
+
+### `sentry dashboard list <org/title-filter...>`
+
+List dashboards
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-n, --limit <value> - Maximum number of dashboards to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**Examples:**
+
+```bash
+# List all dashboards
+sentry dashboard list
+
+# Filter by name pattern
+sentry dashboard list "Backend*"
+
+# Open dashboard list in browser
+sentry dashboard list -w
+```
+
+### `sentry dashboard view <org/project/dashboard...>`
+
+View a dashboard
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-r, --refresh <value> - Auto-refresh interval in seconds (default: 60, min: 10)`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01"`
+
+**Examples:**
+
+```bash
+# View by title
+sentry dashboard view 'Frontend Performance'
+
+# View by ID
+sentry dashboard view 12345
+
+# Auto-refresh every 30 seconds
+sentry dashboard view "Backend Performance" --refresh 30
+
+# Open in browser
+sentry dashboard view 12345 -w
+```
+
+### `sentry dashboard create <org/project/title...>`
+
+Create a dashboard
+
+**Examples:**
+
+```bash
+sentry dashboard create 'Frontend Performance'
+```
+
+### `sentry dashboard widget add <org/project/dashboard/title...>`
+
+Add a widget to a dashboard
+
+**Flags:**
+- `-d, --display <value> - Display type (big_number, line, area, bar, table, stacked_area, top_n, text, categorical_bar, details, wheel, rage_and_dead_clicks, server_tree, agents_traces_table)`
+- `--dataset <value> - Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, transaction-like/transactions, tracemetrics/metrics, logs, issue, discover`
+- `-q, --query <value>... - Aggregate expression (e.g. count, p95:span.duration)`
+- `-w, --where <value> - Search conditions filter (e.g. is:unresolved)`
+- `-g, --group-by <value>... - Group-by column (repeatable)`
+- `-s, --sort <value> - Order by (prefix - for desc, e.g. -count)`
+- `-n, --limit <value> - Result limit`
+- `-x, --col <value> - Grid column position (0-based, 0–5)`
+- `-y, --row <value> - Grid row position (0-based)`
+- `--width <value> - Widget width in grid columns (1–6)`
+- `--height <value> - Widget height in grid rows (min 1)`
+- `-l, --layout <value> - Layout mode: sequential (append in order) or dense (fill gaps) - (default: "sequential")`
+
+**Examples:**
+
+```bash
+# Simple counter widget
+sentry dashboard widget add 'My Dashboard' "Error Count" \
+  --display big_number --query count
+
+# Line chart with group-by
+sentry dashboard widget add 'My Dashboard' "Errors by Browser" \
+  --display line --query count --group-by browser.name
+
+# Table with multiple aggregates, sorted descending
+sentry dashboard widget add 'My Dashboard' "Top Endpoints" \
+  --display table \
+  --query count --query p95:span.duration \
+  --group-by transaction \
+  --sort -count --limit 10
+
+# With search filter
+sentry dashboard widget add 'My Dashboard' "Slow Requests" \
+  --display bar --query p95:span.duration \
+  --where "span.op:http.client" \
+  --group-by span.description
+```
+
+### `sentry dashboard widget edit <org/project/dashboard...>`
+
+Edit a widget in a dashboard
+
+**Flags:**
+- `-i, --index <value> - Widget index (0-based)`
+- `-t, --title <value> - Widget title to match`
+- `--new-title <value> - New widget title`
+- `-d, --display <value> - Display type (big_number, line, area, bar, table, stacked_area, top_n, text, categorical_bar, details, wheel, rage_and_dead_clicks, server_tree, agents_traces_table)`
+- `--dataset <value> - Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, transaction-like/transactions, tracemetrics/metrics, logs, issue, discover`
+- `-q, --query <value>... - Aggregate expression (e.g. count, p95:span.duration)`
+- `-w, --where <value> - Search conditions filter (e.g. is:unresolved)`
+- `-g, --group-by <value>... - Group-by column (repeatable)`
+- `-s, --sort <value> - Order by (prefix - for desc, e.g. -count)`
+- `-n, --limit <value> - Result limit`
+- `-x, --col <value> - Grid column position (0-based, 0–5)`
+- `-y, --row <value> - Grid row position (0-based)`
+- `--width <value> - Widget width in grid columns (1–6)`
+- `--height <value> - Widget height in grid rows (min 1)`
+
+**Examples:**
+
+```bash
+# Change display type
+sentry dashboard widget edit 12345 --title 'Error Count' --display bar
+
+# Rename a widget
+sentry dashboard widget edit 'My Dashboard' --index 0 --new-title 'Total Errors'
+
+# Change the query
+sentry dashboard widget edit 12345 --title 'Error Rate' --query p95:span.duration
+```
+
+### `sentry dashboard widget delete <org/project/dashboard...>`
+
+Delete a widget from a dashboard
+
+**Flags:**
+- `-i, --index <value> - Widget index (0-based)`
+- `-t, --title <value> - Widget title to match`
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Delete by title
+sentry dashboard widget delete 'My Dashboard' --title 'Error Count'
+
+# Delete by index
+sentry dashboard widget delete 12345 --index 2
+```
+
+### `sentry dashboard revisions <org/dashboard...>`
+
+List dashboard revisions
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of revisions to list - (default: "25")`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**Examples:**
+
+```bash
+# List revisions by dashboard title
+sentry dashboard revisions 'Frontend Performance'
+
+# List revisions by dashboard ID
+sentry dashboard revisions 12345
+
+# With explicit org
+sentry dashboard revisions my-org 12345
+```
+
+### `sentry dashboard restore <org/dashboard...>`
+
+Restore a dashboard revision
+
+**Flags:**
+- `-r, --revision <value> - Revision ID to restore`
+
+**Examples:**
+
+```bash
+# Restore by dashboard title and revision number
+sentry dashboard restore 'Frontend Performance' --revision 3
+
+# Restore by dashboard ID
+sentry dashboard restore 12345 --revision 1
+
+# With explicit org
+sentry dashboard restore my-org 12345 --revision 1
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/debug-files.md
+++ b/.agents/skills/sentry-cli/references/debug-files.md
@@ -1,0 +1,117 @@
+---
+name: sentry-cli-debug-files
+version: 0.44.1
+description: Work with debug information files
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Debug-files Commands
+
+Work with debug information files
+
+### `sentry debug-files check <path>`
+
+Inspect a debug information file
+
+### `sentry debug-files find <id...>`
+
+Locate debug files for given debug identifiers
+
+**Flags:**
+- `-t, --type <value>... - Only consider debug files of the given type (repeatable). Default: all`
+- `--no-well-known - Do not look for debug files in well-known locations`
+- `--no-cwd - Do not look for debug files in the current directory`
+- `-p, --path <value>... - Add a directory to search recursively (repeatable)`
+
+### `sentry debug-files upload <path...>`
+
+Upload debug information files to Sentry
+
+**Flags:**
+- `-t, --type <value>... - Only upload files of this type (repeatable): dsym, elf, pe, pdb, portablepdb, wasm, breakpad, sourcebundle, jvm`
+- `--id <value>... - Only upload the object with this debug id (repeatable)`
+- `--require-all - Fail if any --id value was not found among scanned files`
+- `--no-debug - Do not upload files whose only feature is debug/symbol info`
+- `--no-unwind - Do not upload files whose only feature is unwind info`
+- `--no-sources - Do not upload files whose only feature is source info`
+- `--include-sources - Build and upload a source bundle for each file with debug info`
+- `--il2cpp-mapping - Compute and upload Unity IL2CPP line mappings for each scanned file`
+- `--derived-data - Also scan Xcode's DerivedData folder (macOS only)`
+- `--no-zips - Do not scan inside .zip archives`
+- `--no-upload - Scan and print what would be uploaded without uploading`
+- `--wait - Wait for server-side processing and report any errors`
+- `--wait-for <value> - Wait up to this many seconds for server-side processing`
+
+### `sentry debug-files print-sources <path>`
+
+List the source files a debug file references
+
+### `sentry debug-files bundle-sources <path>`
+
+Bundle a debug file's source files for source context
+
+**Flags:**
+- `-o, --output <value> - Output path for the source bundle ZIP (default: <path>.src.zip)`
+
+### `sentry debug-files bundle-jvm <path>`
+
+Create a JVM source bundle for source context
+
+**Flags:**
+- `-o, --output <value> - Output directory for the bundle ZIP`
+- `-d, --debug-id <value> - Debug ID (UUID) to stamp on the bundle`
+- `-e, --exclude <value>... - Additional directory names to exclude (repeatable)`
+
+**Examples:**
+
+```bash
+# Inspect a debug information file (auto-detects the format)
+sentry debug-files check ./libexample.so
+sentry debug-files check MyApp.dSYM/Contents/Resources/DWARF/MyApp
+sentry debug-files check ./app.pdb --json
+
+# List the source files a debug file references (and whether they're available)
+sentry debug-files print-sources ./libexample.so
+sentry debug-files print-sources ./app.pdb --json
+
+# Locate debug files for one or more debug identifiers on disk
+sentry debug-files find <debug-id>
+sentry debug-files find <debug-id> --type dsym --path ./build
+sentry debug-files find <debug-id> --no-cwd --no-well-known -p /symbols --json
+
+# Bundle a debug file's referenced source files (run on the build machine)
+sentry debug-files bundle-sources ./libexample.so
+sentry debug-files bundle-sources ./app.pdb --output ./app.src.zip
+
+# Bundle JVM sources with a debug ID
+sentry debug-files bundle-jvm --output ./out --debug-id <uuid> ./src
+
+# Exclude additional directories
+sentry debug-files bundle-jvm --output ./out --debug-id <uuid> --exclude generated --exclude build-tools ./src
+
+# Output as JSON
+sentry debug-files bundle-jvm --output ./out --debug-id <uuid> --json ./src
+
+# Upload debug information files (scans directories recursively)
+sentry debug-files upload ./build
+sentry debug-files upload ./libexample.so --include-sources
+
+# .zip archives are scanned in place; use --no-zips to skip them
+sentry debug-files upload ./symbols.zip
+sentry debug-files upload ./build --no-zips
+
+# Restrict by type or debug id, and wait for server-side processing
+sentry debug-files upload ./dsyms --type dsym --wait
+sentry debug-files upload ./build --id <debug-id> --require-all
+
+# Unity: upload IL2CPP line mappings (optionally with referenced C# sources)
+sentry debug-files upload ./build --il2cpp-mapping
+sentry debug-files upload ./build --il2cpp-mapping --include-sources
+
+# Preview what would be uploaded without uploading (no credentials needed)
+sentry debug-files upload ./build --no-upload
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/docs.md
+++ b/.agents/skills/sentry-cli/references/docs.md
@@ -1,0 +1,37 @@
+---
+name: sentry-cli-docs
+version: 0.44.1
+description: Search and query current Sentry documentation
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Docs Commands
+
+Search and query current Sentry documentation
+
+### `sentry docs list <keywords...>`
+
+Find Sentry documentation pages by keyword
+
+**Flags:**
+- `-n, --limit <value> - Maximum matches to return (1-20) - (default: "8")`
+
+**Examples:**
+
+```bash
+sentry docs list "source maps"
+```
+
+### `sentry docs query <question...>`
+
+Ask a cited question about Sentry documentation
+
+**Examples:**
+
+```bash
+sentry docs "How do I configure tracing in Next.js?"
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/event.md
+++ b/.agents/skills/sentry-cli/references/event.md
@@ -1,0 +1,148 @@
+---
+name: sentry-cli-event
+version: 0.44.1
+description: View, list, and send Sentry events
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Event Commands
+
+View, list, and send Sentry events
+
+### `sentry event view <org/project/event-id...>`
+
+View details of one or more events
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `--spans <value> - Span tree depth limit (number, "all" for unlimited, "no" to disable) - (default: "3")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+sentry event view abc123def456abc123def456abc12345
+
+# Open in browser
+sentry event view abc123def456abc123def456abc12345 -w
+```
+
+### `sentry event list <issue>`
+
+List events for an issue
+
+**Flags:**
+- `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `--full - Include full event body (stacktraces)`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Internal event ID |
+| `event.type` | string | Event type (error, default, transaction) |
+| `groupID` | string \| null | Group (issue) ID |
+| `eventID` | string | UUID-format event ID |
+| `projectID` | string | Project ID |
+| `message` | string | Event message |
+| `title` | string | Event title |
+| `location` | string \| null | Source location (file:line) |
+| `culprit` | string \| null | Culprit function/module |
+| `user` | object \| null | User context |
+| `tags` | array | Event tags |
+| `platform` | string \| null | Platform (python, javascript, etc.) |
+| `dateCreated` | string | ISO 8601 creation timestamp |
+| `crashFile` | string \| null | Crash file URL |
+| `metadata` | object | Event metadata |
+
+**Examples:**
+
+```bash
+# List events for an issue (using short ID)
+sentry event list PROJ-ABC
+
+# List events for an issue (using numeric ID)
+sentry event list 123456789
+
+# Filter by search query
+sentry event list PROJ-ABC --query "browser:Chrome"
+
+# Include full event bodies (stacktraces)
+sentry event list PROJ-ABC --full
+
+# Limit results and time range
+sentry event list PROJ-ABC --limit 50 --period 24h
+
+# Paginate through results
+sentry event list PROJ-ABC -c next
+sentry event list PROJ-ABC -c prev
+
+# Output as JSON
+sentry event list PROJ-ABC --json
+```
+
+### `sentry event send <args...>`
+
+Send a Sentry event
+
+**Flags:**
+- `--dsn <value> - DSN to send events to (overrides SENTRY_DSN env var)`
+- `-m, --message <value>... - Event message (repeat for multi-line)`
+- `-a, --message-arg <value>... - Arguments for message template (repeat for multiple)`
+- `-l, --level <value> - Event severity level - (default: "error")`
+- `-r, --release <value> - Release version`
+- `-d, --dist <value> - Distribution identifier`
+- `-E, --env <value> - Environment name (e.g. production, staging)`
+- `-p, --platform <value> - Platform identifier (default: other)`
+- `-t, --tag <value>... - Tag as KEY:VALUE (repeat for multiple)`
+- `-e, --extra <value>... - Extra data as KEY:VALUE (repeat for multiple)`
+- `-u, --user <value>... - User info as KEY:VALUE — id, email, username, ip_address, or custom`
+- `-f, --fingerprint <value>... - Custom fingerprint part (repeat for multiple)`
+- `--timestamp <value> - Event timestamp (Unix epoch, ISO 8601, or RFC 2822)`
+- `--no-environ - Do not include environment variables in the event`
+- `--logfile <value> - Path to a log file — last 100 lines are attached as breadcrumbs`
+- `--with-categories - Parse 'CATEGORY: message' prefixes from logfile breadcrumbs`
+- `--raw - Send file contents as-is without parsing`
+
+**Examples:**
+
+```bash
+# Send an error event (default level)
+sentry event send -m "Something went wrong"
+
+# Specify level, release, and environment
+sentry event send -m "Deploy check" -l info -r 1.0.0 -E production
+
+# Add tags and extra data
+sentry event send -m "Payment failed" --tag env:prod --tag region:us-east --extra amount:99.99
+
+# Set user context
+sentry event send -m "Login error" --user id:42 --user email:alice@example.com
+
+# Custom fingerprint to group related events together
+sentry event send -m "DB timeout" --fingerprint db-timeout --fingerprint {{ default }}
+
+# Send a serialized Sentry Event object
+sentry event send ./crash.json
+
+# Send without re-parsing (raw mode — also supports pre-built envelopes)
+sentry event send --raw ./crash.json
+sentry event send --raw ./captured.envelope
+
+# Explicit DSN
+sentry event send -m "Test" --dsn "https://key@o123.ingest.us.sentry.io/456"
+
+# Via environment variable
+export SENTRY_DSN="https://key@o123.ingest.us.sentry.io/456"
+sentry event send -m "Test"
+
+sentry send-event    # same as: sentry event send
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/explore.md
+++ b/.agents/skills/sentry-cli/references/explore.md
@@ -1,0 +1,88 @@
+---
+name: sentry-cli-explore
+version: 0.44.1
+description: Query aggregate event data (Explore)
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Explore Commands
+
+Query aggregate event data (Explore)
+
+### `sentry explore <target>`
+
+Query aggregate event data (Explore)
+
+**Flags:**
+- `-F, --field <value>... - API field or aggregate (repeatable). E.g., title, "count()", "p50(transaction.duration)"`
+- `-m, --metric <value> - Metric name for --dataset metrics. Auto-resolves type/unit via API.`
+- `--agg <value> - Aggregation for --metric (sum, avg, count, p50, p95, etc.) - (default: "sum")`
+- `-d, --dataset <value> - Dataset to query (errors, spans, metrics, logs, replays) - (default: "errors")`
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
+- `-e, --environment <value>... - Environment filter (repeatable, comma-separated)`
+- `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "24h")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**Examples:**
+
+```bash
+# Top errors in the last 24 hours, scoped to a project
+sentry explore my-org/cli
+
+# All projects in an org
+sentry explore my-org/
+
+# Bare project slug (searches across orgs)
+sentry explore cli
+
+# Auto-detect from DSN/config
+sentry explore
+
+# Errors with user impact for a specific UTC window
+sentry explore my-org/cli -F title -F "count()" -F "count_unique(user)" \
+  --period "2024-01-15T00:00:00Z/2024-01-16T00:00:00Z"
+
+# Filter by specific error type (combines with auto-injected project filter)
+sentry explore my-org/cli -F title -F "count()" \
+  -q "error.type:TypeError" --period 1h
+
+# Span operation latency by route
+sentry explore my-org/cli -F span.op -F "p50(span.duration)" \
+  -F "p95(span.duration)" --dataset spans --period 1h
+
+# Top spans by count
+sentry explore my-org/cli -F span.op -F "count()" \
+  --dataset spans --sort "-count()"
+
+# Sum a custom metric (e.g., LLM token usage) across an org
+sentry explore my-org/ -m llm.token_usage --dataset metrics --period 7d
+
+# Break down by a tag column (e.g., model name)
+sentry explore my-org/seer -F gen_ai.request.model \
+  -m llm.token_usage --dataset metrics --period 7d
+
+# Use a different aggregation (default is sum)
+sentry explore my-org/ -m cache.hit_rate --agg avg --dataset metrics
+
+sentry explore my-org/ \
+  -F "sum(value,llm.token_usage,distribution,none)" \
+  --dataset metrics --period 7d
+
+# Log severity counts in the last hour
+sentry explore my-org/cli -F severity -F "count()" \
+  --dataset logs --period 1h
+
+# Pipe to jq for filtering
+sentry explore my-org/cli -F title -F "count()" --json | jq '.data[:5]'
+
+# Get raw data for analysis
+sentry explore my-org/cli -F title -F "count()" -F "count_unique(user)" \
+  --json --limit 100
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/feedback.md
+++ b/.agents/skills/sentry-cli/references/feedback.md
@@ -1,0 +1,137 @@
+---
+name: sentry-cli-feedback
+version: 0.44.1
+description: Search and inspect User Feedback
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Feedback Commands
+
+Search and inspect User Feedback
+
+### `sentry feedback list <org/project>`
+
+List and search User Feedback
+
+**Flags:**
+- `--status <value> - Mailbox: unresolved, resolved, spam, or all - (default: "unresolved")`
+- `-n, --limit <value> - Number of feedback items (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query (Sentry issue search syntax)`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "14d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Numeric issue ID |
+| `shortId` | string | Human-readable short ID (e.g. PROJ-ABC) |
+| `title` | string | Issue title |
+| `culprit` | string \| null | Culprit string |
+| `count` | string | Total event count |
+| `userCount` | number | Number of affected users |
+| `firstSeen` | string \| null | First occurrence (ISO 8601) |
+| `lastSeen` | string \| null | Most recent occurrence (ISO 8601) |
+| `level` | string | Severity level |
+| `status` | string | Issue status |
+| `permalink` | string | URL to the issue in Sentry |
+| `project` | object | Project info |
+| `metadata` | object | Feedback metadata |
+| `assignedTo` | object \| null | Assigned user or team |
+| `priority` | string | Triage priority |
+| `platform` | string | Platform |
+| `substatus` | string \| null | Issue substatus |
+| `isUnhandled` | boolean | Whether the issue is unhandled |
+| `seerFixabilityScore` | number \| null | Seer AI fixability score (0-1) |
+| `issueCategory` | string | Issue category discriminator |
+| `issueType` | string | Issue type discriminator |
+| `hasSeen` | boolean | Whether the feedback has been read |
+| `latestEventHasAttachments` | boolean | Whether the latest event has attachments |
+
+**Examples:**
+
+```bash
+# Auto-detect the organization from the current project
+sentry feedback list
+
+# List Feedback for one project
+sentry feedback list my-org/frontend
+
+# List Feedback across every project in an organization
+sentry feedback list my-org/
+
+# Search for a project across accessible organizations
+sentry feedback list frontend
+
+sentry feedback list my-org/frontend --status resolved
+sentry feedback list my-org/frontend --status spam
+sentry feedback list my-org/frontend --status all --period 90d
+sentry feedback list my-org/frontend --query "message:*checkout*"
+```
+
+### `sentry feedback view <feedback>`
+
+View a User Feedback item
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Numeric issue ID |
+| `shortId` | string | Human-readable short ID (e.g. PROJ-ABC) |
+| `title` | string | Issue title |
+| `culprit` | string \| null | Culprit string |
+| `count` | string | Total event count |
+| `userCount` | number | Number of affected users |
+| `firstSeen` | string \| null | First occurrence (ISO 8601) |
+| `lastSeen` | string \| null | Most recent occurrence (ISO 8601) |
+| `level` | string | Severity level |
+| `status` | string | Issue status |
+| `permalink` | string | URL to the issue in Sentry |
+| `project` | object | Project info |
+| `metadata` | object | Feedback metadata |
+| `assignedTo` | object \| null | Assigned user or team |
+| `priority` | string | Triage priority |
+| `platform` | string | Platform |
+| `substatus` | string \| null | Issue substatus |
+| `isUnhandled` | boolean | Whether the issue is unhandled |
+| `seerFixabilityScore` | number \| null | Seer AI fixability score (0-1) |
+| `issueCategory` | string | Issue category discriminator |
+| `issueType` | string | Issue type discriminator |
+| `hasSeen` | boolean | Whether the feedback has been read |
+| `latestEventHasAttachments` | boolean | Whether the latest event has attachments |
+| `org` | string \| null | Organization slug |
+| `event` | unknown \| null | Latest feedback event |
+| `replayIds` | array | Related Session Replay IDs |
+| `attachments` | array | Attachments on the latest feedback event |
+
+**Examples:**
+
+```bash
+# Most recent unresolved Feedback, with detected or explicit organization
+sentry feedback view @latest
+sentry feedback view my-org/@latest
+
+# Short ID or numeric ID
+sentry feedback view FRONTEND-2SDJ
+sentry feedback view 5146636313
+
+# Explicit organization
+sentry feedback view my-org/FRONTEND-2SDJ
+
+# `view` is the default command; `show` is an alias
+sentry feedback my-org/FRONTEND-2SDJ
+sentry feedback show my-org/FRONTEND-2SDJ
+
+# Open the Feedback item in Sentry
+sentry feedback view my-org/FRONTEND-2SDJ --web
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/info.md
+++ b/.agents/skills/sentry-cli/references/info.md
@@ -1,0 +1,35 @@
+---
+name: sentry-cli-info
+version: 0.44.1
+description: Print configuration and verify authentication
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Info Commands
+
+Print configuration and verify authentication
+
+### `sentry info`
+
+Print configuration and verify authentication
+
+**Flags:**
+- `--config-status-json - Emit configuration + auth status as JSON (for external tooling); always exits 0`
+- `--no-defaults - Verify only authentication, without requiring a default org/project`
+
+**Examples:**
+
+```bash
+# Print the resolved config and verify authentication
+sentry info
+
+# Verify only authentication (don't require a default org/project)
+sentry info --no-defaults
+
+# Machine-readable status for external tooling (always exits 0)
+sentry info --config-status-json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/init.md
+++ b/.agents/skills/sentry-cli/references/init.md
@@ -1,0 +1,54 @@
+---
+name: sentry-cli-init
+version: 0.44.1
+description: Initialize Sentry in your project (experimental)
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Init Commands
+
+Initialize Sentry in your project (experimental)
+
+### `sentry init <target> <directory>`
+
+Initialize Sentry in your project (experimental)
+
+**Flags:**
+- `-y, --yes - Accept non-interactive defaults (requires --features outside a TTY)`
+- `-n, --dry-run - Show what would happen without making changes`
+- `--features <value>... - Features to enable: errors,tracing,logs,replay,metrics,profiling,sourcemaps,crons,attachments,agent-tracing,mcp-observability`
+- `-t, --team <value> - Team slug to create the project under`
+- `--app <value> - App to initialize in a monorepo (required with --yes when multiple apps are detected)`
+- `--tui - Use the Ink-based interactive UI (default). Pass --no-tui to fall back to plain log output.`
+
+**Examples:**
+
+```bash
+# Interactive setup
+sentry init
+
+# Non-interactive agent/CI setup
+sentry init --yes --features errors,tracing,replay
+
+# Dry run to preview changes
+sentry init --dry-run
+
+# Target a subdirectory
+sentry init ./my-app
+
+# Use a specific org (auto-detect project)
+sentry init acme/
+
+# Use a specific org and project
+sentry init acme/my-app
+
+# Assign a team when creating a new project
+sentry init acme/ --team backend
+
+# Enable specific features
+sentry init --features profiling,replay
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/issue.md
+++ b/.agents/skills/sentry-cli/references/issue.md
@@ -1,0 +1,356 @@
+---
+name: sentry-cli-issue
+version: 0.44.1
+description: Manage Sentry issues
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Issue Commands
+
+Manage Sentry issues
+
+### `sentry issue list <org/project>`
+
+List issues in a project
+
+**Flags:**
+- `-q, --query <value> - Search query (Sentry syntax, implicit AND, no OR operator)`
+- `-n, --limit <value> - Maximum number of issues to list - (default: "25")`
+- `-s, --sort <value> - Sort by: recommended, date, new, freq, user (default: recommended on sentry.io, else date)`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "90d")`
+- `-c, --cursor <value> - Pagination cursor (use "next" for next page, "prev" for previous)`
+- `--compact - Single-line rows for compact output (auto-detects if omitted)`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Numeric issue ID |
+| `shortId` | string | Human-readable short ID (e.g. PROJ-ABC) |
+| `title` | string | Issue title |
+| `culprit` | string \| null | Culprit string |
+| `count` | string | Total event count |
+| `userCount` | number | Number of affected users |
+| `firstSeen` | string \| null | First occurrence (ISO 8601) |
+| `lastSeen` | string \| null | Most recent occurrence (ISO 8601) |
+| `level` | string | Severity level |
+| `status` | string | Issue status |
+| `permalink` | string | URL to the issue in Sentry |
+| `project` | object | Project info |
+| `metadata` | object | Issue metadata |
+| `assignedTo` | object \| null | Assigned user or team |
+| `priority` | string | Triage priority |
+| `platform` | string | Platform |
+| `substatus` | string \| null | Issue substatus |
+| `isUnhandled` | boolean | Whether the issue is unhandled |
+| `seerFixabilityScore` | number \| null | Seer AI fixability score (0-1) |
+
+**Examples:**
+
+```bash
+# List issues in a specific project
+sentry issue list my-org/frontend
+
+# All projects in an org
+sentry issue list my-org/
+
+# Search for a project across organizations
+sentry issue list frontend
+
+# Show only unresolved issues
+sentry issue list my-org/frontend --query "is:unresolved"
+
+# Show resolved issues
+sentry issue list my-org/frontend --query "is:resolved"
+
+# Sort by frequency
+sentry issue list my-org/frontend --sort freq --limit 20
+
+# Sort by Sentry's "recommended" relevance ranking (the default on sentry.io;
+# self-hosted instances default to "date" and require a recent Sentry version
+# to accept --sort recommended)
+sentry issue list my-org/frontend --sort recommended
+
+# Multiple filters (space-separated = implicit AND)
+sentry issue list --query "is:unresolved level:error assigned:me"
+
+# Negation and wildcards
+sentry issue list --query "!browser:Chrome message:*timeout*"
+
+# Match multiple values for one key (in-list syntax)
+sentry issue list --query "browser:[Chrome,Firefox]"
+```
+
+### `sentry issue events <issue>`
+
+List events for a specific issue
+
+**Flags:**
+- `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `--full - Include full event body (stacktraces)`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Internal event ID |
+| `event.type` | string | Event type (error, default, transaction) |
+| `groupID` | string \| null | Group (issue) ID |
+| `eventID` | string | UUID-format event ID |
+| `projectID` | string | Project ID |
+| `message` | string | Event message |
+| `title` | string | Event title |
+| `location` | string \| null | Source location (file:line) |
+| `culprit` | string \| null | Culprit function/module |
+| `user` | object \| null | User context |
+| `tags` | array | Event tags |
+| `platform` | string \| null | Platform (python, javascript, etc.) |
+| `dateCreated` | string | ISO 8601 creation timestamp |
+| `crashFile` | string \| null | Crash file URL |
+| `metadata` | object | Event metadata |
+
+**Examples:**
+
+```bash
+# List recent events for an issue
+sentry issue events FRONT-ABC
+
+# Filter events by search query
+sentry issue events FRONT-ABC --query "browser:Chrome"
+
+# Show full event details
+sentry issue events FRONT-ABC --full
+
+# Limit results and filter by time period
+sentry issue events FRONT-ABC --limit 50 --period 24h
+
+# Paginate through results
+sentry issue events FRONT-ABC -c next
+```
+
+### `sentry issue explain <issue>`
+
+Analyze an issue's root cause using Seer AI
+
+**Flags:**
+- `--force - Force new analysis even if one exists`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# View the most recent issue
+sentry issue view @latest
+
+# Explain the most frequently occurring issue
+sentry issue explain @most_frequent
+
+# Generate a fix plan for the latest issue
+sentry issue plan @latest
+
+# Analyze root cause (may take a few minutes for new issues)
+sentry issue explain 123456789
+
+# By short ID with org prefix
+sentry issue explain my-org/MYPROJECT-ABC
+
+# Force a fresh analysis
+sentry issue explain 123456789 --force
+
+# Generate a fix plan (automatically runs explain if needed)
+sentry issue plan 123456789
+
+# Force a fresh plan even if one already exists
+sentry issue plan 123456789 --force
+```
+
+### `sentry issue plan <issue>`
+
+Generate a solution plan using Seer AI
+
+**Flags:**
+- `--force - Force new plan even if one exists`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+### `sentry issue view <issue>`
+
+View details of a specific issue
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `--spans <value> - Span tree depth limit (number, "all" for unlimited, "no" to disable) - (default: "3")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Numeric issue ID |
+| `shortId` | string | Human-readable short ID (e.g. PROJ-ABC) |
+| `title` | string | Issue title |
+| `culprit` | string \| null | Culprit string |
+| `count` | string | Total event count |
+| `userCount` | number | Number of affected users |
+| `firstSeen` | string \| null | First occurrence (ISO 8601) |
+| `lastSeen` | string \| null | Most recent occurrence (ISO 8601) |
+| `level` | string | Severity level |
+| `status` | string | Issue status |
+| `permalink` | string | URL to the issue in Sentry |
+| `project` | object | Project info |
+| `metadata` | object | Issue metadata |
+| `assignedTo` | object \| null | Assigned user or team |
+| `priority` | string | Triage priority |
+| `platform` | string | Platform |
+| `substatus` | string \| null | Issue substatus |
+| `isUnhandled` | boolean | Whether the issue is unhandled |
+| `seerFixabilityScore` | number \| null | Seer AI fixability score (0-1) |
+| `event` | unknown \| null | Latest event for the issue (full detail). Select named fields with `--fields event.id,event.title` to avoid pulling the whole payload; the `request` entry may include live session data. |
+| `org` | string \| null | Organization slug |
+| `replayIds` | array | Related Session Replay IDs |
+| `trace` | object \| null | Trace context from the latest event's span tree |
+
+**Examples:**
+
+```bash
+sentry issue view FRONT-ABC
+
+# Open in browser
+sentry issue view FRONT-ABC -w
+
+# GitHub-style identifiers work too (the "#" replaces the final slash)
+sentry issue view my-org/my-project#FRONT-ABC
+sentry issue view my-project#FRONT-ABC
+
+# Full JSON (issue fields + latest event + trace/replay context)
+sentry issue view FRONT-ABC --json
+
+# Select specific top-level fields to keep output small
+sentry issue view FRONT-ABC --json --fields shortId,title,culprit,count,userCount,permalink
+
+# Pull named fields off the latest event instead of the whole `event` object —
+# the event's `request` entry can include live session data (cookies, headers,
+# body), so extract only what you need
+sentry issue view FRONT-ABC --json --fields event.id,event.title,event.dateCreated
+
+# Issue summary
+sentry issue view FRONT-ABC --json | jq '{shortId, title, count, userCount, permalink}'
+
+# Latest event id + culprit
+sentry issue view FRONT-ABC --json | jq '{event: .event.id, culprit}'
+
+# Just the request URL and method (avoids the full request/session blob)
+sentry issue view FRONT-ABC --json | jq '.event.entries[] | select(.type == "request") | .data | {url, method}'
+
+# Exception type and value from the latest event
+sentry issue view FRONT-ABC --json | jq '.event.entries[] | select(.type == "exception") | .data.values[0] | {type, value}'
+```
+
+### `sentry issue resolve <issue>`
+
+Mark an issue as resolved
+
+**Flags:**
+- `-i, --in <value> - Resolve in a release, next release, or commit ('<version>' | '@next' | '@commit' | '@commit:<repo>@<sha>')`
+
+### `sentry issue unresolve <issue>`
+
+Reopen a resolved issue
+
+**Examples:**
+
+```bash
+# Resolve immediately (no regression tracking)
+sentry issue resolve CLI-G5
+
+# Resolve in a specific release — future events on newer releases are
+# regression-flagged
+sentry issue resolve CLI-G5 --in 0.26.1
+
+# Monorepo-style releases work too (no special parsing)
+sentry issue resolve CLI-G5 --in spotlight@1.2.3
+
+# Resolve in the next release (tied to current HEAD)
+sentry issue resolve CLI-G5 --in @next
+sentry issue resolve CLI-G5 -i @next
+
+# Resolve in the current git HEAD — auto-detects the Sentry repo from
+# your git origin remote (hard-errors if it can't)
+sentry issue resolve CLI-G5 --in @commit
+
+# Explicit commit + repo (no git inspection; repo must be registered in Sentry)
+sentry issue resolve CLI-G5 --in @commit:getsentry/cli@abc123def
+
+# Reopen a resolved issue
+sentry issue unresolve CLI-G5
+sentry issue reopen CLI-G5   # alias
+```
+
+### `sentry issue archive <issue>`
+
+Archive (ignore) an issue
+
+**Flags:**
+- `-u, --until <value> - Condition for unarchival: forever, auto, 30m, 10x, 10u, 10x/5m, etc.`
+
+**Examples:**
+
+```bash
+# Archive forever (fully silenced)
+sentry issue archive CLI-G5
+
+# Smart detection — unarchives when Sentry detects a spike in event frequency
+sentry issue archive CLI-G5 --until auto
+
+# Duration-based
+sentry issue archive CLI-G5 --until 1h    # 1 hour
+sentry issue archive CLI-G5 --until 7d    # 7 days
+sentry issue archive CLI-G5 --until 2026-12-31  # specific date
+
+# Count-based — unarchive after N more events
+sentry issue archive CLI-G5 --until 100x
+
+# User-based — unarchive after N more users affected
+sentry issue archive CLI-G5 --until 10u
+
+# Compound — count within a time window
+sentry issue archive CLI-G5 --until 100x/1h   # 100 events within 1 hour
+sentry issue archive CLI-G5 --until 10u/1d    # 10 users within 1 day
+
+# Verbose forms also work
+sentry issue archive CLI-G5 --until 10events/2hours
+
+# 'ignore' is an alias for 'archive'
+sentry issue ignore CLI-G5 --until auto
+```
+
+### `sentry issue merge <issue...>`
+
+Merge 2+ issues into a single canonical group
+
+**Flags:**
+- `-i, --into <value> - Prefer this issue as the canonical parent (included in the merge if not already listed)`
+
+**Examples:**
+
+```bash
+# Let Sentry auto-pick the parent (typically the largest by event count)
+sentry issue merge CLI-K9 CLI-15H CLI-15N
+
+# Pin the canonical parent explicitly — accepts the same formats as
+# positional args, including org-qualified and project-alias forms
+sentry issue merge CLI-K9 CLI-15H CLI-15N --into CLI-K9
+sentry issue merge my-org/CLI-K9 my-org/CLI-15H --into my-org/CLI-K9
+sentry issue merge cli-k9 cli-15h --into cli-k9    # alias form
+
+# Cross-org merges are rejected — all issues must share an organization
+# Non-error issue types (performance, info, etc.) cannot be merged
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/local.md
+++ b/.agents/skills/sentry-cli/references/local.md
@@ -1,0 +1,63 @@
+---
+name: sentry-cli-local
+version: 0.44.1
+description: Sentry for local development
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Local Commands
+
+Sentry for local development
+
+### `sentry local serve`
+
+Start the local dev server and tail events
+
+**Flags:**
+- `-p, --port <value> - Port to listen on (default 8969) - (default: "8969")`
+- `-H, --host <value> - Hostname to bind to (default localhost) - (default: "localhost")`
+- `-q, --quiet - Suppress per-envelope tail output`
+- `-f, --filter <value>... - Only show items of this type (repeatable: error, transaction, log, ai)`
+- `-F, --format <value> - Output format: human (default) or json (NDJSON) - (default: "human")`
+- `-a, --attributes - Show a grouped attribute table (user vs SDK) under each transaction`
+
+### `sentry local run <command...>`
+
+Run a command with the local dev server enabled
+
+**Flags:**
+- `-p, --port <value> - Port for the local server (default 8969) - (default: "8969")`
+- `--host <value> - Hostname for the local server (default localhost) - (default: "localhost")`
+- `-V, --verify - Verify SDK sends events, then exit`
+- `-t, --timeout <value> - Kill the child after N seconds (0 = no timeout; defaults to 30 s in --verify mode) - (default: "0")`
+
+**Examples:**
+
+```bash
+# Start the server and tail events (default)
+sentry local
+
+# Run your app with the local server auto-enabled
+sentry local run -- npm run dev
+sentry local run -- python manage.py runserver
+
+# Use a custom port
+sentry local --port 9000
+
+# Only show errors and logs (filter out transactions)
+sentry local -f error -f log
+
+# Run quietly (suppress per-envelope tail output)
+sentry local --quiet
+
+sentry local -f error -f log    # only errors and logs
+
+sentry local -f ai          # only AI/agent spans
+sentry local -f ai -f error # agent spans and errors
+
+sentry local --format json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/log.md
+++ b/.agents/skills/sentry-cli/references/log.md
@@ -1,0 +1,84 @@
+---
+name: sentry-cli-log
+version: 0.44.1
+description: View Sentry logs
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Log Commands
+
+View Sentry logs
+
+### `sentry log list <org/project-or-trace-id...>`
+
+List logs from a project
+
+**Flags:**
+- `-n, --limit <value> - Number of log entries (1-1000) - (default: "100")`
+- `-q, --query <value> - Filter query (e.g., "severity:error", "project:backend", "project:[a,b]")`
+- `-f, --follow <value> - Stream logs (optionally specify poll interval in seconds)`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01"`
+- `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
+- `--fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sentry.item_id` | string | Unique log entry ID |
+| `timestamp` | string | Log timestamp (ISO 8601) |
+| `timestamp_precise` | number | Nanosecond-precision timestamp |
+| `message` | string \| null | Log message |
+| `severity` | string \| null | Severity level (error, warning, info, debug) |
+| `trace` | string \| null | Trace ID for correlation |
+
+**Examples:**
+
+```bash
+# List last 100 logs (default)
+sentry log list
+
+# Show only error logs
+sentry log list -q 'severity:error'
+
+# Filter by message content
+sentry log list -q 'database'
+
+# Limit results
+sentry log list --limit 50
+
+# Stream with default 2-second poll interval
+sentry log list -f
+
+# Stream with custom 5-second poll interval
+sentry log list -f 5
+
+# Stream error logs from a specific project
+sentry log list my-org/backend -f -q 'severity:error'
+
+sentry log list --json | jq '.data[] | select(.severity == "error")'
+```
+
+### `sentry log view <org/project/log-id...>`
+
+View details of one or more log entries
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+sentry log view 968c763c740cfda8b6728f27fb9e9b01
+
+# With explicit project
+sentry log view my-org/backend 968c763c740cfda8b6728f27fb9e9b01
+
+# Open in browser
+sentry log view 968c763c740cfda8b6728f27fb9e9b01 -w
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/monitor.md
+++ b/.agents/skills/sentry-cli/references/monitor.md
@@ -1,0 +1,73 @@
+---
+name: sentry-cli-monitor
+version: 0.44.1
+description: Work with Sentry cron monitors
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Monitor Commands
+
+Work with Sentry cron monitors
+
+### `sentry monitor run <monitor-slug command...>`
+
+Wrap a command with cron monitor check-ins
+
+**Flags:**
+- `--dsn <value> - DSN to send check-ins to (overrides SENTRY_DSN env var)`
+- `-e, --environment <value> - Environment of the monitor - (default: "production")`
+- `-s, --schedule <value> - Upsert the monitor with this crontab schedule (e.g. '0 * * * *')`
+- `--check-in-margin <value> - Minutes after the expected check-in before it is missed (requires --schedule)`
+- `--max-runtime <value> - Minutes a check-in may run before timing out (requires --schedule)`
+- `--timezone <value> - Timezone of the schedule, tz database string (requires --schedule)`
+- `--failure-issue-threshold <value> - Consecutive failures before an issue is created (requires --schedule)`
+- `--recovery-threshold <value> - Consecutive successes before an issue is resolved (requires --schedule)`
+
+### `sentry monitor list <org/project>`
+
+List cron monitors
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of monitors to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Monitor ID |
+| `slug` | string | Monitor slug |
+| `name` | string | Monitor name |
+| `status` | string | Monitor status (e.g. active, disabled) |
+| `isMuted` | boolean | Whether the monitor is muted |
+| `config` | object | Schedule configuration |
+| `dateCreated` | string | Creation date (ISO 8601) |
+| `project` | object | Owning project |
+
+**Examples:**
+
+```bash
+# Wrap a command with cron monitor check-ins (DSN-based)
+SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0 \
+  sentry monitor run nightly-job -- python manage.py cron
+
+# The -- separator is optional when the command has no flags
+sentry monitor run nightly-job npm run task
+
+# Create/update the monitor on the first check-in via --schedule (crontab)
+sentry monitor run nightly-job -s "0 0 * * *" --max-runtime 30 --timezone UTC -- ./backup.sh
+
+# List cron monitors in an org
+sentry monitor list my-org/
+
+# Paginate through monitors
+sentry monitor list my-org/ -c next
+
+# Output as JSON
+sentry monitor list --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/org.md
+++ b/.agents/skills/sentry-cli/references/org.md
@@ -1,0 +1,46 @@
+---
+name: sentry-cli-org
+version: 0.44.1
+description: Work with Sentry organizations
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Org Commands
+
+Work with Sentry organizations
+
+### `sentry org list`
+
+List organizations
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of organizations to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+### `sentry org view <org>`
+
+View details of an organization
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# List organizations
+sentry org list
+
+# View organization details
+sentry org view my-org
+
+# Open in browser
+sentry org view my-org -w
+
+# JSON output
+sentry org list --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/platform.md
+++ b/.agents/skills/sentry-cli/references/platform.md
@@ -1,0 +1,37 @@
+---
+name: sentry-cli-platform
+version: 0.44.1
+description: List valid Sentry platform identifiers
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Platform Commands
+
+List valid Sentry platform identifiers
+
+### `sentry platform list`
+
+List all valid Sentry platform identifiers
+
+**Flags:**
+- `-q, --search <value> - Filter platforms by substring`
+
+**Examples:**
+
+```bash
+# List all valid Sentry platform identifiers
+sentry platform list
+
+# Filter by substring
+sentry platform list --search python
+
+# Shortcut for `sentry platform list`
+sentry platforms
+
+# Output as JSON
+sentry platform list --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/proguard.md
+++ b/.agents/skills/sentry-cli/references/proguard.md
@@ -1,0 +1,37 @@
+---
+name: sentry-cli-proguard
+version: 0.44.1
+description: Work with ProGuard/R8 mapping files
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Proguard Commands
+
+Work with ProGuard/R8 mapping files
+
+### `sentry proguard upload <path...>`
+
+Upload ProGuard/R8 mapping files to Sentry
+
+**Flags:**
+- `--uuid <value> - Force a specific UUID instead of computing from file content (only valid with a single file)`
+- `--no-upload - Compute and print UUIDs without uploading (dry-run)`
+- `--require-one - Require at least one mapping file (error if none provided)`
+
+### `sentry proguard uuid <path>`
+
+Compute the UUID for a ProGuard mapping file
+
+**Examples:**
+
+```bash
+# Compute the UUID for a ProGuard/R8 mapping file
+sentry proguard uuid ./app/build/outputs/mapping/release/mapping.txt
+
+# Output as JSON (includes the file path)
+sentry proguard uuid mapping.txt --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/project.md
+++ b/.agents/skills/sentry-cli/references/project.md
@@ -1,0 +1,92 @@
+---
+name: sentry-cli-project
+version: 0.44.1
+description: Work with Sentry projects
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Project Commands
+
+Work with Sentry projects
+
+### `sentry project create [<org>/]<name>:<platform>...`
+
+Create one or more projects
+
+**Flags:**
+- `-t, --team <value> - Team to create the project under`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Every project is a name:platform pair; project names cannot contain whitespace
+# Create a new project
+sentry project create my-new-app:javascript-nextjs
+
+# Create several projects with their own platforms
+sentry project create web:javascript api:python-django worker:node
+
+# Create under a specific org and team
+sentry project create my-org/my-new-app:python --team backend-team
+
+# Preview without creating
+sentry project create my-new-app:node --dry-run
+```
+
+### `sentry project delete <org/project>`
+
+Delete a project
+
+**Flags:**
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Delete a project (will prompt for confirmation)
+sentry project delete my-org/old-project
+
+# Delete without confirmation
+sentry project delete my-org/old-project --yes
+```
+
+### `sentry project list <org/project>`
+
+List projects
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of projects to list - (default: "25")`
+- `-p, --platform <value> - Filter by platform (e.g., javascript, python)`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+### `sentry project view <org/project>`
+
+View details of a project
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# List all projects in an org
+sentry project list my-org/
+
+# Filter by platform
+sentry project list my-org/ --platform javascript
+
+# View project details
+sentry project view my-org/frontend
+
+# Open project in browser
+sentry project view my-org/frontend -w
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/react-native.md
+++ b/.agents/skills/sentry-cli/references/react-native.md
@@ -1,0 +1,60 @@
+---
+name: sentry-cli-react-native
+version: 0.44.1
+description: Upload React Native sourcemaps from build steps
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# React-native Commands
+
+Upload React Native sourcemaps from build steps
+
+### `sentry react-native gradle`
+
+Upload a React Native bundle + sourcemap (Gradle build step)
+
+**Flags:**
+- `--sourcemap <value> - Path to the sourcemap to upload`
+- `--bundle <value> - Path to the bundle to upload`
+- `--release <value> - Release version to publish to`
+- `--dist <value>... - Distribution(s) to publish (repeatable; requires --release)`
+- `--wait - Wait for the server to fully process the uploaded files`
+- `--wait-for <value> - Wait for processing, but at most this many seconds`
+
+### `sentry react-native xcode <script-arg...>`
+
+Upload React Native sourcemaps (Xcode build step)
+
+**Flags:**
+- `-f, --force - Run even in a debug configuration`
+- `--allow-fetch - Fetch sourcemaps from the packager on simulator builds`
+- `--fetch-from <value> - Packager URL to fetch from (default: http://127.0.0.1:8081/)`
+- `--build-script <value> - Path to the react-native-xcode.sh build script`
+- `--dist <value>... - Distribution(s) to publish (repeatable)`
+- `--wait - Wait for the server to fully process the uploaded files`
+- `--wait-for <value> - Wait for processing, but at most this many seconds`
+- `--no-auto-release - Don't read the release from Xcode project files`
+- `--allow-xcode-infoplist-preprocessing - Run the C preprocessor over Info.plist (INFOPLIST_PREPROCESS)`
+
+**Examples:**
+
+```bash
+# Upload a bundle + sourcemap by debug ID (called by the Gradle plugin)
+sentry react-native gradle \
+  --bundle index.android.bundle \
+  --sourcemap index.android.bundle.map
+
+# Also associate with a release and distribution(s)
+sentry react-native gradle \
+  --bundle index.android.bundle \
+  --sourcemap index.android.bundle.map \
+  --release com.example.app@1.0.0 \
+  --dist 1000
+
+# Xcode build phase (usually added automatically to your build script)
+../node_modules/.bin/sentry-cli react-native xcode
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/release.md
+++ b/.agents/skills/sentry-cli/references/release.md
@@ -1,0 +1,168 @@
+---
+name: sentry-cli-release
+version: 0.44.1
+description: Work with Sentry releases
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Release Commands
+
+Work with Sentry releases
+
+### `sentry release list <org/project>`
+
+List releases with adoption and health metrics
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of releases to list - (default: "25")`
+- `-s, --sort <value> - Sort: date, sessions, users, crash_free_sessions (cfs), crash_free_users (cfu) - (default: "date")`
+- `-e, --environment <value>... - Filter by environment (repeatable, comma-separated)`
+- `-t, --period <value> - Health stats period (e.g., 24h, 7d, 14d, 90d) - (default: "90d")`
+- `--status <value> - Filter by status: open (default) or archived - (default: "open")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+### `sentry release view <org/version>`
+
+View release details with health metrics
+
+**Flags:**
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+### `sentry release create <org/version>`
+
+Create a release
+
+**Flags:**
+- `-p, --project <value> - Associate with project(s), comma-separated`
+- `--finalize - Immediately finalize the release (set dateReleased)`
+- `--ref <value> - Git ref (branch or tag name)`
+- `--url <value> - URL to the release source`
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release finalize <org/version>`
+
+Finalize a release
+
+**Flags:**
+- `--released <value> - Custom release timestamp (ISO 8601). Defaults to now.`
+- `--url <value> - URL for the release`
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release delete <org/version>`
+
+Delete a release
+
+**Flags:**
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release archive <org/version>`
+
+Archive a release
+
+**Flags:**
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release restore <org/version>`
+
+Restore an archived release
+
+**Flags:**
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release deploy <org/version> <environment> <name>`
+
+Create a deploy for a release
+
+**Flags:**
+- `--url <value> - URL for the deploy`
+- `--started <value> - Deploy start time (ISO 8601)`
+- `--finished <value> - Deploy finish time (ISO 8601)`
+- `-t, --time <value> - Deploy duration in seconds (sets started = now - time, finished = now)`
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release deploys <org/version>`
+
+List deploys for a release
+
+### `sentry release set-commits <org/version>`
+
+Set commits for a release
+
+**Flags:**
+- `--auto - Auto-discover commits via repository integration (needs local git checkout)`
+- `--local - Read commits from local git history`
+- `--clear - Clear all commits from the release`
+- `--commit <value> - Explicit commit as REPO@SHA or REPO@PREV..SHA (comma-separated)`
+- `--path <value> - Filter commits to these paths (comma-separated). Implies --local.`
+- `--from <value> - Read the local range <ref>..HEAD (e.g. previous release tag). Implies --local.`
+- `--initial-depth <value> - Number of commits to read with --local - (default: "20")`
+
+### `sentry release propose-version`
+
+Propose a release version
+
+**Examples:**
+
+```bash
+# List releases (auto-detect org)
+sentry release list
+
+# List releases in a specific org
+sentry release list my-org/
+
+# View release details
+sentry release view 1.0.0
+sentry release view my-org/1.0.0
+
+# Create and finalize a release
+sentry release create 1.0.0 --finalize
+
+# Create a release, then finalize separately
+sentry release create 1.0.0
+sentry release set-commits 1.0.0 --auto
+sentry release finalize 1.0.0
+
+# Set commits from local git history
+sentry release set-commits 1.0.0 --local
+
+# Create a deploy
+sentry release deploy 1.0.0 production
+sentry release deploy 1.0.0 staging "Deploy #42"
+
+# Propose a version from git HEAD
+sentry release create $(sentry release propose-version)
+
+# List deploys for a release
+sentry release deploys 1.0.0
+sentry release deploys my-org/1.0.0
+
+# Archive a release (hide it from the default list, but keep it)
+sentry release archive 1.0.0
+sentry release archive my-org/1.0.0 --dry-run   # Preview without archiving
+
+# Restore a previously archived release
+sentry release restore 1.0.0
+sentry release restore my-org/1.0.0
+
+# Delete a release
+sentry release delete my-org/1.0.0
+sentry release delete my-org/1.0.0 --yes        # Skip confirmation
+sentry release delete my-org/1.0.0 --dry-run    # Preview without deleting
+
+# Output as JSON
+sentry release list --json
+sentry release view 1.0.0 --json
+
+# Full release workflow with explicit org
+sentry release create my-org/1.0.0 --project my-project
+sentry release set-commits my-org/1.0.0 --auto
+sentry release finalize my-org/1.0.0
+sentry release deploy my-org/1.0.0 production
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/replay.md
+++ b/.agents/skills/sentry-cli/references/replay.md
@@ -1,0 +1,148 @@
+---
+name: sentry-cli-replay
+version: 0.44.1
+description: Search and inspect Session Replays
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Replay Commands
+
+Search and inspect Session Replays
+
+### `sentry replay list <org/project>`
+
+List recent Session Replays
+
+**Flags:**
+- `-n, --limit <value> - Number of replays (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query (Sentry replay search syntax)`
+- `-e, --environment <value>... - Filter by environment (repeatable, comma-separated)`
+- `-s, --sort <value> - Sort by: date, oldest, duration, errors, activity, or a raw replay sort field - (default: "date")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `activity` | number \| null | Replay activity score |
+| `browser` | object \| null | Browser metadata |
+| `count_dead_clicks` | number \| null | Dead click count |
+| `count_errors` | number \| null | Associated error count |
+| `count_infos` | number \| null | Info event count |
+| `count_rage_clicks` | number \| null | Rage click count |
+| `count_segments` | number \| null | Recording segment count |
+| `count_urls` | number \| null | Visited URL count |
+| `count_warnings` | number \| null | Warning event count |
+| `device` | object \| null | Device metadata |
+| `dist` | string \| null | Distribution |
+| `duration` | number \| null | Replay duration in seconds |
+| `environment` | string \| null | Environment |
+| `error_ids` | array | Linked error IDs |
+| `finished_at` | string \| null | Replay finish timestamp |
+| `has_viewed` | boolean \| null | Whether the current user has viewed the replay |
+| `id` | string | Replay ID |
+| `info_ids` | array | Linked info event IDs |
+| `is_archived` | boolean \| null | Archived flag |
+| `os` | object \| null | Operating system metadata |
+| `ota_updates` | object \| null | OTA update metadata |
+| `platform` | string \| null | Platform |
+| `project_id` | string \| null | Numeric project ID |
+| `releases` | array | Associated releases |
+| `sdk` | object \| null | SDK metadata |
+| `started_at` | string \| null | Replay start timestamp |
+| `tags` | object | Replay tags |
+| `trace_ids` | array | Linked trace IDs |
+| `urls` | array | Visited URLs |
+| `user` | object \| null | User metadata |
+| `warning_ids` | array | Linked warning event IDs |
+
+**Examples:**
+
+```bash
+# List recent replays for a project
+sentry replay list my-org/frontend
+
+# Search across all projects in an org
+sentry replay list my-org/ --query "environment:production"
+
+# Change the time window and sort
+sentry replay list my-org/frontend --period 24h --sort errors
+
+# Paginate through results
+sentry replay list my-org/frontend -c next
+sentry replay list my-org/frontend -c prev
+
+# Output machine-readable data
+sentry replay list my-org/frontend --json
+```
+
+### `sentry replay view <replay-id-or-url...>`
+
+View a Session Replay
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `activity` | array | Summarized replay activity |
+| `browser` | object \| null | Browser metadata |
+| `count_dead_clicks` | number \| null | Dead click count |
+| `count_errors` | number \| null | Associated error count |
+| `count_infos` | number \| null | Info event count |
+| `count_rage_clicks` | number \| null | Rage click count |
+| `count_segments` | number \| null | Recording segment count |
+| `count_urls` | number \| null | Visited URL count |
+| `count_warnings` | number \| null | Warning event count |
+| `device` | object \| null | Device metadata |
+| `dist` | string \| null | Distribution |
+| `duration` | number \| null | Replay duration in seconds |
+| `environment` | string \| null | Environment |
+| `error_ids` | array | Linked error IDs |
+| `finished_at` | string \| null | Replay finish timestamp |
+| `has_viewed` | boolean \| null | Whether the current user has viewed the replay |
+| `id` | string | Replay ID |
+| `info_ids` | array | Linked info event IDs |
+| `is_archived` | boolean \| null | Archived flag |
+| `os` | object \| null | Operating system metadata |
+| `ota_updates` | object \| null | OTA update metadata |
+| `platform` | string \| null | Platform |
+| `project_id` | string \| null | Numeric project ID |
+| `releases` | array | Associated releases |
+| `sdk` | object \| null | SDK metadata |
+| `started_at` | string \| null | Replay start timestamp |
+| `tags` | object | Replay tags |
+| `trace_ids` | array | Linked trace IDs |
+| `urls` | array | Visited URLs |
+| `user` | object \| null | User metadata |
+| `warning_ids` | array | Linked warning event IDs |
+| `clicks` | array | Replay click summaries |
+| `replay_type` | string \| null | Replay type |
+| `org` | string | Organization slug |
+| `relatedIssues` | array | Replay-related issues |
+| `relatedTraces` | array | Replay-related traces |
+
+**Examples:**
+
+```bash
+# View a replay by ID using auto-detected org/project context
+sentry replay view 346789a703f6454384f1de473b8b9fcc
+
+# View a replay with an explicit org
+sentry replay view my-org/346789a703f6454384f1de473b8b9fcc
+
+# View a replay with explicit org/project context
+sentry replay view my-org/frontend/346789a703f6454384f1de473b8b9fcc
+
+# Open a replay in the browser
+sentry replay view my-org/346789a703f6454384f1de473b8b9fcc --web
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/repo.md
+++ b/.agents/skills/sentry-cli/references/repo.md
@@ -1,0 +1,50 @@
+---
+name: sentry-cli-repo
+version: 0.44.1
+description: Work with Sentry repositories
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Repo Commands
+
+Work with Sentry repositories
+
+### `sentry repo list <org/project>`
+
+List repositories
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of repositories to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Repository ID |
+| `name` | string | Repository name |
+| `url` | string \| null | Repository URL |
+| `provider` | object | Version control provider |
+| `status` | string | Integration status |
+| `dateCreated` | string | Creation date (ISO 8601) |
+| `integrationId` | string | Integration ID |
+| `externalSlug` | string \| null | External slug (e.g. org/repo) |
+| `externalId` | string \| null | External ID |
+
+**Examples:**
+
+```bash
+# List repositories (auto-detect org)
+sentry repo list
+
+# List repos in a specific org with pagination
+sentry repo list my-org/ -c next
+
+# Output as JSON
+sentry repo list --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/schema.md
+++ b/.agents/skills/sentry-cli/references/schema.md
@@ -1,0 +1,41 @@
+---
+name: sentry-cli-schema
+version: 0.44.1
+description: Browse the Sentry API schema
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Schema Commands
+
+Browse the Sentry API schema
+
+### `sentry schema <resource...>`
+
+Browse the Sentry API schema
+
+**Flags:**
+- `--all - Show all endpoints in a flat list`
+- `-q, --search <value> - Search endpoints by keyword`
+
+**Examples:**
+
+```bash
+# List all API resources
+sentry schema
+
+# Browse issue endpoints
+sentry schema issues
+
+# View details for a specific operation
+sentry schema issues list
+
+# Search for monitoring-related endpoints
+sentry schema --search monitor
+
+# Flat list of every endpoint
+sentry schema --all
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/snapshots.md
+++ b/.agents/skills/sentry-cli/references/snapshots.md
@@ -1,0 +1,84 @@
+---
+name: sentry-cli-snapshots
+version: 0.44.1
+description: Manage and compare snapshots
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Snapshots Commands
+
+Manage and compare snapshots
+
+### `sentry snapshots diff <base-dir> <head-dir>`
+
+Compare two directories of snapshot images
+
+**Flags:**
+- `-o, --output <value> - Directory for diff mask images (default: ./diff-output/)`
+- `--threshold <value> - Pixel color difference threshold (0.0-1.0) - (default: "0.01")`
+- `--no-antialiasing - Disable antialiasing detection`
+- `--fail-on-diff - Exit non-zero if any diffs (changed/added/removed/errored) are found`
+- `--selective - Treat images missing from head as skipped instead of removed`
+
+### `sentry snapshots download`
+
+Download baseline snapshot images
+
+**Flags:**
+- `--app-id <value> - App identifier (e.g. my-app) to resolve the latest baseline; mutually exclusive with --snapshot-id`
+- `--snapshot-id <value> - Direct snapshot artifact ID; mutually exclusive with --app-id`
+- `--branch <value> - Git branch filter (only with --app-id)`
+- `-o, --output <value> - Directory for extracted images (default: ./snapshots-base/)`
+
+### `sentry snapshots upload <path>`
+
+Upload snapshots to a project
+
+**Flags:**
+- `--app-id <value> - The application identifier`
+- `--diff-threshold <value> - Only report an image as changed when its difference exceeds this fraction (0.0–1.0, e.g. 0.01 = 1%)`
+- `--selective - This upload contains only a subset of images (removals/renames won't be detected on PRs)`
+- `--all-image-file-names <value> - Comma-separated list of all image names in the full suite (for selective uploads; implies --selective)`
+- `--all-image-file-names-file <value> - Path to a file listing all image names, one per line (for selective uploads; implies --selective)`
+- `--head-sha <value> - VCS commit SHA (defaults to the current commit)`
+- `--base-sha <value> - VCS base commit SHA (defaults to the merge-base with the base ref)`
+- `--vcs-provider <value> - VCS provider (defaults to the current remote's provider)`
+- `--head-repo-name <value> - Head repository name, e.g. owner/repo (defaults to the current)`
+- `--base-repo-name <value> - Base repository name, e.g. owner/repo (for forks)`
+- `--head-ref <value> - Head branch/reference (defaults to the current branch)`
+- `--base-ref <value> - Base branch/reference (defaults to the merge-base tracking ref)`
+- `--pr-number <value> - Pull request number (auto-detected in pull_request GitHub Actions runs)`
+- `--force-git-metadata - Force collecting git metadata even outside CI (conflicts with --no-git-metadata)`
+- `--no-git-metadata - Disable automatic git metadata collection`
+
+**Examples:**
+
+```bash
+# Upload a folder of screenshots as a snapshot for an app
+sentry snapshots upload ./screenshots --app-id com.example.app
+
+# Upload only a subset of images (removals/renames not inferred on PRs)
+sentry snapshots upload ./screenshots --app-id my-app --selective
+
+# Only flag images that differ by more than 1%
+sentry snapshots upload ./screenshots --app-id my-app --diff-threshold 0.01
+
+# Compare two directories of snapshot images locally
+sentry snapshots diff ./baseline ./head
+
+# Fail (non-zero exit) if any images changed, with a custom threshold
+sentry snapshots diff ./baseline ./head --fail-on-diff --threshold 0.02
+
+# Download a specific baseline snapshot by ID
+sentry snapshots download --snapshot-id 1234567890
+
+# Download the latest baseline for an app, filtered by branch
+sentry snapshots download --app-id my-app --branch main
+
+# Extract images to a specific directory
+sentry snapshots download --app-id my-app --output ./baseline/
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/sourcemap.md
+++ b/.agents/skills/sentry-cli/references/sourcemap.md
@@ -1,0 +1,89 @@
+---
+name: sentry-cli-sourcemap
+version: 0.44.1
+description: Manage sourcemaps
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Sourcemap Commands
+
+Manage sourcemaps
+
+### `sentry sourcemap inject <directory>`
+
+Inject debug IDs into JavaScript files and sourcemaps
+
+**Flags:**
+- `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
+- `--ignore <value> - Comma-separated glob patterns to exclude (gitignore-style)`
+- `--ignore-file <value> - Path to a file with gitignore-style patterns to exclude`
+- `--dry-run - Show what would be modified without writing`
+- `--allow-empty - Exit successfully when no JS + sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
+
+**Examples:**
+
+```bash
+# Inject debug IDs into all JS files in dist/
+sentry sourcemap inject ./dist
+
+# Preview changes without writing
+sentry sourcemap inject ./dist --dry-run
+
+# Only process specific extensions
+sentry sourcemap inject ./build --ext .js,.mjs
+```
+
+### `sentry sourcemap upload <directory>`
+
+Upload sourcemaps to Sentry
+
+**Flags:**
+- `--release <value> - Release version to associate with the upload`
+- `--dist <value> - Distribution identifier to disambiguate builds within a release`
+- `--url-prefix <value> - URL prefix for uploaded files (default: ~/) - (default: "~/")`
+- `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
+- `--ignore <value> - Comma-separated glob patterns to exclude (gitignore-style)`
+- `--ignore-file <value> - Path to a file with gitignore-style patterns to exclude`
+- `--strip-prefix <value> - Strip a prefix from uploaded file paths (e.g. 'build/')`
+- `--strip-common-prefix - Automatically strip the longest common path prefix from all files`
+- `--no-rewrite - Upload files as-is without injecting debug IDs`
+- `--allow-empty - Exit successfully when no JS + sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
+
+**Examples:**
+
+```bash
+# Upload sourcemaps from dist/
+sentry sourcemap upload ./dist
+
+# Associate with a release
+sentry sourcemap upload ./dist --release 1.0.0
+
+# Set a custom URL prefix
+sentry sourcemap upload ./dist --url-prefix '~/static/js/'
+
+sentry sourcemap upload ./dist --allow-empty
+```
+
+### `sentry sourcemap resolve <directory>`
+
+Resolve and report sourcemap linkage for JavaScript files
+
+**Flags:**
+- `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
+- `--ignore <value> - Comma-separated glob patterns to exclude (gitignore-style)`
+- `--ignore-file <value> - Path to a file with gitignore-style patterns to exclude`
+
+**Examples:**
+
+```bash
+# Report how each JS file's sourcemap resolves and whether a debug ID
+# has been injected (read-only — never modifies files)
+sentry sourcemap resolve ./dist
+
+# Machine-readable output
+sentry sourcemap resolve ./dist --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/span.md
+++ b/.agents/skills/sentry-cli/references/span.md
@@ -1,0 +1,89 @@
+---
+name: sentry-cli-span
+version: 0.44.1
+description: List and view spans in projects or traces
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Span Commands
+
+List and view spans in projects or traces
+
+### `sentry span list <org/project/trace-id...>`
+
+List spans in a project or trace
+
+**Flags:**
+- `-n, --limit <value> - Number of spans (<=1000) - (default: "25")`
+- `-q, --query <value> - Filter spans (e.g., "op:db", "project:backend", "project:[cli,api]")`
+- `-s, --sort <value> - Sort order: date, duration - (default: "date")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Span ID |
+| `parent_span` | string \| null | Parent span ID |
+| `span.op` | string \| null | Span operation (e.g. http.client, db) |
+| `description` | string \| null | Span description |
+| `span.duration` | number \| null | Duration (ms) |
+| `timestamp` | string | Timestamp (ISO 8601) |
+| `project` | string | Project slug |
+| `transaction` | string \| null | Transaction name |
+| `trace` | string | Trace ID |
+
+**Examples:**
+
+```bash
+# List recent spans in the current project
+sentry span list
+
+# Find all DB spans
+sentry span list -q "op:db"
+
+# Slow spans in the last 24 hours
+sentry span list -q "duration:>100ms" --period 24h
+
+# List spans within a specific trace
+sentry span list abc123def456abc123def456abc12345
+
+# Paginate through results
+sentry span list -c next
+
+# Show only spans from one project within a trace
+sentry span list my-org/cli-server/abc123def456abc123def456abc12345
+
+# Or use --query to filter by project
+sentry span list abc123def456abc123def456abc12345 -q "project:cli-server"
+
+# Multiple projects at once
+sentry span list abc123def456abc123def456abc12345 -q "project:[cli-server,api]"
+```
+
+### `sentry span view <trace-id/span-id...>`
+
+View details of specific spans
+
+**Flags:**
+- `--spans <value> - Span tree depth limit (number, "all" for unlimited, "no" to disable) - (default: "3")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# View a single span
+sentry span view abc123def456abc123def456abc12345 a1b2c3d4e5f67890
+
+# View multiple spans at once
+sentry span view abc123def456abc123def456abc12345 a1b2c3d4e5f67890 b2c3d4e5f6789012
+
+# With explicit org/project
+sentry span view my-org/backend/abc123def456abc123def456abc12345 a1b2c3d4e5f67890
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/team.md
+++ b/.agents/skills/sentry-cli/references/team.md
@@ -1,0 +1,48 @@
+---
+name: sentry-cli-team
+version: 0.44.1
+description: Work with Sentry teams
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Team Commands
+
+Work with Sentry teams
+
+### `sentry team list <org/project>`
+
+List teams
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of teams to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Team ID |
+| `slug` | string | Team slug |
+| `name` | string | Team name |
+| `dateCreated` | string \| null | Creation date (ISO 8601) |
+| `isMember` | boolean | Whether you are a member |
+| `teamRole` | string \| null | Your role in the team |
+| `memberCount` | number | Number of members |
+
+**Examples:**
+
+```bash
+# List teams
+sentry team list my-org/
+
+# Paginate through teams
+sentry team list my-org/ -c next
+
+# Output as JSON
+sentry team list --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/trace.md
+++ b/.agents/skills/sentry-cli/references/trace.md
@@ -1,0 +1,113 @@
+---
+name: sentry-cli-trace
+version: 0.44.1
+description: View distributed traces
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Trace Commands
+
+View distributed traces
+
+### `sentry trace list <org/project>`
+
+List recent traces in a project
+
+**Flags:**
+- `-n, --limit <value> - Number of traces (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `-s, --sort <value> - Sort by: date, duration - (default: "date")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trace` | string | Trace ID |
+| `id` | string | Event ID |
+| `transaction` | string | Transaction name |
+| `timestamp` | string | Timestamp (ISO 8601) |
+| `transaction.duration` | number | Duration (ms) |
+| `project` | string | Project slug |
+
+**Examples:**
+
+```bash
+# List last 20 traces (default)
+sentry trace list
+
+# Sort by slowest first
+sentry trace list --sort duration
+
+# Filter by transaction name, last 24 hours
+sentry trace list -q "transaction:GET /api/users" --period 24h
+
+# Paginate through results
+sentry trace list my-org/backend -c next
+```
+
+### `sentry trace view <org/project/trace-id...>`
+
+View details of a specific trace
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `--full - Fetch full span attributes (auto-enabled with --json)`
+- `--spans <value> - Span tree depth limit (number, "all" for unlimited, "no" to disable) - (default: "3")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# View trace details with span tree
+sentry trace view abc123def456abc123def456abc12345
+
+# Open trace in browser
+sentry trace view abc123def456abc123def456abc12345 -w
+
+# Auto-recover from an issue short ID
+sentry trace view PROJ-123
+
+# Filter trace view to one project's spans
+sentry trace view my-org/cli-server/abc123def456abc123def456abc12345
+
+# Full trace across all projects (default)
+sentry trace view my-org/abc123def456abc123def456abc12345
+
+# Filter trace logs by project
+sentry trace logs my-org/cli-server/abc123def456abc123def456abc12345
+
+# Multiple projects via --query
+sentry trace logs abc123def456abc123def456abc12345 -q "project:[cli-server,api]"
+```
+
+### `sentry trace logs <org/project/trace-id...>`
+
+View logs associated with a trace
+
+**Flags:**
+- `-w, --web - Open trace in browser`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "14d")`
+- `-n, --limit <value> - Number of log entries (<=1000) - (default: "100")`
+- `-q, --query <value> - Filter query (e.g., "severity:error", "project:backend", "project:[a,b]")`
+- `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# View logs for a trace
+sentry trace logs abc123def456abc123def456abc12345
+
+# Search with a longer time window
+sentry trace logs --period 30d abc123def456abc123def456abc12345
+
+# Filter logs within a trace
+sentry trace logs -q 'severity:error' abc123def456abc123def456abc12345
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.agents/skills/sentry-cli/references/trial.md
+++ b/.agents/skills/sentry-cli/references/trial.md
@@ -1,0 +1,52 @@
+---
+name: sentry-cli-trial
+version: 0.44.1
+description: Manage product trials
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Trial Commands
+
+Manage product trials
+
+### `sentry trial list <org>`
+
+List product trials
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category` | string | Trial category (e.g. seerUsers, seerAutofix) |
+| `startDate` | string \| null | Start date (ISO 8601) |
+| `endDate` | string \| null | End date (ISO 8601) |
+| `reasonCode` | number | Reason code |
+| `isStarted` | boolean | Whether the trial has started |
+| `lengthDays` | number \| null | Trial duration in days |
+
+### `sentry trial start <name> <org>`
+
+Start a product trial
+
+**Examples:**
+
+```bash
+# List all trials for the current org
+sentry trial list
+
+# List trials for a specific org
+sentry trial list my-org
+
+# Start a Seer trial
+sentry trial start seer
+
+# Start a trial for a specific org
+sentry trial start replays my-org
+
+# Start a Business plan trial (opens browser)
+sentry trial start plan
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli
+++ b/.claude/skills/sentry-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/sentry-cli

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -414,6 +414,13 @@
       "skillPath": "skills/misc/scaffold-exercises/SKILL.md",
       "computedHash": "354c91f6dbc9b058632f30594aacb4edc6d25012596585abb00402af8d7ec5e9"
     },
+    "sentry-cli": {
+      "source": "cli.sentry.dev",
+      "sourceUrl": "https://cli.sentry.dev",
+      "sourceType": "well-known",
+      "computedHash": "82ab12258160dbe8f8c75aaac945cf750f34d49bedd942fa753b617d94aecd66",
+      "wellKnownDigest": "sha256:f0e5c3fdf1cfe71cefcdff90fd9bc5ab37e0a5f92692ee8579bfbfac275100a0"
+    },
     "setup-matt-pocock-skills": {
       "source": "mattpocock/skills",
       "sourceType": "github",


### PR DESCRIPTION
Installs the Sentry CLI agent skill (v0.44.1) from https://cli.sentry.dev via `npx skills add`.

- Adds `.agents/skills/sentry-cli/` (SKILL.md + references)
- Adds `.claude/skills/sentry-cli` symlink (matches existing convention)
- Registers `sentry-cli` in `skills-lock.json`

Verification: skill loads via project skill catalog; precommit (`pnpm check && pnpm typecheck`) passed on commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for using the Sentry CLI, including setup, authentication, configuration, safety practices, output formats, and troubleshooting.
  - Documented workflows for issues, events, traces, logs, alerts, dashboards, releases, projects, teams, repositories, feedback, replays, monitors, and trials.
  - Added coverage for source maps, debug files, symbol maps, mobile builds, snapshots, code mappings, API access, schema exploration, and local capture.
  - Added command examples, supported options, JSON fields, filtering, pagination, and dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->