### PR TITLE
feat(web): support public PKCE OAuth clients in developer wizard

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4381,7 +4381,9 @@
           "includeCoreApiLabel": "Sokosumi-API-Zugriff erlauben",
           "includeCoreApiHelp": "Deaktiviert (Standard): nur Identität (openid / userinfo). Aktiviert: zusätzlich Aufruf der Core-API als Nutzer (sokosumi:api).",
           "includeOfflineAccessLabel": "Refresh-Tokens erlauben",
-          "includeOfflineAccessHelp": "Deaktiviert (Standard): keine Refresh-Tokens. Aktiviert: Client darf offline_access anfordern und Refresh-Tokens erhalten, mit denen später neue Access-Tokens geholt werden können (bis etwa 90 Tage). Deaktivieren entfernt offline_access aus der Allow-List des Clients; Nutzer müssen für neue Refresh-Tokens erneut autorisieren."
+          "includeOfflineAccessHelp": "Deaktiviert (Standard): keine Refresh-Tokens. Aktiviert: Client darf offline_access anfordern und Refresh-Tokens erhalten, mit denen später neue Access-Tokens geholt werden können (bis etwa 90 Tage). Deaktivieren entfernt offline_access aus der Allow-List des Clients; Nutzer müssen für neue Refresh-Tokens erneut autorisieren.",
+          "isPublicLabel": "Öffentlicher Client (ohne Secret, nur PKCE)",
+          "isPublicHelp": "Aktiviert: öffentlicher PKCE-Client für native oder mobile Apps, die kein Secret speichern können. Es wird kein Client-Secret ausgestellt; Token-Anfragen nutzen nur PKCE. Deaktiviert (Standard): vertraulicher Client mit Client-Secret."
         },
         "CreatedSuccess": {
           "title": "OAuth-Client erstellt",
@@ -4389,6 +4391,7 @@
           "clientIdLabel": "Client-ID",
           "clientSecretLabel": "Client-Secret",
           "clientSecretWarning": "Dieses Secret wird nur einmal angezeigt. Stelle sicher, dass du es sicher speicherst.",
+          "publicNote": "Öffentlicher Client erstellt — es wurde kein Secret ausgestellt. Nutze die Client-ID mit PKCE (S256).",
           "doneButton": "Fertig",
           "showSecret": "Secret anzeigen",
           "hideSecret": "Secret verbergen"
@@ -4403,7 +4406,9 @@
           "disabled": "Deaktiviert",
           "apiAccess": "API-Zugriff",
           "identityOnly": "Nur Identität",
-          "refresh": "Refresh-Token"
+          "refresh": "Refresh-Token",
+          "public": "Öffentlich",
+          "confidential": "Vertraulich"
         },
         "Actions": {
           "editTooltip": "OAuth-Client bearbeiten",
@@ -4423,7 +4428,10 @@
           "includeCoreApiLabel": "Sokosumi-API-Zugriff erlauben",
           "includeCoreApiHelp": "Deaktiviert: nur Identität (openid). Aktiviert: Core-API (sokosumi:api) bei der Autorisierung. Änderung aktualisiert die Allow-List des Clients. API aus sperrt Core-Zugriff für bestehende Tokens sofort; API an erfordert erneute Autorisierung für neue Tokens mit diesem Scope.",
           "includeOfflineAccessLabel": "Refresh-Tokens erlauben",
-          "includeOfflineAccessHelp": "Deaktiviert: keine Refresh-Tokens. Aktiviert: Client darf offline_access anfordern und Refresh-Tokens erhalten, mit denen später neue Access-Tokens geholt werden können (bis etwa 90 Tage). Änderung aktualisiert die Scope-Allow-List des Clients. Refresh aus entfernt offline_access aus dieser Allow-List; Nutzer müssen für neue Refresh-Tokens erneut autorisieren."
+          "includeOfflineAccessHelp": "Deaktiviert: keine Refresh-Tokens. Aktiviert: Client darf offline_access anfordern und Refresh-Tokens erhalten, mit denen später neue Access-Tokens geholt werden können (bis etwa 90 Tage). Änderung aktualisiert die Scope-Allow-List des Clients. Refresh aus entfernt offline_access aus dieser Allow-List; Nutzer müssen für neue Refresh-Tokens erneut autorisieren.",
+          "clientTypeLabel": "Client-Typ",
+          "clientTypePublic": "Öffentlich — nur PKCE, ohne Secret. Der Typ kann nach der Erstellung nicht geändert werden.",
+          "clientTypeConfidential": "Vertraulich — authentifiziert sich mit einem Client-Secret. Der Typ kann nach der Erstellung nicht geändert werden."
         },
         "DeleteDialog": {
           "title": "OAuth-Client löschen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4411,6 +4411,8 @@
           "includeCoreApiHelp": "Unchecked (default): identity only (openid / userinfo). Checked: also allow calling the Core API as the user (sokosumi:api).",
           "includeOfflineAccessLabel": "Allow refresh tokens",
           "includeOfflineAccessHelp": "Unchecked (default): no refresh tokens. Checked: client may request offline_access and receive refresh tokens that can obtain new access tokens later (up to about 90 days). Turning this off removes offline_access from the client's allow-list; users must reauthorize for new refresh tokens.",
+          "isPublicLabel": "Public client (no secret, PKCE only)",
+          "isPublicHelp": "Checked: public PKCE client for native or mobile apps that cannot keep a secret. No client secret is issued; token requests use PKCE only. Unchecked (default): confidential client with a client secret.",
           "cancelButton": "Cancel",
           "createButton": "Create OAuth Client"
         },
@@ -4420,6 +4422,7 @@
           "clientIdLabel": "Client ID",
           "clientSecretLabel": "Client Secret",
           "clientSecretWarning": "This secret will only be shown once. Make sure to save it securely.",
+          "publicNote": "Public client created — no secret was issued. Use the client ID with PKCE (S256).",
           "doneButton": "Done",
           "showSecret": "Show secret",
           "hideSecret": "Hide secret"
@@ -4434,7 +4437,9 @@
           "disabled": "Disabled",
           "apiAccess": "API access",
           "identityOnly": "Identity only",
-          "refresh": "Refresh token"
+          "refresh": "Refresh token",
+          "public": "Public",
+          "confidential": "Confidential"
         },
         "Actions": {
           "editTooltip": "Edit OAuth client",
@@ -4454,7 +4459,10 @@
           "includeCoreApiLabel": "Allow Sokosumi API access",
           "includeCoreApiHelp": "Unchecked: identity only (openid). Checked: allow Core API (sokosumi:api) on authorize. Changing this updates the client's allow-list. Turning API off blocks Core access for existing tokens immediately; turning it on requires users to reauthorize for new tokens with that scope.",
           "includeOfflineAccessLabel": "Allow refresh tokens",
-          "includeOfflineAccessHelp": "Unchecked: no refresh tokens. Checked: client may request offline_access and receive refresh tokens that can obtain new access tokens later (up to about 90 days). Changing this updates the client's scope allow-list. Turning refresh off removes offline_access from that allow-list; users must reauthorize for new refresh tokens."
+          "includeOfflineAccessHelp": "Unchecked: no refresh tokens. Checked: client may request offline_access and receive refresh tokens that can obtain new access tokens later (up to about 90 days). Changing this updates the client's scope allow-list. Turning refresh off removes offline_access from that allow-list; users must reauthorize for new refresh tokens.",
+          "clientTypeLabel": "Client type",
+          "clientTypePublic": "Public — PKCE only, no secret. Type cannot be changed after creation.",
+          "clientTypeConfidential": "Confidential — authenticates with a client secret. Type cannot be changed after creation."
         },
         "DeleteDialog": {
           "title": "Delete OAuth Client",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4381,7 +4381,9 @@
           "includeCoreApiLabel": "Permitir acceso a la API de Sokosumi",
           "includeCoreApiHelp": "Desmarcado (predeterminado): solo identidad (openid / userinfo). Marcado: también permite llamar a la API Core como el usuario (sokosumi:api).",
           "includeOfflineAccessLabel": "Permitir tokens de actualización",
-          "includeOfflineAccessHelp": "Desmarcado (predeterminado): sin tokens de actualización. Marcado: el cliente puede solicitar offline_access y recibir tokens de actualización que permiten obtener nuevos tokens de acceso más tarde (hasta unos 90 días). Desactivarlo elimina offline_access de la lista de permisos del cliente; los usuarios deben reautorizar para obtener nuevos tokens de actualización."
+          "includeOfflineAccessHelp": "Desmarcado (predeterminado): sin tokens de actualización. Marcado: el cliente puede solicitar offline_access y recibir tokens de actualización que permiten obtener nuevos tokens de acceso más tarde (hasta unos 90 días). Desactivarlo elimina offline_access de la lista de permisos del cliente; los usuarios deben reautorizar para obtener nuevos tokens de actualización.",
+          "isPublicLabel": "Cliente público (sin secreto, solo PKCE)",
+          "isPublicHelp": "Marcado: cliente PKCE público para apps nativas o móviles que no pueden guardar un secreto. No se emite client secret; las peticiones de token usan solo PKCE. Desmarcado (predeterminado): cliente confidencial con client secret."
         },
         "CreatedSuccess": {
           "title": "OAuth Client creado",
@@ -4389,6 +4391,7 @@
           "clientIdLabel": "Client ID",
           "clientSecretLabel": "Client Secret",
           "clientSecretWarning": "Este Secret solo se mostrará una vez. Asegúrate de guardarlo de forma segura.",
+          "publicNote": "Cliente público creado — no se emitió ningún secreto. Usa el ID de cliente con PKCE (S256).",
           "doneButton": "Listo",
           "showSecret": "Mostrar secreto",
           "hideSecret": "Ocultar secreto"
@@ -4403,7 +4406,9 @@
           "disabled": "Deshabilitado",
           "apiAccess": "Acceso API",
           "identityOnly": "Solo identidad",
-          "refresh": "Token de actualización"
+          "refresh": "Token de actualización",
+          "public": "Público",
+          "confidential": "Confidencial"
         },
         "Actions": {
           "editTooltip": "Editar cliente OAuth",
@@ -4423,7 +4428,10 @@
           "includeCoreApiLabel": "Permitir acceso a la API de Sokosumi",
           "includeCoreApiHelp": "Desmarcado: solo identidad (openid). Marcado: permite la API Core (sokosumi:api) en la autorización. Cambiar esto actualiza la lista de permisos del cliente. Desactivar la API bloquea el acceso a Core de los tokens existentes de inmediato; activarla exige que los usuarios reautoricen para obtener tokens nuevos con ese scope.",
           "includeOfflineAccessLabel": "Permitir tokens de actualización",
-          "includeOfflineAccessHelp": "Desmarcado: sin tokens de actualización. Marcado: el cliente puede solicitar offline_access y recibir tokens de actualización que permiten obtener nuevos tokens de acceso más tarde (hasta unos 90 días). Cambiar esto actualiza la lista de permisos de scopes del cliente. Desactivar la actualización elimina offline_access de esa lista; los usuarios deben reautorizar para obtener nuevos tokens de actualización."
+          "includeOfflineAccessHelp": "Desmarcado: sin tokens de actualización. Marcado: el cliente puede solicitar offline_access y recibir tokens de actualización que permiten obtener nuevos tokens de acceso más tarde (hasta unos 90 días). Cambiar esto actualiza la lista de permisos de scopes del cliente. Desactivar la actualización elimina offline_access de esa lista; los usuarios deben reautorizar para obtener nuevos tokens de actualización.",
+          "clientTypeLabel": "Tipo de cliente",
+          "clientTypePublic": "Público — solo PKCE, sin secreto. El tipo no se puede cambiar tras la creación.",
+          "clientTypeConfidential": "Confidencial — se autentica con un client secret. El tipo no se puede cambiar tras la creación."
         },
         "DeleteDialog": {
           "title": "Eliminar cliente OAuth",

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/create-oauth-client-dialog.tsx
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/create-oauth-client-dialog.tsx
@@ -82,6 +82,7 @@ export function CreateOAuthClientDialog({
       redirectUris: parseRedirectUris(values.redirectUris),
       includeCoreApi: values.includeCoreApi,
       includeOfflineAccess: values.includeOfflineAccess,
+      isPublic: values.isPublic,
     });
 
     if (result.success && result.data) {
@@ -201,7 +202,11 @@ export function CreateOAuthClientDialog({
                   hideLabel={t("CreatedSuccess.hideSecret")}
                   onCopy={handleCopy}
                 />
-              ) : null}
+              ) : (
+                <p className="text-muted-foreground text-sm">
+                  {t("CreatedSuccess.publicNote")}
+                </p>
+              )}
 
               <DialogFooter>
                 <Button onClick={handleCredentialsDone}>
@@ -316,6 +321,35 @@ export function CreateOAuthClientDialog({
                           </FormLabel>
                           <FormDescription>
                             {t("CreateDialog.includeOfflineAccessHelp")}
+                          </FormDescription>
+                        </div>
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="isPublic"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-start gap-3">
+                        <FormControl>
+                          <Checkbox
+                            checked={field.value}
+                            onCheckedChange={(checked) => {
+                              field.onChange(checked === true);
+                            }}
+                            disabled={isSubmitting}
+                          />
+                        </FormControl>
+                        <div className="space-y-1">
+                          <FormLabel className="font-normal">
+                            {t("CreateDialog.isPublicLabel")}
+                          </FormLabel>
+                          <FormDescription>
+                            {t("CreateDialog.isPublicHelp")}
                           </FormDescription>
                         </div>
                       </div>

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/edit-oauth-client-dialog.tsx
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/edit-oauth-client-dialog.tsx
@@ -39,6 +39,7 @@ import type {
 import {
   DEFAULT_EDIT_FORM_VALUES,
   editOAuthClientSchema,
+  isPublicOAuthClient,
   parseRedirectUris,
 } from "./utils";
 
@@ -114,6 +115,17 @@ export function EditOAuthClientDialog({
                 </p>
                 <p className="text-muted-foreground mt-1 font-mono text-xs break-all">
                   {client.client_id}
+                </p>
+              </div>
+
+              <div>
+                <p className="text-sm font-medium">
+                  {t("EditDialog.clientTypeLabel")}
+                </p>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  {isPublicOAuthClient(client)
+                    ? t("EditDialog.clientTypePublic")
+                    : t("EditDialog.clientTypeConfidential")}
                 </p>
               </div>
 

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/hooks/use-oauth-clients.test.ts
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/hooks/use-oauth-clients.test.ts
@@ -279,6 +279,74 @@ describe("useOAuthClients", () => {
     });
   });
 
+  it("registers a public PKCE client without a secret", async () => {
+    createClientMock.mockResolvedValue({
+      data: {
+        client_id: "client_public",
+        client_secret: null,
+      },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useOAuthClients());
+    await waitFor(() => {
+      expect(result.current.isInitialLoading).toBe(false);
+    });
+
+    let createResult: Awaited<ReturnType<typeof result.current.create>>;
+    await act(async () => {
+      createResult = await result.current.create({
+        name: "Mac App",
+        redirectUris: ["com.sokosumi.app:/oauth/signin"],
+        includeCoreApi: true,
+        includeOfflineAccess: true,
+        isPublic: true,
+      });
+    });
+
+    expect(createClientMock).toHaveBeenCalledWith({
+      redirect_uris: ["com.sokosumi.app:/oauth/signin"],
+      client_name: "Mac App",
+      scope: "openid sokosumi:api offline_access",
+      grant_types: ["authorization_code", "refresh_token"],
+      application_type: "native",
+      token_endpoint_auth_method: "none",
+    });
+    expect(createResult!.success).toBe(true);
+    expect(createResult!.data?.clientId).toBe("client_public");
+    expect(createResult!.data?.clientSecret).toBeNull();
+  });
+
+  it("omits token_endpoint_auth_method for confidential clients", async () => {
+    createClientMock.mockResolvedValue({
+      data: {
+        client_id: "client_conf",
+        client_secret: "secret",
+      },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useOAuthClients());
+    await waitFor(() => {
+      expect(result.current.isInitialLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.create({
+        name: "Web App",
+        redirectUris: ["https://example.com/cb"],
+        isPublic: false,
+      });
+    });
+
+    expect(createClientMock).toHaveBeenCalledWith({
+      redirect_uris: ["https://example.com/cb"],
+      client_name: "Web App",
+      scope: "openid",
+      grant_types: ["authorization_code"],
+    });
+  });
+
   it("updates a client with the Better Auth payload shape", async () => {
     updateClientMock.mockResolvedValue({
       data: {

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/hooks/use-oauth-clients.ts
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/hooks/use-oauth-clients.ts
@@ -65,6 +65,7 @@ export function useOAuthClients(): UseOAuthClientsReturn {
       try {
         const includeCoreApi = data.includeCoreApi ?? false;
         const includeOfflineAccess = data.includeOfflineAccess ?? false;
+        const isPublic = data.isPublic ?? false;
         const applicationType = inferOAuthApplicationType(data.redirectUris);
         const result = await authClient.oauth2.createClient({
           redirect_uris: data.redirectUris,
@@ -77,6 +78,7 @@ export function useOAuthClients(): UseOAuthClientsReturn {
           ...(applicationType === "native"
             ? { application_type: "native" as const }
             : {}),
+          ...(isPublic ? { token_endpoint_auth_method: "none" as const } : {}),
         });
 
         if (result.error) {

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/index.ts
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/index.ts
@@ -24,6 +24,7 @@ export {
   DEFAULT_EDIT_FORM_VALUES,
   DIALOG_CLEANUP_TIMEOUT,
   editOAuthClientSchema,
+  isPublicOAuthClient,
   isSafeRedirectUri,
   parseRedirectUris,
 } from "./utils";

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/oauth-clients-list.tsx
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/oauth-clients-list.tsx
@@ -11,6 +11,7 @@ import { DeveloperSectionRowsSkeleton } from "@/app/developer/components/develop
 import { Button } from "@/components/ui/button";
 
 import type { OAuthClientsListProps } from "./types";
+import { isPublicOAuthClient } from "./utils";
 
 export function OAuthClientsList({
   clients,
@@ -61,6 +62,7 @@ export function OAuthClientsList({
           : null;
         const allowsCoreApi = hasCoreApiOAuthScope(client.scope);
         const allowsOfflineAccess = hasOfflineAccessOAuthScope(client.scope);
+        const isPublic = isPublicOAuthClient(client);
 
         return (
           <div
@@ -70,6 +72,9 @@ export function OAuthClientsList({
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex flex-wrap items-center gap-2">
                 <p className="truncate font-semibold">{name}</p>
+                <span className="bg-muted text-muted-foreground inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium">
+                  {isPublic ? t("Status.public") : t("Status.confidential")}
+                </span>
                 <span className="bg-muted text-muted-foreground inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium">
                   {allowsCoreApi
                     ? t("Status.apiAccess")
@@ -116,7 +121,7 @@ export function OAuthClientsList({
               >
                 <Pencil className="size-4" />
               </Button>
-              {!client.public ? (
+              {!isPublic ? (
                 <Button
                   size="sm"
                   variant="ghost"

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/types.ts
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/types.ts
@@ -13,6 +13,8 @@ export interface CreateOAuthClientFormData {
   includeCoreApi: boolean;
   /** When true, client may request `offline_access` and use refresh tokens. */
   includeOfflineAccess: boolean;
+  /** When true, register as a public PKCE client with no secret. */
+  isPublic: boolean;
 }
 
 export interface EditOAuthClientFormData {
@@ -29,6 +31,8 @@ export interface CreateOAuthClientRequest {
   includeCoreApi?: boolean;
   /** When true, register with `offline_access` + `refresh_token` grant. */
   includeOfflineAccess?: boolean;
+  /** When true, register as a public PKCE client (`token_endpoint_auth_method: none`). */
+  isPublic?: boolean;
 }
 
 export interface CreateOAuthClientResult {

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/utils.test.ts
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   createOAuthClientSchema,
   inferOAuthApplicationType,
+  isPublicOAuthClient,
   isSafeRedirectUri,
   parseRedirectUris,
 } from "./utils";
@@ -93,6 +94,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "https://example.com/callback",
       includeCoreApi: false,
       includeOfflineAccess: false,
+      isPublic: false,
     });
     expect(result.success).toBe(true);
   });
@@ -103,6 +105,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "https://example.com/callback",
       includeCoreApi: false,
       includeOfflineAccess: false,
+      isPublic: false,
     });
     expect(result.success).toBe(false);
   });
@@ -113,6 +116,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "https://example.com/callback",
       includeCoreApi: false,
       includeOfflineAccess: false,
+      isPublic: false,
     });
     expect(result.success).toBe(false);
   });
@@ -123,6 +127,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "https://example.com/callback",
       includeCoreApi: true,
       includeOfflineAccess: false,
+      isPublic: false,
     });
     expect(result.success).toBe(true);
     if (result.success) {
@@ -138,6 +143,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "not-a-url",
       includeCoreApi: false,
       includeOfflineAccess: false,
+      isPublic: false,
     });
     expect(result.success).toBe(false);
   });
@@ -148,6 +154,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "http://example.com/callback",
       includeCoreApi: false,
       includeOfflineAccess: false,
+      isPublic: false,
     });
     expect(result.success).toBe(false);
   });
@@ -167,6 +174,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "com.sokosumi.app:/oauth/signin",
       includeCoreApi: true,
       includeOfflineAccess: true,
+      isPublic: true,
     });
     expect(result.success).toBe(true);
   });
@@ -177,6 +185,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "sokosumi://oauth/signin",
       includeCoreApi: true,
       includeOfflineAccess: true,
+      isPublic: true,
     });
     expect(result.success).toBe(false);
   });
@@ -187,6 +196,7 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "com.sokosumi.app://auth",
       includeCoreApi: true,
       includeOfflineAccess: true,
+      isPublic: true,
     });
     expect(result.success).toBe(false);
   });
@@ -198,6 +208,7 @@ describe("createOAuthClientSchema", () => {
         "https://example.com/callback\ncom.sokosumi.app:/oauth/signin",
       includeCoreApi: true,
       includeOfflineAccess: true,
+      isPublic: false,
     });
     expect(result.success).toBe(true);
   });
@@ -208,6 +219,17 @@ describe("createOAuthClientSchema", () => {
       redirectUris: "https://example.com/callback\ncom.sokosumi.app://auth",
       includeCoreApi: true,
       includeOfflineAccess: true,
+      isPublic: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing isPublic", () => {
+    const result = schema.safeParse({
+      name: "My App",
+      redirectUris: "https://example.com/callback",
+      includeCoreApi: false,
+      includeOfflineAccess: false,
     });
     expect(result.success).toBe(false);
   });
@@ -233,5 +255,29 @@ describe("inferOAuthApplicationType", () => {
         "com.sokosumi.app:/oauth/signin",
       ]),
     ).toBe("native");
+  });
+});
+
+describe("isPublicOAuthClient", () => {
+  it("returns true for token_endpoint_auth_method none", () => {
+    expect(isPublicOAuthClient({ token_endpoint_auth_method: "none" })).toBe(
+      true,
+    );
+  });
+
+  it("returns false for confidential auth methods", () => {
+    expect(
+      isPublicOAuthClient({
+        token_endpoint_auth_method: "client_secret_basic",
+      }),
+    ).toBe(false);
+    expect(isPublicOAuthClient({})).toBe(false);
+    expect(isPublicOAuthClient(null)).toBe(false);
+    expect(isPublicOAuthClient(undefined)).toBe(false);
+  });
+
+  it("falls back to the legacy public flag", () => {
+    expect(isPublicOAuthClient({ public: true })).toBe(true);
+    expect(isPublicOAuthClient({ public: false })).toBe(false);
   });
 });

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/utils.ts
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/utils.ts
@@ -9,6 +9,7 @@ export const DEFAULT_CREATE_FORM_VALUES = {
   redirectUris: "",
   includeCoreApi: false,
   includeOfflineAccess: false,
+  isPublic: false,
 };
 
 export const DEFAULT_EDIT_FORM_VALUES = {
@@ -200,11 +201,37 @@ export function createOAuthClientSchema(t: TranslationFunction) {
       }),
     includeCoreApi: z.boolean(),
     includeOfflineAccess: z.boolean(),
+    isPublic: z.boolean(),
   });
 }
 
+/**
+ * True for public PKCE clients (no secret). Better Auth 1.7 derives this from
+ * `token_endpoint_auth_method === "none"`; the legacy `public` flag is kept
+ * as a fallback for rows shaped by older clients.
+ */
+export function isPublicOAuthClient(
+  client:
+    | {
+        token_endpoint_auth_method?: string | null;
+        public?: boolean | null;
+      }
+    | null
+    | undefined,
+): boolean {
+  if (!client) {
+    return false;
+  }
+  if (client.token_endpoint_auth_method === "none") {
+    return true;
+  }
+  return client.public === true;
+}
+
 export function editOAuthClientSchema(t: TranslationFunction) {
-  return createOAuthClientSchema(t);
+  // Client auth method cannot change after creation, so edit keeps the
+  // create shape minus the immutable client-type flag.
+  return createOAuthClientSchema(t).omit({ isPublic: true });
 }
 
 export { parseRedirectUris };


### PR DESCRIPTION
Developers can now register public PKCE OAuth clients (no client secret) from the OAuth Clients wizard, e.g. for the native Mac app with redirect `com.sokosumi.app:/auth`.

- Create dialog gains a public-client checkbox; public registrations send `token_endpoint_auth_method: none` and return only a client ID (PKCE S256 at the token endpoint, secret field replaced by a note).
- Client list shows a Public/Confidential badge and hides secret rotation for public clients (auth-method check replaces the stale `client.public` flag).
- Edit dialog shows the client type read-only; the auth method cannot change after creation.
- Locales synced: en (source), de, es.

No schema/migration changes; no new routes.

Verification:
- `pnpm --filter web test src/app/(app)/developer` — 6 files, 66 tests passed
- `pnpm --filter web typecheck` — clean
- `pnpm --filter web check` — clean
- `pnpm --filter web messages:parity` — de/es ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating public OAuth clients using PKCE without client secrets.
  * Added public and confidential client status labels throughout the OAuth client interface.
  * Added creation confirmations and guidance for public clients.
  * Clarified that client types cannot be changed after creation.
* **Bug Fixes**
  * Improved recognition of public clients across current and legacy configurations.
* **Tests**
  * Added coverage for public and confidential client creation and status detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->