### PR TITLE
fix(core): require authorized context on task workspace GET

### DIFF
--- a/apps/core/src/routes/v1/tasks/[id]/workspace/get.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/workspace/get.test.ts
@@ -14,40 +14,68 @@ vi.mock("@/middleware/auth", async (importOriginal) => {
   return { ...actual, authMiddleware: stubAuthMiddleware };
 });
 
-const { resolveMemberOrganizationByIdMock, taskFindUniqueMock } = vi.hoisted(
-  () => ({
-    resolveMemberOrganizationByIdMock: vi.fn(),
-    taskFindUniqueMock: vi.fn(),
-  }),
-);
-
-vi.mock("@/helpers/organization", () => ({
-  resolveMemberOrganizationById: resolveMemberOrganizationByIdMock,
-}));
-
-vi.mock("@/lib/db/prisma", () => ({
-  default: {
-    task: {
-      findUnique: taskFindUniqueMock,
-    },
+const {
+  getWorkspaceGrantMock,
+  requireTaskReadForRouteVarsMock,
+  workspaceRepositoryMock,
+} = vi.hoisted(() => ({
+  getWorkspaceGrantMock: vi.fn(),
+  requireTaskReadForRouteVarsMock: vi.fn(),
+  workspaceRepositoryMock: {
+    resolveWorkspaceForContext: vi.fn(),
   },
 }));
 
-function createTask(
-  overrides: { userId?: string; organizationId?: string | null } = {},
-) {
+vi.mock("@sokosumi/database/repositories", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@sokosumi/database/repositories")>();
+  return {
+    ...actual,
+    workspaceRepository: workspaceRepositoryMock,
+  };
+});
+
+vi.mock("@/helpers/vendor-grants", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/helpers/vendor-grants")>();
+  return {
+    ...actual,
+    getWorkspaceGrant: getWorkspaceGrantMock,
+  };
+});
+
+vi.mock("@/helpers/access-control", () => ({
+  requireTaskReadForRouteVars: requireTaskReadForRouteVarsMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {},
+}));
+
+const WORKSPACE_ID = "11111111-1111-7111-8111-111111111111";
+
+function createTask(overrides: { organizationId?: string | null } = {}) {
   const organizationId =
     "organizationId" in overrides ? overrides.organizationId : "org_123";
 
   return {
     name: "Research competitor pricing",
-    ownerId: overrides.userId ?? "user_123",
-    workspaceId: "11111111-1111-7111-8111-111111111111",
+    workspaceId: WORKSPACE_ID,
     workspace: {
       organizationId,
     },
   };
 }
+
+const coworkerAuth = {
+  actor: "coworker" as const,
+  coworkerId: "cow_123",
+  vendorId: TEST_VENDOR_ID,
+  context: {
+    userId: "user_123",
+    organizationId: "org_123",
+  },
+};
 
 function createApp(
   authContext: AuthenticationContext = {
@@ -63,6 +91,11 @@ function createApp(
     c.set("requestId", "req_workspace_get_test");
     c.set("isAuthenticated", true);
     c.set("authContext", authContext);
+    c.set("workspaceContext", {
+      workspaceId: WORKSPACE_ID,
+      userId: null,
+      organizationId: "org_123",
+    });
 
     return await next();
   });
@@ -76,13 +109,15 @@ function createApp(
 describe("GET /tasks/{id}/workspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    taskFindUniqueMock.mockResolvedValue(createTask());
-    resolveMemberOrganizationByIdMock.mockResolvedValue({
-      organization: {
-        id: "org_123",
-      },
-      role: "member",
+    workspaceRepositoryMock.resolveWorkspaceForContext.mockResolvedValue({
+      id: "ws_task_workspace",
     });
+    getWorkspaceGrantMock.mockResolvedValue({
+      id: "grant_123",
+      status: "GRANTED",
+      permission: "WORKSPACE",
+    });
+    requireTaskReadForRouteVarsMock.mockResolvedValue(createTask());
   });
 
   it("returns the task title and workspace mapping for accessible tasks", async () => {
@@ -92,18 +127,26 @@ describe("GET /tasks/{id}/workspace", () => {
     expect(response.status).toBe(200);
     expect(body.data).toEqual({
       name: "Research competitor pricing",
-      workspaceId: "11111111-1111-7111-8111-111111111111",
+      workspaceId: WORKSPACE_ID,
       organizationId: "org_123",
     });
-    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith({
-      id: "org_123",
-      userId: "user_123",
-      tx: expect.any(Object),
-    });
+    expect(requireTaskReadForRouteVarsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authContext: expect.objectContaining({
+          actor: "user",
+          userId: "user_123",
+        }),
+      }),
+      "tsk_123",
+      expect.any(Object),
+      {
+        workspace: { select: { organizationId: true } },
+      },
+    );
   });
 
-  it("allows personal tasks owned by the caller", async () => {
-    taskFindUniqueMock.mockResolvedValue(
+  it("returns a personal workspace mapping when the task has no organization", async () => {
+    requireTaskReadForRouteVarsMock.mockResolvedValue(
       createTask({
         organizationId: null,
       }),
@@ -117,28 +160,16 @@ describe("GET /tasks/{id}/workspace", () => {
       name: "Research competitor pricing",
       organizationId: null,
     });
-    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
   });
 
-  it("allows coworker with context headers as the context user", async () => {
-    const response = await createApp({
-      actor: "coworker",
-      coworkerId: "cow_123",
-      vendorId: TEST_VENDOR_ID,
-      context: {
-        userId: "user_123",
-        organizationId: "org_123",
-      },
-    }).request("/tsk_123/workspace");
+  it("allows coworker with GRANTED context as the context user", async () => {
+    const response =
+      await createApp(coworkerAuth).request("/tsk_123/workspace");
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.data.workspaceId).toBe("11111111-1111-7111-8111-111111111111");
-    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith({
-      id: "org_123",
-      userId: "user_123",
-      tx: expect.any(Object),
-    });
+    expect(body.data.workspaceId).toBe(WORKSPACE_ID);
+    expect(requireTaskReadForRouteVarsMock).toHaveBeenCalled();
   });
 
   it("returns 403 for bare coworker without context headers", async () => {
@@ -153,6 +184,40 @@ describe("GET /tasks/{id}/workspace", () => {
     expect(body.message).toBe(
       "Context headers (X-Context-User-Id) are required for this resource",
     );
-    expect(taskFindUniqueMock).not.toHaveBeenCalled();
+    expect(requireTaskReadForRouteVarsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for coworker with a DENIED workspace grant", async () => {
+    getWorkspaceGrantMock.mockResolvedValue({
+      id: "grant_123",
+      status: "DENIED",
+      permission: "WORKSPACE",
+    });
+
+    const response =
+      await createApp(coworkerAuth).request("/tsk_123/workspace");
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.message).toBe("Vendor workspace access was denied");
+    expect(body.kind).toBe("grant_denied");
+    expect(requireTaskReadForRouteVarsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for coworker with a REVOKED workspace grant", async () => {
+    getWorkspaceGrantMock.mockResolvedValue({
+      id: "grant_123",
+      status: "REVOKED",
+      permission: "WORKSPACE",
+    });
+
+    const response =
+      await createApp(coworkerAuth).request("/tsk_123/workspace");
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.message).toBe("Vendor workspace access was revoked");
+    expect(body.kind).toBe("grant_revoked");
+    expect(requireTaskReadForRouteVarsMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/tasks/[id]/workspace/get.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/workspace/get.ts
@@ -1,12 +1,11 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
-import { forbidden, notFound } from "@/helpers/error";
+import { requireTaskReadForRouteVars } from "@/helpers/access-control";
+import { requireAuthorizedUserContext } from "@/helpers/coworker-user-context-binding";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
-import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 import { taskWorkspaceSchema } from "@/schemas/task.schema";
 
 const paramsSchema = z.object({
@@ -45,40 +44,12 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const { authContext } = c.var;
-    const userContext = requireUserContext(authContext);
+    await requireAuthorizedUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    const task = await prisma.task.findUnique({
-      where: {
-        id,
-        archivedAt: null,
-      },
-      select: {
-        name: true,
-        ownerId: true,
-        workspaceId: true,
-        workspace: {
-          select: {
-            organizationId: true,
-          },
-        },
-      },
+    const task = await requireTaskReadForRouteVars(c.var, id, prisma, {
+      workspace: { select: { organizationId: true } },
     });
-
-    if (!task) {
-      throw notFound("Task not found");
-    }
-
-    if (task.workspace.organizationId) {
-      await resolveMemberOrganizationById({
-        id: task.workspace.organizationId,
-        userId: userContext.userId,
-        tx: prisma,
-      });
-    } else if (task.ownerId !== userContext.userId) {
-      throw forbidden("You do not have access to this task");
-    }
 
     return ok(
       c,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GET `/v1/tasks/{id}/workspace` advertised authorized context headers but only checked org membership / owner. A coworker bound to any org member could resolve any task in that org.

This route now uses `requireAuthorizedUserContext` (DENIED/REVOKED/unbound fail first) and `requireTaskReadForRouteVars` (real task-read gate), matching Drive (#4168), vendors (#4192), and jobs lists (#4235).

## Changes

- `apps/core/src/routes/v1/tasks/[id]/workspace/get.ts`
- `apps/core/src/routes/v1/tasks/[id]/workspace/get.test.ts`

Out of scope: PUT job/task workspace, other task routes, grant helpers.

## Verification

- `pnpm --filter @sokosumi/core test src/routes/v1/tasks/[id]/workspace/get.test.ts` (6 passed)
- `pnpm check` and `pnpm typecheck` (husky)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c61e82b9-4056-4eb1-af4f-37e204298de6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c61e82b9-4056-4eb1-af4f-37e204298de6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization handling when retrieving a task workspace.
  * Requests from coworkers with denied or revoked access are now rejected consistently.
  * Workspace access continues to return the expected workspace details for authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->