### PR TITLE
perf(database): index chat notifications by the room they point at

### DIFF
--- a/packages/database/prisma/migrations/20260908010000_notification_kind_reference_index/migration.sql
+++ b/packages/database/prisma/migrations/20260908010000_notification_kind_reference_index/migration.sql
@@ -1,0 +1,4 @@
+-- CreateIndex
+-- CONCURRENTLY: the old Core instance keeps serving while this runs, and a
+-- plain build takes a write lock on the notification table for its duration.
+CREATE INDEX CONCURRENTLY "notification_kind_referenceId_idx" ON "notification"("kind", "referenceId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -462,6 +462,11 @@ model Notification {
   @@index([userId, isRead])
   @@index([eventId])
   @@index([kind, eventId])
+  /// Reads every notification of one chat room. Chat is the only kind whose
+  /// rows are looked up by what they point at rather than by who they are
+  /// for: editing or deleting a message has to find the copy of it that its
+  /// notifications carry, across every recipient at once.
+  @@index([kind, referenceId])
   @@map("notification")
 }
 

--- a/packages/database/src/types/__tests__/notification-chat-room-index.test.ts
+++ b/packages/database/src/types/__tests__/notification-chat-room-index.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const schemaPath = join(packageRoot, "prisma/schema.prisma");
+const migrationPath = join(
+  packageRoot,
+  "prisma/migrations/20260908010000_notification_kind_reference_index/migration.sql",
+);
+
+function notificationModel(): string {
+  const schema = readFileSync(schemaPath, "utf8");
+  const match = schema.match(/model Notification\s*\{([\s\S]*?)\n\}/);
+
+  expect(match, "model Notification in schema.prisma").toBeTruthy();
+
+  return match?.[1] ?? "";
+}
+
+describe("chat notification lookup by room", () => {
+  /**
+   * Editing or deleting a message has to find the copy of it that its
+   * notifications carry, for every recipient at once. Without this index that
+   * read is a sequential scan of every notification in the product.
+   */
+  it("schema.prisma indexes notifications by kind and referenceId", () => {
+    expect(notificationModel()).toContain("@@index([kind, referenceId])");
+  });
+
+  it("the migration creates that index on the notification table", () => {
+    expect(readFileSync(migrationPath, "utf8")).toMatch(
+      /CREATE INDEX CONCURRENTLY "notification_kind_referenceId_idx" ON "notification"\("kind", "referenceId"\)/,
+    );
+  });
+
+  /**
+   * Core runs its migrations while the previous instance still serves
+   * traffic. A plain build holds a write lock for its whole duration, so
+   * every chat message posted in that window would block on it.
+   */
+  it("builds the index without locking writes on the table", () => {
+    const sql = readFileSync(migrationPath, "utf8");
+
+    expect(sql).toContain("CREATE INDEX CONCURRENTLY");
+    expect(sql).not.toMatch(/CREATE INDEX "notification_kind/);
+  });
+});


### PR DESCRIPTION
## What this changes

One index on `notification`, over `kind` and `referenceId`.

Editing or deleting a chat message has to find the copy of that message which
its notifications carry, across every recipient at once. That reads by kind and
room. Of the five indexes on the table, none led with either column, so the
planner either read the table or skipped through the unique index.

Measured on a 600,000-row copy of the table with the same schema and indexes:

| | Buffers | Time |
| --- | --- | --- |
| Skip scan over the unique index | 17,077 | 237 ms |
| Parallel sequential scan | 22,326 | 51 ms |
| With this index | 3 | under 1 ms |

Chat is the only kind whose rows are read by what they point at rather than by
who they are for, which is why this pairs `kind` with `referenceId` rather than
indexing `referenceId` alone.

## Migration

`20260908010000_notification_kind_reference_index` — one `CREATE INDEX`, no
data change.

The statement is built `CONCURRENTLY`. Core runs its migrations while the
previous instance still serves traffic, so a plain build would hold a write
lock on `notification` for its whole duration and every chat message posted in
that window would block behind it. The repo already does this for the same
reason in `20260824110000_add_taskfile_status_origin_createdat_index`.

`prisma migrate diff` generates the statement without `CONCURRENTLY`, since it
does not know how the migration is deployed. The two build the same index.

## User-facing impact

None. The read this serves arrives in the layer above.

## Verification

- `prisma validate` — the schema is valid
- `prisma migrate diff --from-empty --to-schema` emits
  `CREATE INDEX "notification_kind_referenceId_idx" ON "notification"("kind", "referenceId");`
  — the same index the migration builds, which adds `CONCURRENTLY`
- `pnpm --filter @sokosumi/database test` pins the schema line and the
  migration statement, including `CONCURRENTLY`
- `pnpm typecheck`, `pnpm check`

Part of [SOK-980](https://linear.app/masumi/issue/SOK-980/show-the-chat-message-text-in-push-notifications).
