### PR TITLE
chore: maintain verification skill / feature map

### DIFF
--- a/.cursor/skills/verify-sokosumi/SKILL.md
+++ b/.cursor/skills/verify-sokosumi/SKILL.md
@@ -190,7 +190,7 @@ Each git worktree gets its own named URLs (`https://web.sokosumi.localhost` on t
 - Copying `.env.example` without replacing `<…>` placeholders → Core/Web fail Zod at boot (“missing env”)
 - Optional URL env vars (`AGENT_HIRED_WEBHOOK`, Sentry DSN) set to non-URL dummies → Web crashes after Ready (`z.url()`); omit or use a real URL
 - `COMPOSIO_API_KEY` set without an `ak_` prefix → Core refuses to start (optional key; omit or use `ak_…`)
-- `/agents` stacks the Coworker gallery above an Agent catalog (`Browse all agents` when catalog data is present). Empty coworker data blanks the gallery section; the catalog stays independent. App Hire stays off. Cookie **Accept all** covers lower catalog cards until dismissed.
+- `/agents` stacks the Coworker gallery above an Agent catalog (`Browse all agents` when catalog data is present). Empty coworker data omits the whole gallery tier (hero included); the catalog stays independent. App Hire stays off. Cookie **Accept all** covers lower catalog cards until dismissed.
 - Authenticated default landing is Welcome `/` (`DEFAULT_AUTHENTICATED_LANDING_PATH`), not `/chat`. Desktop (`md+`) `/chat` redirects to `/`; mobile may keep `/chat`.
 - Desktop main nav includes **Files** (`/drive`) after Tasks (and Schedules when that beta item is on). Mobile keeps Files on the You page, not the sidebar.
 - Ably placeholders break realtime chat UI

--- a/.cursor/skills/verify-sokosumi/features/README.md
+++ b/.cursor/skills/verify-sokosumi/features/README.md
@@ -51,6 +51,6 @@ Each feature file starts with an H1 title and one paragraph describing the user-
 - [Chat landing](./chat-landing.md) — authenticated default Welcome at `/` (not Ably messaging; `/chat` is adjacent).
 - [Tasks board](./tasks-board.md) — `/tasks` task manager shell (kanban / tabs).
 - [Projects](./projects.md) — `/projects` list or empty state.
-- [Files](./files.md) — `/drive` Recents / My Files (desktop main nav **Files**).
+- [Files](./files.md) — `/drive` Recents / browse (desktop main nav **Files**; personal tab **My Files**).
 - [Jobs history](./jobs-history.md) — `/history` unified History (tasks + jobs) for the signed-in user.
 - [Sign up](./sign-up.md) — disposable account creation when fixtures are absent.

--- a/.cursor/skills/verify-sokosumi/features/browse-agents.md
+++ b/.cursor/skills/verify-sokosumi/features/browse-agents.md
@@ -1,6 +1,6 @@
 # Browse agents
 
-Browse agents lets a signed-in user open `/agents`, use the **Coworker gallery**, and browse the **Agent catalog** tier below it (Cardano / x402, search, category, kind filters). App Hire stays off — catalog cards and Agent detail are read-only (no Hire, no price).
+Browse agents lets a signed-in user open `/agents`, use the **Coworker gallery**, and browse the **Agent catalog** tier below it (Cardano / x402, search, `categories`, kind filters). App Hire stays off — catalog cards and Agent detail are read-only (no Hire, no price).
 
 ## Sub-features
 
@@ -19,13 +19,13 @@ Preconditions:
 
 - Signed in (see [Sign in](./sign-in.md)); session healthy.
 - `verify-sokosumi doctor` ok.
-- Prefer a Neon fork with coworkers and catalog Agents; empty coworker list may render nothing under the gallery section (`return null`).
+- Prefer a Neon fork with coworkers and catalog Agents; empty coworker list returns `null` for the **whole gallery tier** (hero search included). Catalog still renders below.
 
 - **Open gallery.** Run `agent-browser open $WEB_URL/agents` then `agent-browser wait --load networkidle` and `agent-browser snapshot -i`. Page is `/agents` and not `/signin`.
 - **Cookie banner.** If **Accept all** is in the snapshot, click its `@eN` ref before catalog cards or lower-page clicks. The banner panel covers those targets; a click reports covered/no-op while URL stays `/agents`.
 - **Healthy gallery.** Snapshot shows coworker hero / **Your AI coworkers**, and catalog copy such as **Browse all agents** (or locale equivalent) when Core catalog data is present.
-- **Catalog card.** Prefer a Cardano catalog row / **Show Details** control that navigates to `/agents/<id>`. If the click stays on `/agents`, deep-link `/agents/<cardanoId>` (`agent-browser get attr @eN href`). x402 cards open an external resource URL when present (or show Details unavailable). Do not expect Hire / Create Job / credits price on catalog cards.
-- **Search miss (optional).** Type nonsense in the coworker search field (`?query=`); use the snapshot textbox ref if fill-by-name misses. Expect **Your AI coworkers** to clear under the hero. Catalog search uses `?agentQuery=` plus category / kind filters and does not share coworker search state.
+- **Catalog card.** Prefer a Cardano catalog row / **Show Details** control that navigates to `/agents/<id>`. Dismiss **Accept all** first, then `scrollintoview` the card. If the click stays on `/agents` (common when the card is below the fold), deep-link `/agents/<cardanoId>` (`agent-browser get attr @eN href`). x402 cards open an external resource URL when present (or show Details unavailable). Do not expect Hire / Create Job / credits price on catalog cards.
+- **Search miss (optional).** Type nonsense in the coworker search field (`?query=`); use the snapshot textbox ref if fill-by-name misses. Expect **Your AI coworkers** to clear under the hero. Catalog search uses `?agentQuery=` plus `categories` / `kind` filters and does not share coworker search state.
 - **Detail.** From a Cardano catalog card or Cardano deep-link `/agents/<id>` only: page loads read-only detail with no Hire and no price/credits chrome. Do not treat x402 catalog ids as in-app detail targets.
 - **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/browse-agents` then screenshot + `snapshot -i`.
 
@@ -33,6 +33,7 @@ Preconditions:
 
 - `/agents` stacks Coworker gallery above an Agent catalog Suspense tier (`getAllCoreAgents` / categories). Failures in the catalog tier must not blank the coworker gallery.
 - App Hire remains banned (ADR-0024); Core Hire APIs stay for Soko Bot / Coworker.
-- Soft-empty for coworkers is a blank gallery section; catalog uses **No agents available** / **No Agents found** (or locale equivalents). Keep kind/search chrome mounted when catalog filters match nothing.
+- Soft-empty for coworkers omits the entire gallery tier (`CoworkerGallerySection` returns `null`), including the hero search band. Catalog uses **No agents available** / **No Agents found** (or locale equivalents). Keep kind/search chrome mounted when catalog filters match nothing.
+- Catalog URL params are `agentQuery`, `categories` (array), and `kind` — not `category`.
 - Core Agent detail is Cardano-only; x402 catalog entries are external links, not `/agents/[id]`.
 - Cookie **Accept all** sits above catalog cards. Dismiss it (snapshot `@eN`) before clicking **Show Details**; fill-by-accessible-name for the coworker search can miss — use the textbox ref.

--- a/.cursor/skills/verify-sokosumi/features/files.md
+++ b/.cursor/skills/verify-sokosumi/features/files.md
@@ -6,7 +6,7 @@ Files lets a signed-in user open `/drive` (nav label **Files**) and see Recents 
 
 - `files-open` loads `/drive` while authenticated.
 - `files-recents-or-empty` shows Recents rows or “No recent files” (placeholder Blob tokens may toast **Failed to load recent files** — environment gap, not a routing failure).
-- `files-my-files-or-empty` shows My Files browse chrome (Upload / Create folder / list-grid) and rows or “No files yet”.
+- `files-my-files-or-empty` shows browse chrome (Upload / Create folder / list-grid). The browse tab label is **My Files** on a personal workspace; an org-scoped drive uses the org name (or **Organization**). Root browse usually includes a **Tasks** folder row even with no user files — heading **No files yet** only appears when that list is fully empty (for example a search miss).
 - `files-gated` is covered by the shared app auth gate (anonymous users bounce to sign-in).
 
 ## How to get to it (user POV)
@@ -24,13 +24,13 @@ Preconditions:
 - Prefer a desktop viewport so **Files** is in the sidebar.
 
 - **Open Files.** Run `agent-browser open $WEB_URL/drive` then `agent-browser wait --load networkidle` and `agent-browser snapshot -i`. URL stays `/drive` (not `/signin`).
-- **Recents.** Snapshot shows Recents / My Files tabs and either recent-file rows or heading **No recent files**. A toast **Failed to load recent files** with dummy Vercel Blob tokens is an environment gap (same class as Ably placeholders) — landing still counts if the Files shell and tabs are present.
-- **My Files.** Select the **My Files** tab (or open `$WEB_URL/drive?view=browse`). Snapshot shows browse chrome (**Upload**, **Create folder**, list/grid). Empty is valid (**No files yet** or an empty list). Do not require existing files.
+- **Recents.** Snapshot shows Recents plus the browse tab (**My Files** on personal, org name when org-scoped) and either recent-file rows or heading **No recent files**. A toast **Failed to load recent files** with dummy Vercel Blob tokens is an environment gap (same class as Ably placeholders) — landing still counts if the Files shell and tabs are present.
+- **My Files.** Select the browse tab (personal: **My Files**) or open `$WEB_URL/drive?view=browse`. Snapshot shows browse chrome (**Upload**, **Create folder**, list/grid). Empty user files are valid: a **Tasks** folder row at root, heading **No files yet**, or an empty list. Do not require uploaded files.
 - **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/files` then screenshot + snapshot of Recents and My Files.
 
 ## Gotchas
 
 - Nav label is **Files**; the route is `/drive`.
 - Desktop main nav includes Files after Tasks (and after Schedules when that beta item is on). Mobile does **not** show Files in the sidebar — use the You page.
-- Recents calls `GET /v1/drive/recents`, which needs a real Blob token. Placeholder local tokens 500 with **Failed to load recent files**; that is not proof the route is missing.
+- Recents calls `GET /v1/drive/recents`, which needs a real Blob token. Missing token is Core **503**; placeholder tokens may toast **Failed to load recent files**. That is an environment gap, not proof the route is missing.
 - Upload, rename, delete, and project File Browser (`/drive?view=tasks&projectId=…`) are out of scope for this landing entry.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Please assign this draft to @mrosberghaus.

`/maintain-verification-skill` pass for `.cursor/skills/verify-sokosumi`. Edit scope is the verification skill only. Live pass covered every mapped feature; these docs now match that run.

## What changed

- **Browse agents:** empty coworker list omits the whole gallery tier (hero included). Catalog filter query is `categories`, not `category`. Catalog card clicks that stay on `/agents` should `scrollintoview` or deep-link via `href`.
- **Files:** personal browse tab is **My Files**; org-scoped drive uses the org name. Root browse usually shows a **Tasks** folder even with no user files (**No files yet** is not the default empty). Missing Blob token is Core **503**, not 500.

## Live coverage

| Feature | Result |
| --- | --- |
| Sign in | `method=ui`, persist on `/agents` |
| Browse agents | gallery + catalog + Cardano detail (no Hire) |
| Chat landing | Welcome `/`; desktop `/chat` → `/` |
| Tasks board | Tasks/Jobs tabs + BACKLOG…DONE |
| Projects | **No projects yet** |
| Files | Recents empty + My Files chrome |
| Jobs history | **No history yet**; unauth gate → `/signin?returnUrl=%2Fhistory` |
| Sign up | form submit → `/` then `/setup` (no workspace) |

## Not in this PR

- No product-code changes.
- No harness script changes (bin already drove UI signup after terms check).
- Did not add new feature files for `/you`, `/notifications`, `/calendar` (beta), or `/chat/rooms/*` (Ably placeholders). Those remain unmapped; chat messaging is `verified-unreachable` without real Ably keys.

## Product gaps

None on the mapped surfaces.

![Sign-in persist on Agents](https://cursor.com/artifacts/c/art-0295acc2-2c6c-4475-8444-d83e8a640616)
![Welcome landing](https://cursor.com/artifacts/c/art-545ce2ae-48d9-4ddc-a308-6fceb118c8b2)
![Tasks board columns](https://cursor.com/artifacts/c/art-18c7ecf8-ad59-4736-b12b-bebf999130a8)
![Files Recents empty](https://cursor.com/artifacts/c/art-f9745e0f-2463-4ca9-898d-faeee7f37726)
![Signup workspace setup](https://cursor.com/artifacts/c/art-6c95f4f4-4328-4931-808d-a2f5dacbc6e6)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f8dc25-8546-4462-b238-c1cd1a78cd09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f8dc25-8546-4462-b238-c1cd1a78cd09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

