### PR TITLE
fix(web): stack latest update with briefing column

### DIFF
--- a/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
@@ -259,7 +259,11 @@ describe("ProjectDetailPage", () => {
     expect(latestHeading.compareDocumentPosition(briefingHeading)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(screen.getByTestId("project-latest-update")).toBeInTheDocument();
+    const latestUpdate = screen.getByTestId("project-latest-update");
+    const briefing = screen.getByTestId("project-briefing");
+    expect(latestUpdate.parentElement).toBe(briefing.parentElement);
+    expect(briefing.parentElement?.className).toContain("xl:col-span-2");
+    expect(briefing.parentElement?.className).not.toContain("xl:col-span-3");
     expect(screen.getByText(/Shipped/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.tsx
@@ -93,18 +93,15 @@ export default async function ProjectDetailPage({
           websiteUrl={project.websiteUrl}
         >
           <div className="mt-6 grid grid-cols-1 gap-8 px-4 md:px-0 xl:grid-cols-3">
-            {project.latestUpdate ? (
-              <div className="xl:col-span-3">
+            <div className="order-1 space-y-8 xl:order-1 xl:col-span-2">
+              {project.latestUpdate ? (
                 <ProjectLatestUpdate
                   title={t("latestUpdate")}
                   content={project.latestUpdate.content}
                   showMoreLabel={t("showMore")}
                   showLessLabel={t("showLess")}
                 />
-              </div>
-            ) : null}
-
-            <div className="order-1 xl:order-1 xl:col-span-2">
+              ) : null}
               <ProjectBriefing
                 title={t("briefing")}
                 briefing={project.briefing}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Latest update on project details now shares the briefing column (`xl:col-span-2`) instead of spanning the full grid row.

- Latest update still renders above Briefing when a report exists
- The section stays hidden when there is no report
- Vertical spacing matches the overview grid (`space-y-8`)

Refs [SOK-981](https://linear.app/masumi/issue/SOK-981/latest-update-weekly-activity-report-on-project-details)

## Verification

- `pnpm --filter web test src/app/(app)/projects/[projectId]/page.test.tsx` — 4 passed
- Live project details at `https://web.sokosumi.localhost/projects/a1b2c3d4-e5f6-7890-abcd-ef1234567890`
  - xl (1440): Latest update and Briefing share `xl:col-span-2`; Brand sits to the right
  - mobile (390): same parent; Latest update still stacks above Briefing

[xl layout: latest update stacked with briefing, brand on the right](https://cursor.com/agents/bc-708aa4f4-9def-4a06-95ff-b8c6d38815d5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproject_details_xl_latest_update_with_briefing.png)

[project_details_latest_update_in_briefing_column.mp4](https://cursor.com/agents/bc-708aa4f4-9def-4a06-95ff-b8c6d38815d5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproject_details_latest_update_in_briefing_column.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-708aa4f4-9def-4a06-95ff-b8c6d38815d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-708aa4f4-9def-4a06-95ff-b8c6d38815d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

