### PR TITLE
fix(core): keep DM notify when mentions are silenced

### DIFF
--- a/apps/core/src/helpers/chat-direct-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.test.ts
@@ -5,11 +5,13 @@ const {
   createNotificationMock,
   workspaceFindUniqueMock,
   membershipFindManyMock,
+  userFindManyMock,
   captureExceptionMock,
 } = vi.hoisted(() => ({
   createNotificationMock: vi.fn(),
   workspaceFindUniqueMock: vi.fn(),
   membershipFindManyMock: vi.fn(),
+  userFindManyMock: vi.fn(),
   captureExceptionMock: vi.fn(),
 }));
 
@@ -24,6 +26,9 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     chatRoomUserMember: {
       findMany: membershipFindManyMock,
+    },
+    user: {
+      findMany: userFindManyMock,
     },
   },
 }));
@@ -44,11 +49,22 @@ const PEER_ID = "user_alice";
 const OTHER_ID = "user_bob";
 const THIRD_ID = "user_carol";
 
+/** A reader who never opened the settings page: mentions still arrive. */
+function reader(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    pushOptIn: true,
+    notificationPreferences: [],
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   createNotificationMock.mockResolvedValue({ created: true });
   workspaceFindUniqueMock.mockResolvedValue({ id: "workspace_1" });
   membershipFindManyMock.mockResolvedValue([]);
+  userFindManyMock.mockResolvedValue([reader(PEER_ID)]);
 });
 
 describe("shouldEmitChatDirectMessageNotifications", () => {
@@ -197,6 +213,85 @@ describe("emitChatDirectMessageNotifications", () => {
 
     expect(createNotificationMock).not.toHaveBeenCalled();
     expect(membershipFindManyMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Mentions still arrive, so the same message must not also land as a
+   * direct-message row.
+   */
+  it("skips a mentioned recipient whose mention reaches them", async () => {
+    await emitChatDirectMessageNotifications({
+      roomId: ROOM_ID,
+      roomName: "Alice",
+      organizationId: "org_1",
+      messageId: MESSAGE_ID,
+      authorUserId: AUTHOR_ID,
+      authorName: "Patrick",
+      recipientUserIds: [PEER_ID],
+      mentionedUserIds: [PEER_ID],
+    });
+
+    expect(userFindManyMock).toHaveBeenCalledWith({
+      where: { id: { in: [PEER_ID] } },
+      select: {
+        id: true,
+        pushOptIn: true,
+        notificationPreferences: {
+          select: { category: true, channel: true, enabled: true },
+        },
+      },
+    });
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Mentions off, direct messages on. Skipping this reader because the
+   * message named them would leave a 1:1 DM with no notification at all:
+   * the room-message emitter also leaves this room alone.
+   */
+  it("notifies a mentioned recipient who silenced mentions", async () => {
+    userFindManyMock.mockResolvedValue([
+      reader(PEER_ID, {
+        notificationPreferences: [
+          { category: "CHAT_MENTION", channel: "IN_APP", enabled: false },
+          { category: "CHAT_MENTION", channel: "OS_BANNER", enabled: false },
+        ],
+      }),
+    ]);
+
+    await emitChatDirectMessageNotifications({
+      roomId: ROOM_ID,
+      roomName: "Alice",
+      organizationId: "org_1",
+      messageId: MESSAGE_ID,
+      authorUserId: AUTHOR_ID,
+      authorName: "Patrick",
+      recipientUserIds: [PEER_ID],
+      mentionedUserIds: [PEER_ID],
+    });
+
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: PEER_ID,
+        messageKey: "Notifications.Chat.directMessage",
+      }),
+    );
+  });
+
+  it("does not load readers when nobody named is a recipient", async () => {
+    await emitChatDirectMessageNotifications({
+      roomId: ROOM_ID,
+      roomName: "Alice",
+      organizationId: "org_1",
+      messageId: MESSAGE_ID,
+      authorUserId: AUTHOR_ID,
+      authorName: "Patrick",
+      recipientUserIds: [PEER_ID],
+      mentionedUserIds: [OTHER_ID],
+    });
+
+    expect(userFindManyMock).not.toHaveBeenCalled();
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
   });
 
   it("continues when createNotification fails for one recipient", async () => {

--- a/apps/core/src/helpers/chat-direct-message-notifications.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.ts
@@ -1,4 +1,6 @@
 import { CHAT_DIRECT_MESSAGE_MESSAGE_KEY } from "@sokosumi/utils";
+import { resolveNotificationDelivery } from "@/helpers/notification-delivery";
+import prisma from "@/lib/db/prisma";
 
 import { fanOutChatNotifications } from "./chat-notification-fanout";
 
@@ -28,14 +30,63 @@ export interface EmitChatDirectMessageNotificationsParams {
   authorUserId: string | null;
   authorName: string;
   recipientUserIds: readonly string[];
+  /** Named in the message. Skipped only when that mention actually reaches them. */
+  mentionedUserIds?: readonly string[];
+}
+
+/**
+ * Drop recipients whose mention already reaches them.
+ *
+ * A 1:1 direct room never emits a room-message row, so skipping every named
+ * human here used to drop the only remaining notify path. Mentions can be
+ * silenced. Keep the direct-message row when the mention would not arrive.
+ */
+async function recipientsNotCoveredByMention(
+  params: EmitChatDirectMessageNotificationsParams,
+): Promise<readonly string[]> {
+  const mentioned = new Set(params.mentionedUserIds ?? []);
+  const mentionedRecipients = params.recipientUserIds.filter((userId) =>
+    mentioned.has(userId),
+  );
+  if (mentionedRecipients.length === 0) {
+    return params.recipientUserIds;
+  }
+
+  const readers = await prisma.user.findMany({
+    where: { id: { in: mentionedRecipients } },
+    select: {
+      id: true,
+      pushOptIn: true,
+      notificationPreferences: {
+        select: { category: true, channel: true, enabled: true },
+      },
+    },
+  });
+  const covered = new Set(
+    readers
+      .filter((reader) => {
+        const delivery = resolveNotificationDelivery({
+          category: "CHAT_MENTION",
+          preferences: reader.notificationPreferences,
+          pushOptIn: reader.pushOptIn,
+        });
+        return delivery.inApp || delivery.osBanner;
+      })
+      .map((reader) => reader.id),
+  );
+
+  return params.recipientUserIds.filter((userId) => !covered.has(userId));
 }
 
 /** Emit CHAT notifications for other humans in a direct room. Schedule via waitUntil. */
 export async function emitChatDirectMessageNotifications(
   params: EmitChatDirectMessageNotificationsParams,
 ): Promise<void> {
+  const recipientUserIds = await recipientsNotCoveredByMention(params);
+
   await fanOutChatNotifications({
     ...params,
+    recipientUserIds,
     messageKey: CHAT_DIRECT_MESSAGE_MESSAGE_KEY,
     notificationType: "chat-direct-message-notification",
   });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -1003,10 +1003,11 @@ describe("POST /chats/rooms/{id}/messages", () => {
         authorUserId: USER_ID,
         authorName: "Patrick",
         recipientUserIds: [ALICE_ID],
+        mentionedUserIds: [],
       });
     });
 
-    it("skips direct-message emit for humans already covered by mention notifications", async () => {
+    it("still emits direct-message for mentioned humans so the emitter can decide", async () => {
       roomFindFirstMock.mockResolvedValue(
         roomWithMembers({
           kind: "direct",
@@ -1045,7 +1046,16 @@ describe("POST /chats/rooms/{id}/messages", () => {
           mentionedUserIds: [ALICE_ID],
         }),
       );
-      expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
+      expect(emitChatDirectMessageNotificationsMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        roomName: "Alice",
+        organizationId: "org_1",
+        messageId: MESSAGE_ID,
+        authorUserId: USER_ID,
+        authorName: "Patrick",
+        recipientUserIds: [ALICE_ID],
+        mentionedUserIds: [ALICE_ID],
+      });
     });
 
     it("does not emit direct-message notifications for group directs", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -488,10 +488,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           memberUserIds: room.memberUserIds,
         })
       ) {
-        const mentionedUserIdSet = new Set(mentionedUserIds);
         const recipientUserIds = room.memberUserIds.filter(
-          (userId) =>
-            userId !== userContext.userId && !mentionedUserIdSet.has(userId),
+          (userId) => userId !== userContext.userId,
         );
         if (recipientUserIds.length > 0) {
           waitUntil(
@@ -503,6 +501,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
               authorUserId: userContext.userId,
               authorName: message.senderUser?.name ?? "Someone",
               recipientUserIds,
+              mentionedUserIds,
             }),
           );
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

A 1:1 DM that @mentions the peer drops the only remaining chat notification when that peer has silenced mentions and kept direct messages on.

The room-message path already keeps the fallback (`emitChatRoomMessageNotifications` skips a named member only when the mention actually arrives). 1:1 DMs never take that path, so the old “already covered by mention” skip in `POST .../chats/rooms/:id/messages` left a hole.

## Trigger

1. Reader turns `CHAT_MENTION` off on both channels and leaves `CHAT_DIRECT_MESSAGE` on.
2. Peer posts in their 1:1 DM and @mentions the reader.
3. Mention emit writes a hidden row. Direct-message emit is skipped. Room-message emit returns early for two-person directs.
4. Reader gets no toast, no OS banner, and no feed row for that message.

## Fix

Pass mentioned humans through to `emitChatDirectMessageNotifications`. Skip them only when `resolveNotificationDelivery` says the mention would actually reach them.

## Validation

`pnpm --filter core test` on:

- `src/helpers/chat-direct-message-notifications.test.ts`
- `src/routes/v1/chats/rooms/[id]/messages/post.test.ts`

37 passed. `pnpm --filter core typecheck` passed. Biome check passed on the touched files.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1ad2fd-4aaf-451e-b309-00f3a55ecd7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1ad2fd-4aaf-451e-b309-00f3a55ecd7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

