### PR TITLE
fix(chat): preserve room updates against stale polls

### DIFF
--- a/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
@@ -373,6 +373,38 @@ describe("authoritative sidebar refresh", () => {
     expect(result.current.roomRows.map((room) => room.id)).toEqual(["joined"]);
   });
 
+  it.each(["joined", "updated"])(
+    "keeps a %s room payload when an older poll finishes last",
+    async (change) => {
+      const original = channel("room");
+      const staleRooms = change === "joined" ? [] : [original];
+      const pendingPoll =
+        Promise.withResolvers<ReturnType<typeof emptyListResult>>();
+      listRoomsMock.mockReturnValueOnce(pendingPoll.promise);
+      const { result } = mount({ rooms: staleRooms });
+      const updated = { ...original, name: "New room name" };
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT, {
+            detail: { room: updated },
+          }),
+        );
+      });
+      expect(result.current.roomRows).toEqual([updated]);
+
+      await act(async () => pendingPoll.resolve(emptyListResult(staleRooms)));
+      expect(result.current.roomRows).toEqual([updated]);
+
+      const refreshed = { ...updated, name: "Later room name" };
+      listRoomsMock.mockResolvedValue(emptyListResult([refreshed]));
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+      });
+      expect(result.current.roomRows).toEqual([refreshed]);
+    },
+  );
+
   it("protects a read completed while the mount fetch was in flight", async () => {
     const original = channel("room", { unreadCount: 5 });
     const response =

--- a/apps/web/src/components/chat/use-organization-chat-rooms.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.ts
@@ -120,6 +120,7 @@ export function useOrganizationChatRooms({
    * appearing twice.
    */
   const upsertRoomToTop = useCallback((room: ChatRoom) => {
+    latestAppliedRefreshRef.current = beginRoomAttentionRefresh();
     setRoomRows((current) => {
       const without = current.filter((row) => row.id !== room.id);
       return applyRoomReadOverlays([room, ...without]);


### PR DESCRIPTION
VERIFIED: A poll that started before a room update could remove a joined room or restore an older room name. `upsertRoomToTop` now advances the existing revision counter before applying the room. Older polls are rejected; later refreshes still apply.

Addresses the remaining CodeRabbit finding on #4216. The original stack (#4216, #4218, #4219) has merged.

Validation:
- VERIFIED: Before the source fix, the hook suite reported `2 failed | 19 passed (21)`. Both new regression cases failed after the stale response arrived.
- VERIFIED: Hook, overlay, and sidebar suites reported `Test Files 5 passed (5)` and `Tests 49 passed (49)`.
- VERIFIED: `pnpm precommit` reported `19 successful, 19 total`; Biome reported `Checked 3807 files` and `No fixes applied`.
- REPORTED: Independent adversarial review found no issues in this diff. That review inspected code and tests; it did not run tests.
