### PR TITLE
chore(skills): drop stale docs/superpowers plan and spec paths

### DIFF
--- a/.agents/skills/brainstorming/SKILL.md
+++ b/.agents/skills/brainstorming/SKILL.md
@@ -97,7 +97,7 @@ your path and complete them in order.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Write design doc** — record architecture decisions in `docs/adr/` (see `docs/agents/domain.md`); track tickets in Linear. Do not write under `docs/superpowers/`.
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
@@ -203,7 +203,7 @@ is the whole process.
 
 **Documentation:**
 
-- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+- Write architecture decisions that belong in-repo to `docs/adr/` (`NNNN-slug.md`; see `docs/agents/domain.md`). Track work in Linear (`docs/agents/issue-tracker.md`). Do not write specs under `docs/superpowers/`.
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git

--- a/.agents/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/.agents/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -4,7 +4,7 @@ Use this template when dispatching a spec document reviewer subagent.
 
 **Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
 
-**Dispatch after:** Spec document is written to docs/superpowers/specs/
+**Dispatch after:** Spec document is written (architecture decisions in `docs/adr/`; never `docs/superpowers/`)
 
 ```
 Subagent (general-purpose):

--- a/.agents/skills/subagent-driven-development/SKILL.md
+++ b/.agents/skills/subagent-driven-development/SKILL.md
@@ -506,8 +506,8 @@ Use superpowers:finishing-a-development-branch.
 You: I'm using Subagent-Driven Development to execute this plan.
 
 [Setup: worktree verified]
-[Read plan file once: docs/superpowers/plans/feature-plan.md]
-[Resolve workspace: scripts/sdd-workspace docs/superpowers/plans/feature-plan.md — no ledger inside, fresh start]
+[Read plan file once: <plan-file>]
+[Resolve workspace: scripts/sdd-workspace <plan-file> — no ledger inside, fresh start]
 [Create todos for all tasks]
 
 Task 1: Hook installation script

--- a/.agents/skills/writing-plans/SKILL.md
+++ b/.agents/skills/writing-plans/SKILL.md
@@ -15,7 +15,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** If working in an isolated worktree, it should have been created via the `superpowers:using-git-worktrees` skill at execution time.
 
-**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
+**Do not write plans under `docs/superpowers/`.** Track work in Linear (team Sokosumi, key `SOK`; see `docs/agents/issue-tracker.md`). Architecture decisions that belong in-repo go in `docs/adr/` (see `docs/agents/domain.md`).
 - (User preferences for plan location override this default)
 
 ## Scope Check
@@ -154,7 +154,7 @@ If you find issues, fix them inline. No need to re-review — just fix and move 
 
 After saving the plan, offer execution choice:
 
-**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+**"Plan complete. Track the work in Linear; do not save it under `docs/superpowers/`. Two execution options:**
 
 **1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #4169, which deleted `docs/superpowers/` (shipped plans and specs). Three agent skills still told agents to write under that tree.

## What changed

Minimal path/guidance edits only. No skill rewrites, no vendor reinstall, no new `docs/superpowers/` tree.

- `writing-plans`: stop saving plans under `docs/superpowers/plans/`. Track work in Linear; architecture decisions that belong in-repo go in `docs/adr/`.
- `brainstorming`: same for specs (`docs/superpowers/specs/` → `docs/adr/` and Linear). Sibling `spec-document-reviewer-prompt.md` got the same one-line fix so the skill no longer points at the deleted path.
- `subagent-driven-development`: example workflow no longer reads `docs/superpowers/plans/feature-plan.md`.

`.claude/skills/{writing-plans,brainstorming,subagent-driven-development}` are directory symlinks to `.agents/skills/…`, so they were not edited twice.

## Out of scope

`requesting-code-review` still has an example `PLAN_OR_REQUIREMENTS` path under `docs/superpowers/plans/`. Left alone to keep this cleanup to the three named skills.

## Verification

```bash
rg 'docs/superpowers/(plans|specs)/' \
  .agents/skills/writing-plans \
  .agents/skills/brainstorming \
  .agents/skills/subagent-driven-development
```

Expect no matches that instruct writing under those directories. Remaining `docs/superpowers/` mentions are "do not write here" guards.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aad5a89f-ff64-4968-a468-640bbbd437bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aad5a89f-ff64-4968-a468-640bbbd437bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

