### PR TITLE
feat(chat): share one plain-text preview rule for a room message

### DIFF
--- a/apps/web/src/app/(app)/chat/utils/unread-threads-preview.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/unread-threads-preview.test.ts
@@ -1,3 +1,4 @@
+import { CHAT_MESSAGE_PREVIEW_MAX_LENGTH } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 import { formatUnreadThreadsPreview } from "@/app/chat/utils/unread-threads-preview";
 
@@ -26,5 +27,17 @@ describe("formatUnreadThreadsPreview", () => {
 
   it("returns empty string when content is only markup", () => {
     expect(formatUnreadThreadsPreview("****")).toBe("");
+  });
+
+  /**
+   * A thread row is one line beside a room name. The shared rule already cuts
+   * to a length that fits, and this row must take the cut rather than let a
+   * long message push the room name off the screen.
+   */
+  it("cuts a long message to the length the shared rule allows", () => {
+    const preview = formatUnreadThreadsPreview("a".repeat(400));
+
+    expect([...preview]).toHaveLength(CHAT_MESSAGE_PREVIEW_MAX_LENGTH);
+    expect(preview.endsWith("…")).toBe(true);
   });
 });

--- a/apps/web/src/app/(app)/chat/utils/unread-threads-preview.ts
+++ b/apps/web/src/app/(app)/chat/utils/unread-threads-preview.ts
@@ -1,17 +1,12 @@
-import { stripMarkdownToText } from "@/lib/utils/strip-markdown";
-
-/** Persist mention token `@key:slug` (key is uuid, `all`, etc.). */
-const MENTION_TOKEN_REGEX = /@([^\s:]+):([^\s]+)/g;
+import { buildChatMessagePreview } from "@sokosumi/utils";
 
 /**
  * Build a scannable plain-text label for an unread-thread row.
- * Strips markdown and collapses `@id:slug` mention tokens to `@slug`.
+ *
+ * The rule lives in `@sokosumi/utils` because Core builds the same preview for
+ * an OS banner, and a message that reads one way in a thread row and another
+ * way on a lock screen is two answers to one message.
  */
 export function formatUnreadThreadsPreview(content: string): string {
-  const withReadableMentions = content.replace(
-    MENTION_TOKEN_REGEX,
-    (_match, _key: string, slug: string) => `@${slug}`,
-  );
-  const plain = stripMarkdownToText(withReadableMentions) ?? "";
-  return plain.replace(/\s+/g, " ").trim();
+  return buildChatMessagePreview(content);
 }

--- a/apps/web/src/lib/utils/sanitizeMarkdown.ts
+++ b/apps/web/src/lib/utils/sanitizeMarkdown.ts
@@ -1,7 +1,5 @@
+import { MARKDOWN_FENCED_BLOCK_REGEX } from "@sokosumi/utils";
 import sanitizeHtml from "sanitize-html";
-
-const FENCED_CODE_BLOCK_REGEX =
-  /(^|\n)(`{3,})([^\n]*)\n([\s\S]*?)\n\2(?=\n|$)/g;
 
 function createUniqueCodeBlockToken(
   source: string,
@@ -25,7 +23,7 @@ function tokenizeFencedCodeBlocks(markdown: string) {
   const usedTokens = new Set<string>();
 
   const tokenized = markdown.replace(
-    FENCED_CODE_BLOCK_REGEX,
+    MARKDOWN_FENCED_BLOCK_REGEX,
     (fullMatch: string, leadingNewline: string) => {
       const token = createUniqueCodeBlockToken(
         markdown,

--- a/packages/utils/src/chat-message-preview.test.ts
+++ b/packages/utils/src/chat-message-preview.test.ts
@@ -1,0 +1,657 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChatMessagePreview,
+  CHAT_MESSAGE_PREVIEW_MAX_LENGTH,
+} from "./chat-message-preview";
+
+describe("buildChatMessagePreview", () => {
+  it("reads a plain message back as it was written", () => {
+    expect(buildChatMessagePreview("can you look at the login flow")).toBe(
+      "can you look at the login flow",
+    );
+  });
+
+  it("shows a mention as the name it carries", () => {
+    expect(
+      buildChatMessagePreview(
+        "@019fc7e4-e4bd-7005-900c-66e44d33f5e4:Ada can you take this one",
+      ),
+    ).toBe("@Ada can you take this one");
+  });
+
+  it("shows a room-wide mention as the word the composer inserts", () => {
+    expect(buildChatMessagePreview("@all:all standup in five")).toBe(
+      "@all standup in five",
+    );
+  });
+
+  it("shows every mention in a message, not only the first", () => {
+    expect(
+      buildChatMessagePreview(
+        "@019fc7e4-e4bd-7005-900c-66e44d33f5e4:Ada @019fc7e4-e4bd-7005-900c-66e44d33f5e5:Ben standup?",
+      ),
+    ).toBe("@Ada @Ben standup?");
+  });
+
+  /**
+   * The key stops at `@`, so the token starts at the last one. Reading from
+   * the first would eat the words in front of it.
+   */
+  it("starts a mention at the last @, not the first", () => {
+    expect(
+      buildChatMessagePreview(
+        "@ada@019fc7e4-e4bd-7005-900c-66e44d33f5e4:Ada hi",
+      ),
+    ).toBe("@ada@Ada hi");
+  });
+
+  /**
+   * A uuid is written in either case. The room looks the key up, falls back
+   * to the slug when the key names nobody, and shows the name either way.
+   */
+  it("shows a mention whose key is written in capitals", () => {
+    expect(
+      buildChatMessagePreview(
+        "@019FC7E4-E4BD-7005-900C-66E44D33F5E4:Ada can you take this one",
+      ),
+    ).toBe("@Ada can you take this one");
+  });
+
+  /**
+   * The room reads the slug as `[^\s]+` (`MENTION_MATCH_REGEX`), so the name
+   * runs to the next space whatever it starts with. Reading less leaves the
+   * token unmatched, and a banner shows the reader a raw uuid.
+   */
+  it("shows a name the room reads but a word rule would not", () => {
+    expect(
+      buildChatMessagePreview(
+        "@019fc7e4-e4bd-7005-900c-66e44d33f5e4:-ada can you take this one",
+      ),
+    ).toBe("@-ada can you take this one");
+  });
+
+  /**
+   * A mention key is a uuid or `all`. The room rewrites a token only when its
+   * key names someone in the room, so every other `word:word` is text a
+   * person wrote and the preview has to leave it whole.
+   */
+  it("leaves a time alone, which only looks like a mention", () => {
+    expect(buildChatMessagePreview("standup @10:30am")).toBe(
+      "standup @10:30am",
+    );
+    expect(buildChatMessagePreview("export @16:9 please")).toBe(
+      "export @16:9 please",
+    );
+  });
+
+  it("leaves an address alone, which the room leaves alone too", () => {
+    expect(
+      buildChatMessagePreview("git clone git@github.com:org/repo.git"),
+    ).toBe("git clone git@github.com:org/repo.git");
+    expect(buildChatMessagePreview("ssh ada@10.0.0.4:2222")).toBe(
+      "ssh ada@10.0.0.4:2222",
+    );
+    expect(buildChatMessagePreview("note @TODO:fix the header")).toBe(
+      "note @TODO:fix the header",
+    );
+  });
+
+  it("strips markdown markers", () => {
+    expect(buildChatMessagePreview("**ship it** and _then_ tell me")).toBe(
+      "ship it and then tell me",
+    );
+  });
+
+  it("keeps the label of a link and drops the url", () => {
+    expect(
+      buildChatMessagePreview("see [the design](https://example.test/spec)"),
+    ).toBe("see the design");
+  });
+
+  it("keeps the text of an inline code span", () => {
+    expect(buildChatMessagePreview("run `pnpm test` first")).toBe(
+      "run pnpm test first",
+    );
+  });
+
+  /**
+   * `sanitizeMarkdown` runs over the raw body before the room parses it, so an
+   * inline code span is no shelter: the room renders this as "use `` not ``".
+   * A preview that kept the tag names would read back words the room removed.
+   */
+  it("drops a tag between backticks, which the room drops as well", () => {
+    expect(buildChatMessagePreview("use `<Button>` not `<button>`")).toBe(
+      "use not",
+    );
+  });
+
+  /**
+   * `sanitizeMarkdown` drops a comment before the room renders it, so nobody
+   * reading the message ever sees this. A banner that showed it would be the
+   * one surface the text reaches.
+   */
+  it("drops an html comment, which the room shows to nobody", () => {
+    expect(
+      buildChatMessagePreview("looks fine <!-- token=sk-live-abc123 -->"),
+    ).toBe("looks fine");
+  });
+
+  /**
+   * These five are `sanitize-html`'s own `nonTextTags`. It throws the words
+   * away with the tags, so a reader opening the message sees nothing of them.
+   */
+  it.each(["script", "style", "textarea", "option", "xmp"])(
+    "drops the words inside a <%s>, which the room shows to nobody",
+    (tag) => {
+      expect(
+        buildChatMessagePreview(
+          `nothing to see <${tag}>the door code is 4417</${tag}>`,
+        ),
+      ).toBe("nothing to see");
+    },
+  );
+
+  /** A tag name is case-insensitive, and so is the room reading one. */
+  it("drops the words inside a non-text element written in capitals", () => {
+    expect(
+      buildChatMessagePreview(
+        "nothing to see <SCRIPT>the code is 4417</SCRIPT>",
+      ),
+    ).toBe("nothing to see");
+  });
+
+  /**
+   * The room reads to the close tag that matches the open one and treats
+   * every other tag on the way as part of the text it throws away.
+   */
+  it("reads a non-text element to the close tag that matches it", () => {
+    expect(
+      buildChatMessagePreview(
+        "note <script>a</b> the code is 4417</script> end",
+      ),
+    ).toBe("note end");
+  });
+
+  it("reads two non-text elements as two, not as one long one", () => {
+    expect(
+      buildChatMessagePreview(
+        "one <style>a</style> MIDDLE <style>b</style> two",
+      ),
+    ).toBe("one MIDDLE two");
+  });
+
+  it("drops the words inside an element the writer never closed", () => {
+    expect(
+      buildChatMessagePreview("nothing to see <script>the door code is 4417"),
+    ).toBe("nothing to see");
+  });
+
+  it("drops an html comment the writer never closed", () => {
+    expect(
+      buildChatMessagePreview("looks fine <!-- token=sk-live-abc123"),
+    ).toBe("looks fine");
+  });
+
+  it("leaves the words either side of a comment two words", () => {
+    expect(buildChatMessagePreview("meet<!-- not today -->at five")).toBe(
+      "meet at five",
+    );
+  });
+
+  /** The address belongs to the markup: markdown prints the label alone. */
+  it("drops a link reference definition and keeps the words", () => {
+    expect(
+      buildChatMessagePreview(
+        "see [the doc][1]\n\n[1]: https://internal.example/secret",
+      ),
+    ).toBe("see [the doc][1]");
+  });
+
+  it("keeps a colon in the words, which starts no definition", () => {
+    expect(buildChatMessagePreview("note: [the doc] is ready")).toBe(
+      "note: [the doc] is ready",
+    );
+  });
+
+  /**
+   * A definition holds one destination and an optional title. What follows
+   * the colon here is a sentence, and markdown prints it as one.
+   */
+  it("keeps a bracketed line the room prints as a sentence", () => {
+    expect(buildChatMessagePreview("[Note]: this is important")).toBe(
+      "[Note]: this is important",
+    );
+    expect(
+      buildChatMessagePreview(
+        "deploy stopped\n\n[Warning]: do not ship on friday",
+      ),
+    ).toBe("deploy stopped [Warning]: do not ship on friday");
+  });
+
+  it("drops a definition that carries a title beside its address", () => {
+    expect(
+      buildChatMessagePreview(
+        'see [the doc][1]\n\n[1]: https://e.test/x "The doc"',
+      ),
+    ).toBe("see [the doc][1]");
+  });
+
+  /**
+   * Markdown closes a fence at the end of the message, on a line indented up
+   * to three spaces, and on tildes. The room prints no delimiter line and no
+   * info string, and an info string is a whole line the writer chose.
+   */
+  it.each([
+    ["an unclosed fence", "```call 555-0100 to unlock your account"],
+    ["a tilde fence", "~~~call 555-0100 to unlock\ny\n~~~"],
+    ["a closer that is indented", "```call 555-0100 to unlock\ny\n   ```"],
+  ])("shows no info string from %s", (_name, content) => {
+    expect(buildChatMessagePreview(content)).not.toContain("555-0100");
+  });
+
+  /**
+   * A backtick fence carries no backtick in its info string, so this line is
+   * a code span and the room shows the words in it.
+   */
+  it("shows a code span that opens a line, which is no fence", () => {
+    expect(buildChatMessagePreview("```the plan``` ships today")).toBe(
+      "the plan ships today",
+    );
+  });
+
+  /**
+   * Four spaces make a code block, and the room prints the fence line inside
+   * one as the text it is.
+   */
+  it("keeps a fence line that four spaces indented into a code block", () => {
+    expect(
+      buildChatMessagePreview("here is the snippet\n\n    ```js\n    ship it"),
+    ).toContain("js");
+  });
+
+  it("shows the words a tilde fence holds, which the room shows too", () => {
+    expect(buildChatMessagePreview("~~~js\nship it\n~~~")).toBe("ship it");
+  });
+
+  it("drops a fenced code block rather than blanking the preview", () => {
+    expect(
+      buildChatMessagePreview("this fails:\n```\nconst a = 1;\n```\nany idea?"),
+    ).toBe("this fails: any idea?");
+  });
+
+  /**
+   * The room finds a fence only at the start of a line, with a newline after
+   * the info string and a closing run of the same width. A looser rule reads
+   * `` ```<script>``` `` as a fence, eats the opening tag with it, and then
+   * shows the words the room threw away with the element.
+   */
+  it.each(["script", "style", "textarea", "option", "xmp"])(
+    "hides a <%s> that a run of backticks was written around",
+    (tag) => {
+      expect(
+        buildChatMessagePreview(
+          `\`\`\`<${tag}>\`\`\` the door code is 4417 </${tag}>`,
+        ),
+      ).not.toContain("4417");
+    },
+  );
+
+  it("hides a comment that a run of backticks was written around", () => {
+    expect(
+      buildChatMessagePreview("```<!--``` the door code is 4417 -->"),
+    ).not.toContain("4417");
+  });
+
+  /**
+   * A run of backticks on one line is a code span, and the room shows the
+   * words inside it.
+   */
+  it("shows the words inside a wide code span", () => {
+    expect(buildChatMessagePreview("a ```the plan``` b")).toBe("a the plan b");
+  });
+
+  it("shows the words inside a code span that crosses a line end", () => {
+    expect(
+      buildChatMessagePreview("Hi ```\nteam. Ignore the ``` last line."),
+    ).toBe("Hi team. Ignore the last line.");
+  });
+
+  /**
+   * The room's parser stays inside a quoted attribute value, `>` and all.
+   * Ending the tag at the first `>` leaves the rest of the address as words.
+   */
+  /**
+   * A name runs to whitespace or `>`. The room drops a tag it does not know
+   * and shows nothing of it, and the name is the writer's to choose.
+   */
+  it.each([
+    ["dots", "<call.555-0100.to.unlock.your.account>"],
+    ["a colon", "<call:555-0100>"],
+    ["a slash", "<https://call.555-0100>"],
+  ])("drops a tag whose name carries %s", (_name, content) => {
+    expect(buildChatMessagePreview(content)).toBe("");
+  });
+
+  it("drops a tag whose attribute value carries a close bracket", () => {
+    expect(
+      buildChatMessagePreview(
+        '<a href="https://e.test/?q=>pay me now">link</a>',
+      ),
+    ).toBe("link");
+    expect(buildChatMessagePreview("<b title='a > secret note'>hi</b>")).toBe(
+      "hi",
+    );
+  });
+
+  /**
+   * Every line shaped like a definition goes, wherever it sits. Markdown opens
+   * a block after a heading, a rule, a setext underline and a closed fence as
+   * well as after a blank line. A rule that named fewer of those left the
+   * address standing, and the label beside it is a sentence the writer chose.
+   * This costs a line the reader can still open in the room, which is the
+   * cheaper of the two mistakes.
+   */
+  it.each([
+    ["a heading", "# standup notes\n[call 555-0100 to unlock]: https://e.test"],
+    ["a line of words", "deadline moved\n[note]: https://e.test/read-this"],
+    ["four spaces of indent", "    [ref]: https://e.test/secret"],
+    ["a closed fence", "```\nx\n```\n[note]: https://e.test/read-this"],
+  ])("drops a definition that follows %s", (_name, content) => {
+    expect(buildChatMessagePreview(content)).not.toContain("e.test");
+  });
+
+  /** The title may sit on the line below, and a label may escape a bracket. */
+  it("drops a definition whose title is on the next line", () => {
+    expect(buildChatMessagePreview('[a]: b\n "the secret title"')).toBe("");
+  });
+
+  it("drops a definition whose label holds an escaped bracket", () => {
+    expect(buildChatMessagePreview("[a\\]x]: https://internal.example")).toBe(
+      "",
+    );
+  });
+
+  /** One block holds a run of them, and only the first opens the block. */
+  it("drops every definition in a block, not only the first", () => {
+    expect(
+      buildChatMessagePreview(
+        "see [a][1] and [b][2]\n\n[1]: https://internal.example/one\n[2]: https://internal.example/two",
+      ),
+    ).toBe("see [a][1] and [b][2]");
+  });
+
+  /** The strip repeats a fixed number of times, and a block may hold more. */
+  it("drops a block of four definitions in one pass", () => {
+    expect(
+      buildChatMessagePreview(
+        "see it\n\n[1]: https://internal.example/one\n[2]: https://internal.example/two\n[3]: https://internal.example/three\n[4]: https://internal.example/four",
+      ),
+    ).toBe("see it");
+  });
+
+  /**
+   * The blank line that opened the block stays put. Taking it away joins the
+   * next definition to the line above, and a definition that opens no block
+   * is left standing with its address.
+   */
+  it("drops two definitions that a blank line stands between", () => {
+    expect(
+      buildChatMessagePreview(
+        "a\n\n[1]: https://internal.example/one\n\n[2]: https://internal.example/two",
+      ),
+    ).toBe("a");
+  });
+
+  it("keeps a bracketed line whose colon is followed by nothing", () => {
+    expect(buildChatMessagePreview("[Todo]:\nbuy milk")).toBe(
+      "[Todo]: buy milk",
+    );
+  });
+
+  it("keeps a line whose brackets hold no label", () => {
+    expect(buildChatMessagePreview("[]: nothing\nreal words")).toBe(
+      "[]: nothing real words",
+    );
+  });
+
+  /**
+   * The room tokenizes a fence out before it sanitizes, so markup written
+   * inside one is text there. Read as markup here, an unclosed tag or comment
+   * runs to the end of the body and swallows the words that follow it.
+   */
+  it("reads the words after a fence that holds an unclosed element", () => {
+    expect(
+      buildChatMessagePreview(
+        "```html\n<script>\n```\n\nprod is down, roll back release 42",
+      ),
+    ).toBe("prod is down, roll back release 42");
+  });
+
+  it("reads the words after a fence that holds an unclosed comment", () => {
+    expect(buildChatMessagePreview("```\n<!-- todo\n```\nship it")).toBe(
+      "ship it",
+    );
+  });
+
+  it("reads a message that carries html as its words alone", () => {
+    expect(buildChatMessagePreview("Hello <b>world</b>")).toBe("Hello world");
+  });
+
+  /**
+   * A name runs to whitespace or `>`, so `<di<div>` is one tag here and one
+   * tag to the room, which shows `v>alert(1) hi`. The `>` goes to the blunt
+   * marker strip, which is a limit this rule already carries.
+   */
+  it("leaves no partial tag behind when one tag hides inside another", () => {
+    expect(buildChatMessagePreview("<di<div>v>alert(1)</div> hi")).toBe(
+      "valert(1) hi",
+    );
+  });
+
+  /**
+   * The same trick around a non-text element. What the strip leaves is a
+   * fragment of markup rather than words, and the words the room threw away
+   * are gone either way, which is the part that matters.
+   */
+  it("keeps the words out of a non-text element hidden inside another tag", () => {
+    expect(
+      buildChatMessagePreview(
+        "<scr<script>ipt>the door code is 4417</script> hi",
+      ),
+    ).not.toContain("4417");
+  });
+
+  /**
+   * Both halves matter: without the tag name, `< 10 and y >` reads as one tag
+   * and the words between it go. The `>` goes either way, because the cleaner
+   * reads it as a quote marker.
+   */
+  it("keeps a comparison, which is not a tag", () => {
+    expect(buildChatMessagePreview("use x < 10 and y > 3 as the range")).toBe(
+      "use x < 10 and y 3 as the range",
+    );
+  });
+
+  it("keeps two paragraphs two words apart", () => {
+    expect(buildChatMessagePreview("<p>one</p><p>two</p>")).toBe("one two");
+  });
+
+  it("reads a tag that closes itself as one tag", () => {
+    expect(buildChatMessagePreview("line one<br/>line two")).toBe(
+      "line one line two",
+    );
+  });
+
+  /**
+   * A pass can reveal one more construct, so the strip repeats. It repeats a
+   * fixed number of times, because a body of half-open brackets would
+   * otherwise buy a pass each and cost seconds of the server's only thread.
+   *
+   * The budget is loose on purpose. This body takes about 18 seconds without
+   * the cap and about a third of a second with it, so a second and a half
+   * tells the two apart while leaving room for a machine running the rest of
+   * the suite beside it.
+   */
+  it("reads a message of broken brackets without stalling", () => {
+    const body = `${"[](".repeat(1666)}${"<a".repeat(1666)}${">".repeat(1666)}`;
+    const started = performance.now();
+
+    buildChatMessagePreview(body);
+
+    expect(performance.now() - started).toBeLessThan(1500);
+  });
+
+  /**
+   * Interleaved brackets are what buy a pass each: every tag closing at the
+   * same level goes in one pass, so only this shape reaches the cap.
+   */
+  it("clears three levels of interleaved tags", () => {
+    expect(buildChatMessagePreview("<a<b<c>>> hi")).toBe("hi");
+  });
+
+  it("keeps a link whose address is written in angle brackets", () => {
+    expect(
+      buildChatMessagePreview("see [the design](<https://example.test/spec>)"),
+    ).toBe("see the design");
+  });
+
+  it("joins a multi-line message into one line", () => {
+    expect(buildChatMessagePreview("first line\n\nsecond line")).toBe(
+      "first line second line",
+    );
+  });
+
+  it("names the file when the message is only a file", () => {
+    expect(
+      buildChatMessagePreview("[report.pdf](https://example.test/report.pdf)"),
+    ).toBe("report.pdf");
+  });
+
+  it("names the image when the message is only an image", () => {
+    expect(
+      buildChatMessagePreview("![shot](https://example.test/shot.png)"),
+    ).toBe("shot");
+  });
+
+  it("drops an image that carries no alt rather than showing its url", () => {
+    expect(buildChatMessagePreview("![](https://example.test/shot.png)")).toBe(
+      "",
+    );
+  });
+
+  it("drops a link that carries no label rather than showing its url", () => {
+    expect(buildChatMessagePreview("[](https://example.test/shot.png)")).toBe(
+      "",
+    );
+  });
+
+  it("drops an empty link that only appears once the outer one goes", () => {
+    expect(
+      buildChatMessagePreview("[[]()](https://example.test/shot.png)"),
+    ).toBe("");
+  });
+
+  it("keeps the words of a message whose image carries no alt", () => {
+    expect(
+      buildChatMessagePreview(
+        "here is the chart\n![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg)",
+      ),
+    ).toBe("here is the chart");
+  });
+
+  it("keeps the file's name beside the words that came with it", () => {
+    expect(
+      buildChatMessagePreview(
+        "here it is [report.pdf](https://example.test/report.pdf)",
+      ),
+    ).toBe("here it is report.pdf");
+  });
+
+  it("names every image when a message carries more than one", () => {
+    expect(
+      buildChatMessagePreview(
+        "![one](https://example.test/1.png) ![two](https://example.test/2.png)",
+      ),
+    ).toBe("one two");
+  });
+
+  it("drops every unlabelled link, not only the first", () => {
+    expect(
+      buildChatMessagePreview(
+        "[](https://example.test/1.png)[](https://example.test/2.png)" +
+          "[](https://example.test/3.png)[](https://example.test/4.png)",
+      ),
+    ).toBe("");
+  });
+
+  it("names every file when a message carries more than one", () => {
+    expect(
+      buildChatMessagePreview(
+        "[a.pdf](https://example.test/a.pdf) [b.pdf](https://example.test/b.pdf)",
+      ),
+    ).toBe("a.pdf b.pdf");
+  });
+
+  it("returns nothing when the body cleans to nothing", () => {
+    expect(buildChatMessagePreview("   \n  ")).toBe("");
+  });
+
+  it("cuts a long message and says it was cut", () => {
+    const preview = buildChatMessagePreview("a".repeat(400));
+
+    expect([...preview]).toHaveLength(CHAT_MESSAGE_PREVIEW_MAX_LENGTH);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  it("leaves a message at the limit whole", () => {
+    const body = "a".repeat(CHAT_MESSAGE_PREVIEW_MAX_LENGTH);
+
+    expect(buildChatMessagePreview(body)).toBe(body);
+  });
+
+  /**
+   * The limit counts codepoints, so a message of emoji at the limit is whole
+   * too. Counting the string's length instead would cut it and claim a cut
+   * that the reader's message did not have.
+   */
+  it("leaves a message of emoji at the limit whole", () => {
+    const body = "\u{1F642}".repeat(CHAT_MESSAGE_PREVIEW_MAX_LENGTH);
+
+    expect(buildChatMessagePreview(body)).toBe(body);
+  });
+
+  it("does not leave a space hanging before the ellipsis", () => {
+    const preview = buildChatMessagePreview(
+      `${"a".repeat(CHAT_MESSAGE_PREVIEW_MAX_LENGTH - 2)} ${"b".repeat(50)}`,
+    );
+
+    expect(preview.endsWith("a\u2026")).toBe(true);
+  });
+
+  it("never cuts inside a character built from several codepoints", () => {
+    const family = "\u{1F468}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}";
+    const preview = buildChatMessagePreview(family.repeat(40));
+
+    expect(preview.endsWith(`${family}\u2026`)).toBe(true);
+    expect([...preview].length).toBeLessThanOrEqual(
+      CHAT_MESSAGE_PREVIEW_MAX_LENGTH,
+    );
+  });
+
+  /**
+   * The ellipsis stands for the words it replaced. On its own it stands for
+   * nothing, and the caller reads an empty preview as "show the sender".
+   */
+  it("returns nothing when one character is longer than the whole limit", () => {
+    const body = `a${"\u0301".repeat(CHAT_MESSAGE_PREVIEW_MAX_LENGTH)}`;
+
+    expect(buildChatMessagePreview(body)).toBe("");
+  });
+
+  it("never cuts inside an emoji", () => {
+    const preview = buildChatMessagePreview("🙂".repeat(400));
+
+    expect([...preview]).toHaveLength(CHAT_MESSAGE_PREVIEW_MAX_LENGTH);
+    expect(preview.endsWith("🙂…")).toBe(true);
+  });
+});

--- a/packages/utils/src/chat-message-preview.ts
+++ b/packages/utils/src/chat-message-preview.ts
@@ -1,0 +1,244 @@
+import { cleanChatMessageText } from "./chat-room-quote-snippet.js";
+import { MARKDOWN_FENCED_BLOCK_REGEX } from "./markdown-fenced-block.js";
+
+/**
+ * Persisted mention token `@key:slug`.
+ *
+ * The key is a uuid (users, coworkers and soko bots all carry one) or the
+ * room-wide `all`. Nothing else, because the room rewrites a token only when
+ * its key names someone in the room and leaves every other `word:word` as
+ * written. A looser rule here eats the middle of ordinary text: `@10:30am` is
+ * a time, and `git@github.com:org/repo.git` is an address.
+ */
+const MENTION_TOKEN_REGEX =
+  /@([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|all):(\S+)/g;
+
+/** The `!` of `![alt](url)`, which the link scan leaves behind on its own. */
+const MARKDOWN_IMAGE_BANG_REGEX = /!(?=\[[^\][]*\]\()/g;
+
+/**
+ * `![](url)` and `[](url)`. The link scan wants a label and finds none, so
+ * without this the url itself is left standing where the words should be.
+ */
+const EMPTY_LABEL_LINK_REGEX = /!?\[\]\([^)]*\)/g;
+
+/**
+ * A named tag: `<b>`, `</b>`, `<img src="x">`, `<br/>`, `<x:a-b>`.
+ *
+ * A name starts with a letter and then runs to whitespace or `>`, which is
+ * where the room's parser ends one. Reading a narrower name leaves the rest
+ * standing as words, and the name is the writer's to choose: the room shows
+ * nothing at all for `<call.555-0100.to.unlock.your.account>`, because it
+ * drops the tag it does not know.
+ *
+ * A quoted attribute value runs to its closing quote, `>` included, for the
+ * same reason. The room shows `link` for
+ * `<a href="https://e.test/?q=>pay me">link</a>`, and so must this.
+ *
+ * The leading letter is what keeps `x < 10` a comparison. A comparison
+ * written without spaces still reads as a tag, which no plain-text rule can
+ * tell apart from one.
+ */
+const HTML_TAG_REGEX =
+  /<\/?[A-Za-z][^\s>]*(?:\s(?:"[^"]*"|'[^']*'|[^>"'])*)?\/?>/g;
+
+/**
+ * An html comment, closed or left open.
+ *
+ * The room renders none of this, so text parked in one reaches nobody who
+ * opens the message. Carrying it to a banner would make the lock screen the
+ * one place a message can be read.
+ */
+const HTML_COMMENT_REGEX = /<!--[\s\S]*?(?:-->|$)/g;
+
+/**
+ * An element whose text the room throws away with the tags.
+ *
+ * These five are `sanitize-html`'s own `nonTextTags`: it drops what is between
+ * them, not only the tags around it. Keeping the words would put a sentence on
+ * a lock screen that nobody opening the message can read.
+ *
+ * The close tag is matched by name, because the parser reads to the matching
+ * one and treats every other tag on the way as text. Case-insensitive, because
+ * a tag name is.
+ */
+const NON_TEXT_ELEMENT_REGEX =
+  /<(script|style|textarea|option|xmp)\b[^>]*>[\s\S]*?(?:<\/\1\s*>|$)/gi;
+
+/**
+ * A link reference definition: `[1]: https://example.test`, with its title on
+ * that line or the next, and its label free to carry an escaped bracket.
+ *
+ * Markdown reads it as the address for a `[label][1]` somewhere else and
+ * prints none of it. The address is markup, not words, and the label beside
+ * it is a whole sentence the writer chose.
+ *
+ * It is deliberately read on any line, at any indent, rather than only where
+ * markdown would open a block. Markdown opens one after a heading, a rule, a
+ * setext underline and a closed fence as well as after a blank line, and a
+ * rule that names fewer of those leaves a definition standing with its
+ * address on the banner. Reading one line too many costs a line of a message
+ * that a reader can still open; reading one too few puts a sentence on a lock
+ * screen that nobody can check. Taking a whole line can leave no words
+ * behind, so it cannot leave the words of a definition it half-removed.
+ *
+ * What it will not take is a line that only looks like one. A definition
+ * holds one destination and at most one title, so `[Note]: this is important`
+ * stays the sentence markdown prints.
+ */
+const LINK_DEFINITION_REGEX =
+  /^[^\S\n]*\[(?:\\[\s\S]|[^\][\\])+\][^\S\n]*:[^\S\n]*(?:\n[^\S\n]*)?\S+[^\S\n]*(?:(?:\n[^\S\n]*)?(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?[^\S\n]*$/gm;
+
+/**
+ * The line that opens or closes a fence.
+ *
+ * The block rule above takes out a fence that is closed and written in
+ * backticks, which is the only shape the room lifts out before it sanitizes.
+ * Markdown itself knows more: a fence closes at the end of the message, it
+ * closes on a line indented up to three spaces, and it opens on tildes. The
+ * room prints none of those delimiter lines, and an info string is the
+ * writer's to choose, so `` ```call 555-0100 to unlock your account `` would
+ * otherwise be a whole sentence on a lock screen above an empty code block.
+ *
+ * A backtick fence carries no backtick in its info string, which is what
+ * keeps `` ```the plan``` `` the code span the room shows.
+ */
+const FENCE_DELIMITER_LINE_REGEX = /^ {0,3}(?:`{3,}[^`\n]*|~{3,}[^\n]*)$/gm;
+
+/**
+ * A run of backticks, which the cleaner below reads only one of.
+ *
+ * `` ```plan``` `` on one line is a code span, and the room shows the words
+ * in it. The cleaner takes a fence out before it unwraps a span, so a run left
+ * whole would read as a fence and the words would go. One backtick is what the
+ * room's own rule comes down to for a span of any width.
+ */
+const BACKTICK_RUN_REGEX = /`{2,}/g;
+
+/**
+ * How many times the strip below may repeat.
+ *
+ * The two constructs that a strip can reveal are one level deep, and two
+ * passes settle either. The cap is what stops a body built out of thousands of
+ * half-open brackets from buying a pass each, which costs seconds of the
+ * server's only thread for a message anyone may post.
+ */
+const MAX_STRIP_PASSES = 3;
+
+/**
+ * Removing one of these can complete another: `[[]()](url)` leaves a whole
+ * empty link once the inner one goes, and a global scan has already passed
+ * the place the new one starts at. So repeat, up to the cap.
+ *
+ * Where a repair and the room's parser disagree, the preview says less. The
+ * room reads `<scr<script>ipt>x</script>` as one unknown tag and prints
+ * `ipt>x`, while the strip here takes the whole element out. Saying less is
+ * the safe half of the promise and the half a plain-text rule can keep.
+ *
+ * A tag becomes a space rather than nothing: `<p>one</p><p>two</p>` is two
+ * words, and joining them into one would say something the writer did not.
+ */
+function stripTags(text: string): string {
+  let current = text;
+
+  for (let pass = 0; pass < MAX_STRIP_PASSES; pass += 1) {
+    const stripped = current
+      .replace(HTML_COMMENT_REGEX, " ")
+      .replace(NON_TEXT_ELEMENT_REGEX, " ")
+      .replace(LINK_DEFINITION_REGEX, "")
+      .replace(HTML_TAG_REGEX, " ")
+      .replace(EMPTY_LABEL_LINK_REGEX, "");
+    if (stripped === current) {
+      break;
+    }
+
+    current = stripped;
+  }
+
+  return current;
+}
+
+/**
+ * The longest preview a caller may show.
+ *
+ * Matches the push parameter ceiling in Core, so the preview stored on a
+ * notification row and the one that rides a push are the same string. Cutting
+ * here rather than there also buys the ellipsis: the push cap protects a
+ * display name, where a silent cut reads as the whole name, and this protects
+ * a sentence, where it reads as the whole message.
+ */
+export const CHAT_MESSAGE_PREVIEW_MAX_LENGTH = 128;
+
+/** Counted in codepoints, cut on what the reader sees as one character. */
+const GRAPHEME_SEGMENTER = new Intl.Segmenter();
+
+/**
+ * Cut on a grapheme, so the last thing standing is a character.
+ *
+ * A codepoint is not a character: a family emoji, a flag, a skin tone and an
+ * accented letter are each several, and a cut between them leaves a joiner
+ * with nothing to join or a letter without its accent.
+ */
+function capPreview(preview: string): string {
+  if ([...preview].length <= CHAT_MESSAGE_PREVIEW_MAX_LENGTH) {
+    return preview;
+  }
+
+  // One codepoint of the budget goes to the ellipsis.
+  const budget = CHAT_MESSAGE_PREVIEW_MAX_LENGTH - 1;
+  let kept = "";
+  let length = 0;
+
+  for (const { segment } of GRAPHEME_SEGMENTER.segment(preview)) {
+    const size = [...segment].length;
+    if (length + size > budget) {
+      break;
+    }
+
+    kept += segment;
+    length += size;
+  }
+
+  // A cut that keeps nothing has nothing to say it cut, and an ellipsis alone
+  // reads as a message. Say nothing instead, and let the caller fall back.
+  const trimmed = kept.trimEnd();
+
+  return trimmed ? `${trimmed}\u2026` : "";
+}
+
+/**
+ * One line of plain text standing for a room message body.
+ *
+ * Used where a message is named rather than read: an OS banner, a thread-list
+ * row. Mention tokens become the name they carry, because `@<uuid>:Ada` is an
+ * id the reader never sees anywhere else in the product. A file keeps the name
+ * it was posted under, because that name is what the sender wrote.
+ *
+ * Returns an empty string when the body cleans to nothing at all. The caller
+ * decides what an empty preview means: a banner drops its body, and a
+ * thread-list row falls back to the sender.
+ */
+export function buildChatMessagePreview(content: string): string {
+  // A fence goes first, by the room's own rule. The room lifts one out before
+  // it sanitizes, so an unclosed `<script>` or `<!--` written inside a fence
+  // is text there, not markup. Reading it as markup here would swallow the
+  // rest of the message: the strip runs to the end of the body when it finds
+  // no close tag.
+  //
+  // A code span is different. `sanitizeMarkdown` runs over the raw body, so
+  // the room renders "use `` not ``" for "use `<Button>` not `<button>`", and
+  // a preview that kept the tag names would read back words the room removed.
+  const withoutCode = content
+    .replace(MARKDOWN_FENCED_BLOCK_REGEX, " ")
+    .replace(FENCE_DELIMITER_LINE_REGEX, "");
+  const readable = stripTags(withoutCode)
+    .replace(MARKDOWN_IMAGE_BANG_REGEX, "")
+    .replace(BACKTICK_RUN_REGEX, "`")
+    .replace(MENTION_TOKEN_REGEX, (_match, _key: string, slug: string) => {
+      return `@${slug}`;
+    });
+
+  const oneLine = cleanChatMessageText(readable).replace(/\s+/g, " ").trim();
+
+  return capPreview(oneLine);
+}

--- a/packages/utils/src/chat-room-quote-snippet.test.ts
+++ b/packages/utils/src/chat-room-quote-snippet.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildQuoteSnippet,
   buildRoomQuoteSnippetParts,
+  cleanChatMessageText,
 } from "./chat-room-quote-snippet";
 
 describe("buildQuoteSnippet", () => {
@@ -111,5 +112,18 @@ describe("buildRoomQuoteSnippetParts", () => {
         mediaKind: "image",
       },
     });
+  });
+});
+
+describe("cleanChatMessageText", () => {
+  /**
+   * A label stops at a bracket, so an unclosed `[` in front of a link is not
+   * read as the start of that link's label. Reading it that way would put the
+   * words of the broken bracket inside the label and drop the real one.
+   */
+  it("reads a link whose label is preceded by an unclosed bracket", () => {
+    expect(cleanChatMessageText("see [a [b](https://e.test/x)")).toBe(
+      "see [a b",
+    );
   });
 });

--- a/packages/utils/src/chat-room-quote-snippet.ts
+++ b/packages/utils/src/chat-room-quote-snippet.ts
@@ -29,7 +29,7 @@ export function buildRoomQuoteSnippetParts(
     : content;
 
   return {
-    snippet: cleanQuoteSnippet(contentForSnippet),
+    snippet: cleanChatMessageText(contentForSnippet),
     attachment: attachmentMatch?.attachment ?? null,
   };
 }
@@ -76,11 +76,15 @@ function findQuoteAttachmentMatch(content: string): {
   };
 }
 
-function cleanQuoteSnippet(content: string): string {
+/**
+ * A chat message body as plain text: markdown markers gone, a link reduced to
+ * its label, horizontal whitespace collapsed, newlines kept.
+ */
+export function cleanChatMessageText(content: string): string {
   return content
     .replace(/```[\s\S]*?```/g, " ")
     .replace(/`([^`]+)`/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\][]+)\]\([^)]+\)/g, "$1")
     .replace(/[*_~>#]+/g, "")
     .replace(/[^\S\n]+/g, " ")
     .trim();

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -47,6 +47,10 @@ export {
   type ChatMembershipRevokeReason,
 } from "./chat-membership-revoked.js";
 export {
+  buildChatMessagePreview,
+  CHAT_MESSAGE_PREVIEW_MAX_LENGTH,
+} from "./chat-message-preview.js";
+export {
   CHAT_DIRECT_MESSAGE_MESSAGE_KEY,
   CHAT_MENTION_MESSAGE_KEY,
   CHAT_ROOM_MESSAGE_GROUP_MESSAGE_KEY,
@@ -216,6 +220,7 @@ export {
   resolveRequestLocale,
   SUPPORTED_LOCALES,
 } from "./locale.js";
+export { MARKDOWN_FENCED_BLOCK_REGEX } from "./markdown-fenced-block.js";
 export {
   escapeMarkdownLinkUrl,
   findMarkdownLinks,

--- a/packages/utils/src/markdown-fenced-block.ts
+++ b/packages/utils/src/markdown-fenced-block.ts
@@ -1,0 +1,16 @@
+/**
+ * A fenced code block, as the chat room finds one.
+ *
+ * The room lifts these out of a message before it sanitizes the rest and puts
+ * them back afterwards, so what is written inside one is text the room prints
+ * rather than markup the room acts on. Anything that reads a message body for
+ * markup has to agree with the room about where a fence begins and ends. A
+ * looser rule reads the room's text as markup: `` ```<script>``` `` on one
+ * line is a code span to the room, and a reader that takes it for a fence
+ * consumes the opening tag and then shows the words the room throws away.
+ *
+ * A fence opens on its own line, carries an info string to the end of that
+ * line, and closes on a run of exactly as many backticks.
+ */
+export const MARKDOWN_FENCED_BLOCK_REGEX =
+  /(^|\n)(`{3,})([^\n]*)\n([\s\S]*?)\n\2(?=\n|$)/g;


### PR DESCRIPTION
## What this changes

One shared rule turns a stored chat message body into one line of plain text:
`buildChatMessagePreview` in `@sokosumi/utils`.

The chat sidebar already did this for its unread-thread rows, in a web-only
helper. An OS notification banner now needs the same line, and Core builds that
line, so the rule moves to a package both can import.
`formatUnreadThreadsPreview` keeps its name and delegates.

The rule: html tags go, markdown markers go, a mention token `@<uuid>:Ada`
becomes `@Ada`, a link keeps its label and loses its address, and a link with no
label goes rather than leaving its address standing. The line is cut at 128
codepoints with an ellipsis, on a character boundary, so a family emoji or an
accented letter is never cut in half. A cut that keeps nothing returns nothing
rather than an ellipsis on its own, and the caller then falls back to the line
that names the sender.

One rule holds the whole thing together: **the preview never shows text the
room hides, and never hides text the room shows.** The room's own rule is
`sanitizeMarkdown`, so that is what this was measured against.

Three things it takes out, because the room shows none of them:

- **An html comment.** `sanitize-html` drops it, so text parked in one reaches
  nobody who opens the message. Carrying it to a banner would make the lock
  screen the one place a message can be read.
- **The words inside `<script>`, `<style>`, `<textarea>`, `<option>` and
  `<xmp>`.** Those five are `sanitize-html`'s own `nonTextTags`: it throws the
  content away with the tags. `"nothing to see <script>the door code is
  4417</script>"` renders as `"nothing to see"` in the room, so that is what
  the banner says. The element is read to the close tag that matches the open
  one, in either case, the way the room's parser reads it.
- **A link reference definition** (`[1]: https://example.test` on its own
  line), with its title on that line or the next, and a label free to carry an
  escaped bracket. Markdown reads it as the address for a `[label][1]`
  elsewhere and prints none of it, and the label beside the address is a whole
  sentence the writer chose. What it will not take is a line that only looks
  like one: a definition holds one destination and at most one title, so
  `[Note]: this is important` stays the sentence markdown prints.

And one thing it leaves alone that an earlier draft of this rule did not. A
mention token is rewritten only when its key is a uuid or `all`, which is what
a persisted token can carry. The room rewrites a token only when its key names
someone in the room, so every other `word:word` is text a person wrote:
`git clone git@github.com:org/repo.git` keeps its host, and `@10:30am` stays a
time.

A fenced code block comes out before any of that runs, and it comes out by the
room's own rule. `sanitizeMarkdown` lifts a fence out before it sanitizes and
puts it back after, so markup written inside one is text there rather than
markup the room acts on. Read as markup, an unclosed `<script>` or `<!--`
inside a fence runs to the end of the body and swallows the message: a fence
holding `<script>` followed by "prod is down, roll back release 42" would have
reached the lock screen as `` "```html" ``.

The rule has to be the room's rule and not a near one, which is why
`MARKDOWN_FENCED_BLOCK_REGEX` now has a single owner in `@sokosumi/utils` that
`sanitizeMarkdown` imports. A fence opens a line, carries its info string to
the end of that line, and closes on a run of the same width. A looser pattern
reads a code span as a fence and then hides the fence's own opening tag from
the strip that follows: `` ```<script>``` wire 5000 EUR now </script> `` is a
code span to the room, which renders nothing at all, and a preview built on
`` /```[\s\S]*?```/ `` put those words on the banner.

A fence also has to be found where the room's tokenizer does not look. That
tokenizer only handles a closed backtick fence, but markdown closes a fence at
the end of the message, closes one on a line indented up to three spaces, and
opens one on tildes. The room prints no delimiter line and no info string in
any of those, and an info string is a whole line the writer chose, so
`` ```call 555-0100 to unlock your account `` reached the banner as a sentence
sitting above an empty code block. A delimiter line is now taken out on its
own, by markdown's rule rather than the tokenizer's: a backtick fence carries
no backtick in its info string, which is what keeps `` ```the plan``` `` the
code span the room shows.

Two more places where the plain-text rule had to learn how the room's parser
reads:

- **A quoted attribute value runs to its closing quote, `>` and all.** The room
  shows `link` for `<a href="https://e.test/?q=>pay me">link</a>`. A tag rule
  that ends at the first `>` left `pay me">link` standing.
- **A tag name runs to whitespace or `>`.** The room drops a tag it does not
  know and shows nothing of it, and the name is the writer's to choose. A name
  rule of `[A-Za-z][A-Za-z0-9-]*` showed
  `<call.555-0100.to.unlock.your.account>` as words.
- **A run of backticks is a code span of that width.** The room shows the words
  in `` ```the plan``` ``, so the preview reduces a run to one backtick before
  the cleaner unwraps it. Otherwise the cleaner reads the run as a fence and
  the words go, which in one shape reverses a sentence: "Hi ``` / team. Ignore
  the ``` last line." reads in the room as "Hi team. Ignore the last line."

### A correction, and the rule it taught

An earlier round of this branch narrowed that definition rule so it fired only
where markdown opens a block, because a definition cannot interrupt a
paragraph and the room does print `deadline moved` / `[note]: https://e.test`
in full. That was right about markdown and wrong about the job. Markdown opens
a block after a heading, a rule, a setext underline and a closed fence as well
as after a blank line, and every boundary the narrower rule failed to name put
a definition, with its label and its address, back on the lock screen.

So these two mistakes are not worth the same, and the code now says so where
it matters:

- Reading one line too many costs a line of a message the reader can still
  open in the room.
- Reading one line too few puts a sentence on a lock screen that nobody can
  check.

A line-shaped rule can be widened safely because taking a whole line leaves no
half of it behind. A delimiter cannot: removing `` ``` `` from around
`` ```<script>``` `` took the opening tag with it and left the words the room
throws away, which is how the fence rule went wrong in the other direction.
That is why the fence rule is the room's exactly and the definition rule is
deliberately wider.

One reversal worth calling out. An earlier round of this branch exempted
inline code spans from tag-stripping, so that `` `<Button>` `` survived as the
subject of "use `` `<Button>` `` not `` `<button>` ``". That was built on a
wrong belief about the room. `sanitizeMarkdown` runs over the raw body before
the room parses it, so a code span is no shelter: the room renders that message
as ``use `` not `` ``. Keeping the tag names would have shown words the room
took away, which is the same fault as the three above. The exemption is gone,
and with it a regex and a function.

The cleaner it uses is the one the quote-snippet feature already had. That
function was private and called `cleanQuoteSnippet`; it is now exported as
`cleanChatMessageText`, since two features read it. Its link rule gained one
character, so a label stops at a bracket: an unclosed `[` in front of a link no
longer swallows the label, and the scan stops being quadratic on a body of
brackets.

## User-facing impact

None on its own. This is the shared rule the two layers above it use.

The sidebar rows change in two small ways, both back towards what the old
helper did: a message carrying several files now names all of them, and a
message carrying words and a file shows both.

## Known limits

Two the preview keeps on purpose. It shows less than the room for a message
whose markup the room's parser reads differently, such as `<scr<script>ipt>`,
and it shows a definition-shaped line as nothing where markdown would have
printed it. Both say less than the room rather than more, which is the half a
plain-text rule can keep.

Two it inherits from the shared cleaner, which the quote-snippet feature also
reads: an html entity is not decoded (`&amp;` reads as `&amp;amp;`), and a list
marker survives (`1. item` reads as `1. item`). Both show markup as text; both
would change another feature, so they are left where they are.

### Markdown markers, carried over

The cleaner strips `*`, `_`, `~`, `>` and `#` wherever they appear, which is
what it has always done for quote snippets. On a banner, where the reader
cannot open the message to check, that reads worse:

| Message | Banner |
| --- | --- |
| `cost is 5*3 = 15 credits` | `cost is 53 = 15 credits` |
| `temperature > 30 means we stop the job` | `temperature 30 means we stop the job` |
| `the id is user_42, column created_at` | `the id is user42, column createdat` |
| `https://example.test/a_b_c#top` | `https://example.test/abctop` |

The room renders all four verbatim. Telling an emphasis marker from a
multiplication sign needs the pairing rules markdown itself uses, which is a
change to a helper the quote-snippet feature also reads, so it wants its own
change and its own tests rather than a corner of this one.

## Verification

- `pnpm --filter @sokosumi/utils test` — 602 passed, 65 files
- The rule was measured against the room rather than read: every case above
  was rendered through the real `sanitizeMarkdown`, `react-markdown`,
  `remark-gfm`, `remark-breaks`, `remark-emoji` and `rehype-raw`, and the two
  outputs compared
- Every assertion here was written against a mutant of the code it covers, and
  each mutant fails at least one test: the code-span split, the digit-key
  guard, three regex `g` flags, the self-closing tag, the codepoint cap, both
  tightened character classes, the comment strip, the link-definition strip
  (loosened, stripped of its title clause, and with each of its two tightened
  quantifiers loosened again), the non-text element strip (removed, reduced to
  dropping the tags alone, robbed of `xmp`, made case-sensitive, made greedy,
  and with its close tag matched by any name), the mention key loosened back
  and narrowed to one case, the mention slug narrowed to word characters, the
  fence strip removed and loosened back to a near rule, the delimiter-line
  strip (removed, robbed of tildes, made to need a closing newline, loosened
  to any indent, and allowed a backtick in its info string), the
  quoted-attribute clause and the widened name in the tag rule, the
  backtick-run rule, the definition rule re-anchored to a blank line, its
  escaped label, its next-line title, and the empty-cut branch
- The strip repeats a fixed number of times. The worst body I could build for
  it takes about 18 seconds without that cap and about a third of a second
  with it; the test asserts under 1.5 seconds, which tells the two apart and
  still holds on a machine running the rest of the suite beside it
- `pnpm typecheck`, `pnpm check`

Part of [SOK-980](https://linear.app/masumi/issue/SOK-980/show-the-chat-message-text-in-push-notifications).
