### PR TITLE
chore(core): drop leftover Stripe console.log noise

### DIFF
--- a/apps/core/src/services/stripe-backed-subscription.service.ts
+++ b/apps/core/src/services/stripe-backed-subscription.service.ts
@@ -35,7 +35,7 @@ export async function reconcileActiveStripeBackedSubscription(
 
   const settledAt = new Date();
   await prisma.$transaction(async (tx) => {
-    const result = await tx.subscription.updateMany({
+    await tx.subscription.updateMany({
       where: {
         id: {
           not: localSubscription.id,
@@ -53,12 +53,6 @@ export async function reconcileActiveStripeBackedSubscription(
         status: "canceled",
       },
     });
-
-    if (result.count > 0) {
-      console.log(
-        `✅ Closed ${result.count} local free subscription(s) for reference ${localSubscription.referenceId} after Stripe subscription ${localSubscription.stripeSubscriptionId} became ${localSubscription.status}`,
-      );
-    }
 
     const organization = await tx.organization.findUnique({
       where: { id: localSubscription.referenceId },

--- a/apps/core/src/services/stripe-customer-created.service.test.ts
+++ b/apps/core/src/services/stripe-customer-created.service.test.ts
@@ -108,24 +108,15 @@ describe("handleCustomerCreatedEvent", () => {
   });
 
   it("ignores customers with an unknown customer type", async () => {
-    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { handleCustomerCreatedEvent } = await getService();
 
-    try {
-      const { handleCustomerCreatedEvent } = await getService();
+    await handleCustomerCreatedEvent({
+      id: "cus_other_1",
+      metadata: { customerType: "something-else" },
+    } as never);
 
-      await handleCustomerCreatedEvent({
-        id: "cus_other_1",
-        metadata: { customerType: "something-else" },
-      } as never);
-
-      expect(prismaUserUpdateMock).not.toHaveBeenCalled();
-      expect(prismaOrganizationUpdateMock).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "Unknown customer type something-else",
-      );
-    } finally {
-      consoleLogSpy.mockRestore();
-    }
+    expect(prismaUserUpdateMock).not.toHaveBeenCalled();
+    expect(prismaOrganizationUpdateMock).not.toHaveBeenCalled();
   });
 
   it("rethrows when the user write-back fails so Stripe retries the event", async () => {

--- a/apps/core/src/services/stripe-customer-created.service.ts
+++ b/apps/core/src/services/stripe-customer-created.service.ts
@@ -108,9 +108,5 @@ export async function handleCustomerCreatedEvent(
       });
       break;
     }
-    default: {
-      console.log(`Unknown customer type ${metadata?.customerType}`);
-      break;
-    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly cleanup area: `core-strip-stripe-console-logs`.

Remove leftover production `console.log` noise in two Stripe services. No logger wrappers, no per-handler `useLogger`, no billing/auth/webhook behavior change.

- `apps/core/src/services/stripe-backed-subscription.service.ts` — drop the “Closed N local free subscription(s)…” log (and the unused `result` capture that only served it)
- `apps/core/src/services/stripe-customer-created.service.ts` — drop the “Unknown customer type” log (and the now-empty `default` case)
- `apps/core/src/services/stripe-customer-created.service.test.ts` — keep unknown-type ignore coverage; drop the `console.log` spy

Existing `warn` / `error` / Sentry paths are unchanged.

### Why delete the empty default
After removing the log, `default: { break; }` would be a no-op leftover. Unknown `customerType` still no-ops via fall-through, which is the existing ignore behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07c81079-3ef1-4681-9649-d53046f68fdf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07c81079-3ef1-4681-9649-d53046f68fdf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

