### PR TITLE
ci(workflows): report test matrix legs by name on docs-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,12 @@ jobs:
   test:
     name: Test ${{ matrix.target.name }}
     needs: changes
-    if: needs.changes.outputs.js == 'true' || github.event_name == 'workflow_dispatch'
+    # No job-level `if:` here on purpose: the matrix must expand so each
+    # leg reports under its real name (Test Web / Test Core / Test
+    # Packages), which the branch ruleset requires. Gating is per-step
+    # below, so docs-only PRs report fast successes instead of one
+    # `Test ${{ matrix.target.name }}` skip placeholder that satisfies
+    # none of the required contexts.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -60,9 +65,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup
+        if: needs.changes.outputs.js == 'true' || github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/setup
         with:
           turbo_team: ${{ vars.TURBO_TEAM }}
 
       - name: Run Tests
+        if: needs.changes.outputs.js == 'true' || github.event_name == 'workflow_dispatch'
         run: ${{ matrix.target.command }}


### PR DESCRIPTION
Docs-only PRs (e.g. #4237, markdown under .cursor/skills/) evaluate the paths-filter to js=false, so the test matrix skipped at job level and reported a single `Test ${{ matrix.target.name }}` placeholder. That name matches none of the required contexts (Test Web / Test Core / Test Packages), leaving them pending and the PR BLOCKED.

This moves the gate from the job to the Setup and Run Tests steps, so the matrix always expands and each leg reports success under its real name. Checkout stays unconditional; manual workflow_dispatch still runs everything. build.yml, lint.yml and apple.yml are untouched (single-job skips already report under their exact required names).

Verification:
- Parsed edited YAML: no job-level if, Setup + Run Tests gated on js == true or workflow_dispatch, matrix legs Web / Core / Packages / Local env / CI config intact
- git diff --check clean; pre-commit hooks passed on commit