### PR TITLE
fix(core): take a deleted message's text off its notifications

### DIFF
--- a/apps/core/src/helpers/chat-direct-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.test.ts
@@ -25,6 +25,13 @@ vi.mock("@/lib/db/prisma", () => ({
     chatRoomUserMember: {
       findMany: membershipFindManyMock,
     },
+    // The fan-out reads the message before it builds a preview, so a body
+    // deleted while it ran is not written back onto the notifications.
+    chatRoomMessage: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue({ deletedAt: null, content: "ship it" }),
+    },
   },
 }));
 

--- a/apps/core/src/helpers/chat-mention-notifications.test.ts
+++ b/apps/core/src/helpers/chat-mention-notifications.test.ts
@@ -25,6 +25,13 @@ vi.mock("@/lib/db/prisma", () => ({
     chatRoomUserMember: {
       findMany: membershipFindManyMock,
     },
+    // The fan-out reads the message before it builds a preview, so a body
+    // deleted while it ran is not written back onto the notifications.
+    chatRoomMessage: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue({ deletedAt: null, content: "ship it" }),
+    },
   },
 }));
 

--- a/apps/core/src/helpers/chat-notification-fanout.test.ts
+++ b/apps/core/src/helpers/chat-notification-fanout.test.ts
@@ -13,6 +13,8 @@ const {
   notificationUpdateManyMock,
   notificationFindUniqueMock,
   captureExceptionMock,
+  transactionMock,
+  queryRawMock,
 } = vi.hoisted(() => ({
   createNotificationMock: vi.fn(),
   resolveDeliveryMock: vi.fn(),
@@ -25,6 +27,8 @@ const {
   notificationUpdateManyMock: vi.fn(),
   notificationFindUniqueMock: vi.fn(),
   captureExceptionMock: vi.fn(),
+  transactionMock: vi.fn(),
+  queryRawMock: vi.fn(),
 }));
 
 vi.mock("@/helpers/notifications", () => ({
@@ -36,6 +40,7 @@ vi.mock("@/helpers/notifications", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
+    $transaction: transactionMock,
     workspace: {
       findUnique: workspaceFindUniqueMock,
     },
@@ -57,6 +62,8 @@ vi.mock("@/lib/db/prisma", () => ({
 vi.mock("@sentry/node", () => ({
   captureException: (...args: unknown[]) => captureExceptionMock(...args),
 }));
+
+import prisma from "@/lib/db/prisma";
 
 import {
   fanOutChatNotifications,
@@ -94,6 +101,18 @@ function messageSays(content: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  queryRawMock.mockResolvedValue([]);
+  transactionMock.mockImplementation(async (callback) =>
+    callback({
+      $queryRaw: queryRawMock,
+      chatRoomMessage: { findUnique: messageFindUniqueMock },
+      notification: {
+        findMany: notificationFindManyMock,
+        updateMany: notificationUpdateManyMock,
+        findUnique: notificationFindUniqueMock,
+      },
+    }),
+  );
   createNotificationMock.mockResolvedValue({ created: true });
   workspaceFindUniqueMock.mockResolvedValue({ id: "workspace_1" });
   membershipFindManyMock.mockResolvedValue([]);
@@ -332,7 +351,7 @@ describe("fanOutChatNotifications", () => {
   it("takes the text back when the message is deleted while it wrote", async () => {
     messageFindUniqueMock
       .mockResolvedValueOnce({ deletedAt: null, content: "door code 4417" })
-      .mockResolvedValueOnce({ deletedAt: new Date(), content: "" });
+      .mockResolvedValue({ deletedAt: new Date(), content: "" });
     notificationFindManyMock.mockResolvedValue([
       storedRow({
         authorName: "Patrick",
@@ -356,6 +375,7 @@ describe("fanOutChatNotifications", () => {
         metadata: { contains: `"messageId":"${MESSAGE_ID}"` },
       },
       select: { id: true, messageParams: true, metadata: true },
+      orderBy: { id: "asc" },
     });
     expect(paramsWrittenTo(0)).toEqual({
       authorName: "Patrick",
@@ -366,7 +386,7 @@ describe("fanOutChatNotifications", () => {
   it("writes what the message now says when it is edited while it wrote", async () => {
     messageFindUniqueMock
       .mockResolvedValueOnce({ deletedAt: null, content: "meet at five" })
-      .mockResolvedValueOnce({ deletedAt: null, content: "meet at **six**" });
+      .mockResolvedValue({ deletedAt: null, content: "meet at **six**" });
     notificationFindManyMock.mockResolvedValue([
       storedRow({
         authorName: "Patrick",
@@ -393,7 +413,7 @@ describe("fanOutChatNotifications", () => {
     const order: string[] = [];
     messageFindUniqueMock
       .mockResolvedValueOnce({ deletedAt: null, content: "door code 4417" })
-      .mockResolvedValueOnce({ deletedAt: new Date(), content: "" });
+      .mockResolvedValue({ deletedAt: new Date(), content: "" });
     notificationFindManyMock.mockImplementation(async () => {
       await new Promise((resolve) => setTimeout(resolve, 5));
       order.push("rewrite");
@@ -698,10 +718,10 @@ describe("rewriteChatNotificationPreviews", () => {
   it("takes the text off the row when the message is deleted", async () => {
     notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(paramsWrittenTo(0)).toEqual({
@@ -715,10 +735,10 @@ describe("rewriteChatNotificationPreviews", () => {
       storedRow({ ...BASE, isGroup: true, count: 4 }),
     ]);
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(paramsWrittenTo(0)).toEqual({
@@ -732,10 +752,10 @@ describe("rewriteChatNotificationPreviews", () => {
   it("puts what the message now says on the row when it is edited", async () => {
     notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
 
+    messageSays("meet at **six**");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "meet at **six**",
     });
 
     expect(paramsWrittenTo(0)).toEqual({
@@ -754,10 +774,10 @@ describe("rewriteChatNotificationPreviews", () => {
       storedRow({ authorName: "Ada", roomName: "general" }),
     ]);
 
+    messageSays("meet at six");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "meet at six",
     });
 
     expect(notificationUpdateManyMock).not.toHaveBeenCalled();
@@ -772,10 +792,10 @@ describe("rewriteChatNotificationPreviews", () => {
       storedRow(BASE, "550e8400-e29b-41d4-a716-4466554400ff"),
     ]);
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).not.toHaveBeenCalled();
@@ -789,10 +809,10 @@ describe("rewriteChatNotificationPreviews", () => {
     const row = storedRow(BASE);
     notificationFindManyMock.mockResolvedValue([row]);
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledWith(
@@ -812,10 +832,10 @@ describe("rewriteChatNotificationPreviews", () => {
       { ...storedRow({ ...BASE, authorName: "Ben" }), id: "notification_2" },
     ]);
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledTimes(2);
@@ -835,10 +855,10 @@ describe("rewriteChatNotificationPreviews", () => {
       { ...storedRow(BASE), id: "n_2" },
     ]);
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
@@ -860,10 +880,10 @@ describe("rewriteChatNotificationPreviews", () => {
       { ...storedRow(BASE), id: "n_2" },
     ]);
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
@@ -875,10 +895,10 @@ describe("rewriteChatNotificationPreviews", () => {
   });
 
   it("looks only at the chat rows of the room the message is in", async () => {
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationFindManyMock).toHaveBeenCalledWith(
@@ -914,10 +934,10 @@ describe("rewriteChatNotificationPreviews", () => {
       .mockResolvedValueOnce({ count: 1 });
     notificationFindUniqueMock.mockResolvedValue(storedRow(edited));
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationFindUniqueMock).toHaveBeenCalledWith({
@@ -949,10 +969,10 @@ describe("rewriteChatNotificationPreviews", () => {
       storedRow(BASE, "550e8400-e29b-41d4-a716-446655440009"),
     );
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
@@ -964,10 +984,10 @@ describe("rewriteChatNotificationPreviews", () => {
     notificationUpdateManyMock.mockResolvedValue({ count: 1 });
     notificationFindUniqueMock.mockResolvedValue(storedRow(BASE));
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
@@ -984,10 +1004,10 @@ describe("rewriteChatNotificationPreviews", () => {
       storedRow({ authorName: "Ada", roomName: "general" }),
     );
 
+    messageSays("meet at six");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "meet at six",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
@@ -999,10 +1019,10 @@ describe("rewriteChatNotificationPreviews", () => {
     notificationUpdateManyMock.mockResolvedValue({ count: 0 });
     notificationFindUniqueMock.mockResolvedValue(storedRow(BASE));
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledTimes(3);
@@ -1014,10 +1034,10 @@ describe("rewriteChatNotificationPreviews", () => {
     notificationUpdateManyMock.mockResolvedValue({ count: 0 });
     notificationFindUniqueMock.mockResolvedValue(null);
 
+    messageSays("");
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
 
     expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
@@ -1030,7 +1050,6 @@ describe("rewriteChatNotificationPreviews", () => {
       rewriteChatNotificationPreviews({
         roomId: ROOM_ID,
         messageId: MESSAGE_ID,
-        content: "",
       }),
     ).resolves.toBeUndefined();
 
@@ -1045,10 +1064,93 @@ describe("rewriteChatNotificationPreviews", () => {
       rewriteChatNotificationPreviews({
         roomId: ROOM_ID,
         messageId: MESSAGE_ID,
-        content: "",
       }),
     ).resolves.toBeUndefined();
 
     expect(captureExceptionMock).toHaveBeenCalled();
+  });
+});
+
+describe("preview rewrite ordering", () => {
+  it("keeps the latest committed edit when an older request resumes", async () => {
+    let row = storedRow({ messagePreview: "original" });
+    notificationFindManyMock.mockImplementation(async () => [{ ...row }]);
+    notificationUpdateManyMock.mockImplementation(async ({ where, data }) => {
+      if (where.messageParams !== row.messageParams) return { count: 0 };
+      row = { ...row, messageParams: data.messageParams };
+      return { count: 1 };
+    });
+    messageSays("latest edit B");
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+    });
+    // Edit A resumes after its realtime publication. Its old body is not input.
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+    });
+    expect(JSON.parse(row.messageParams).messagePreview).toBe("latest edit B");
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("reads the current message only after acquiring its lock", async () => {
+    const locked = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    queryRawMock.mockImplementationOnce(async () => {
+      locked.resolve();
+      await release.promise;
+      messageSays("edit committed while waiting");
+      return [];
+    });
+    notificationFindManyMock.mockResolvedValue([
+      storedRow({ messagePreview: "old" }),
+    ]);
+    const rewrite = rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+    });
+    await locked.promise;
+    expect(messageFindUniqueMock).not.toHaveBeenCalled();
+    expect(notificationUpdateManyMock).not.toHaveBeenCalled();
+    release.resolve();
+    await rewrite;
+    expect(paramsWrittenTo(0)).toEqual({
+      messagePreview: "edit committed while waiting",
+    });
+    const [sql, ...values] = queryRawMock.mock.calls[0];
+    expect(sql.join("?")).toContain("FOR UPDATE");
+    expect(values).toEqual([MESSAGE_ID, ROOM_ID]);
+    expect(messageFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: MESSAGE_ID, roomId: ROOM_ID },
+      select: { content: true, deletedAt: true },
+    });
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([null, { content: "old body", deletedAt: new Date() }])(
+    "clears surviving text when the source is gone or deleted: %j",
+    async (message) => {
+      messageFindUniqueMock.mockResolvedValue(message);
+      notificationFindManyMock.mockResolvedValue([
+        storedRow({ messagePreview: "old" }),
+      ]);
+      await rewriteChatNotificationPreviews({
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+      });
+      expect(paramsWrittenTo(0)).toEqual({});
+    },
+  );
+
+  it("reports a failed lock without writing notification rows", async () => {
+    const error = new Error("lock failed");
+    queryRawMock.mockRejectedValueOnce(error);
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+    });
+    expect(notificationUpdateManyMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledWith(error, expect.anything());
   });
 });

--- a/apps/core/src/helpers/chat-notification-fanout.test.ts
+++ b/apps/core/src/helpers/chat-notification-fanout.test.ts
@@ -1146,11 +1146,91 @@ describe("preview rewrite ordering", () => {
   it("reports a failed lock without writing notification rows", async () => {
     const error = new Error("lock failed");
     queryRawMock.mockRejectedValueOnce(error);
+    notificationFindManyMock.mockResolvedValue([
+      storedRow({ messagePreview: "old" }),
+    ]);
     await rewriteChatNotificationPreviews({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
     });
     expect(notificationUpdateManyMock).not.toHaveBeenCalled();
     expect(captureExceptionMock).toHaveBeenCalledWith(error, expect.anything());
+  });
+});
+
+describe("preview rewrite transaction bounds", () => {
+  function recipientRows() {
+    return ["recipient_1", "recipient_2"].map((id) => ({
+      ...storedRow({ messagePreview: "old" }),
+      id,
+    }));
+  }
+  it("uses one transaction and fresh source read per recipient", async () => {
+    notificationFindManyMock.mockResolvedValue(recipientRows());
+    messageFindUniqueMock
+      .mockResolvedValueOnce({ content: "first edit", deletedAt: null })
+      .mockResolvedValueOnce({ content: "second edit", deletedAt: null });
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+    });
+    expect(transactionMock).toHaveBeenCalledTimes(2);
+    expect(paramsWrittenTo(0)).toEqual({ messagePreview: "first edit" });
+    expect(paramsWrittenTo(1)).toEqual({ messagePreview: "second edit" });
+  });
+  it.each(["P2028", "P2034"])(
+    "retries a transient %s transaction failure",
+    async (code) => {
+      const error = Object.assign(new Error("transaction failed"), { code });
+      notificationFindManyMock.mockResolvedValue([recipientRows()[0]]);
+      transactionMock.mockRejectedValueOnce(error);
+      messageSays("latest edit");
+      await rewriteChatNotificationPreviews({
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+      });
+      expect(transactionMock).toHaveBeenCalledTimes(2);
+      expect(paramsWrittenTo(0)).toEqual({ messagePreview: "latest edit" });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    },
+  );
+  it("continues to the next recipient after a permanent failure", async () => {
+    const error = new Error("write failed");
+    notificationFindManyMock.mockResolvedValue(recipientRows());
+    transactionMock.mockRejectedValueOnce(error);
+    messageSays("");
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+    });
+    expect(transactionMock).toHaveBeenCalledTimes(2);
+    expect(notificationUpdateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "recipient_2" }),
+      }),
+    );
+    expect(paramsWrittenTo(0)).toEqual({});
+    expect(captureExceptionMock).toHaveBeenCalledWith(error, {
+      extra: {
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+        notificationId: "recipient_1",
+        notificationType: "chat_notification_preview_rewrite",
+      },
+    });
+  });
+  it("bounds retries per recipient and reports each exhausted row", async () => {
+    const error = Object.assign(new Error("transaction expired"), {
+      code: "P2028",
+    });
+    notificationFindManyMock.mockResolvedValue(recipientRows());
+    transactionMock.mockRejectedValue(error);
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+    });
+    expect(transactionMock).toHaveBeenCalledTimes(6);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(2);
+    expect(notificationUpdateManyMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/helpers/chat-notification-fanout.test.ts
+++ b/apps/core/src/helpers/chat-notification-fanout.test.ts
@@ -7,7 +7,9 @@ const {
   publishNotificationRowMock,
   workspaceFindUniqueMock,
   membershipFindManyMock,
+  messageFindUniqueMock,
   notificationFindFirstMock,
+  notificationFindManyMock,
   notificationUpdateManyMock,
   notificationFindUniqueMock,
   captureExceptionMock,
@@ -17,7 +19,9 @@ const {
   publishNotificationRowMock: vi.fn(),
   workspaceFindUniqueMock: vi.fn(),
   membershipFindManyMock: vi.fn(),
+  messageFindUniqueMock: vi.fn(),
   notificationFindFirstMock: vi.fn(),
+  notificationFindManyMock: vi.fn(),
   notificationUpdateManyMock: vi.fn(),
   notificationFindUniqueMock: vi.fn(),
   captureExceptionMock: vi.fn(),
@@ -38,8 +42,12 @@ vi.mock("@/lib/db/prisma", () => ({
     chatRoomUserMember: {
       findMany: membershipFindManyMock,
     },
+    chatRoomMessage: {
+      findUnique: messageFindUniqueMock,
+    },
     notification: {
       findFirst: notificationFindFirstMock,
+      findMany: notificationFindManyMock,
       updateMany: notificationUpdateManyMock,
       findUnique: notificationFindUniqueMock,
     },
@@ -50,7 +58,10 @@ vi.mock("@sentry/node", () => ({
   captureException: (...args: unknown[]) => captureExceptionMock(...args),
 }));
 
-import { fanOutChatNotifications } from "./chat-notification-fanout";
+import {
+  fanOutChatNotifications,
+  rewriteChatNotificationPreviews,
+} from "./chat-notification-fanout";
 
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440002";
@@ -76,12 +87,19 @@ function params(
   };
 }
 
+/** The message row the fan-out reads, saying what the caller passed. */
+function messageSays(content: string) {
+  messageFindUniqueMock.mockResolvedValue({ deletedAt: null, content });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   createNotificationMock.mockResolvedValue({ created: true });
   workspaceFindUniqueMock.mockResolvedValue({ id: "workspace_1" });
   membershipFindManyMock.mockResolvedValue([]);
   notificationFindFirstMock.mockResolvedValue(null);
+  notificationFindManyMock.mockResolvedValue([]);
+  messageSays("ship it");
   // One row matched, which is the write landing on the row it named.
   notificationUpdateManyMock.mockResolvedValue({ count: 1 });
   notificationFindUniqueMock.mockResolvedValue({ id: "notification_1" });
@@ -170,10 +188,47 @@ describe("fanOutChatNotifications", () => {
   });
 
   /**
+   * The fan-out runs after the response, so a reader can delete the message
+   * before it lands. The delete wipes the rows that exist by then; writing
+   * the preview now would put the text back with nothing left to take it off.
+   */
+  it("writes no preview for a message deleted while it ran", async () => {
+    messageFindUniqueMock.mockResolvedValue({ deletedAt: new Date() });
+
+    await fanOutChatNotifications(params({ content: "meet at five" }));
+
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageParams: expect.not.objectContaining({
+          messagePreview: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  it("writes no preview for a message that is gone entirely", async () => {
+    messageFindUniqueMock.mockResolvedValue(null);
+
+    await fanOutChatNotifications(params({ content: "meet at five" }));
+
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageParams: expect.not.objectContaining({
+          messagePreview: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  /**
    * The preview is what a reader is shown on a lock screen, so the line is
    * written out here rather than built by calling the rule the code calls.
    */
   it("gives every recipient the same preview of the message", async () => {
+    messageSays(
+      "@019fc7e4-e4bd-7005-900c-66e44d33f5e4:Ada **can you** look at the login flow",
+    );
+
     await fanOutChatNotifications(
       params({
         content:
@@ -195,6 +250,8 @@ describe("fanOutChatNotifications", () => {
   });
 
   it("names the file when the message is only a file", async () => {
+    messageSays("[report.pdf](https://example.test/report.pdf)");
+
     await fanOutChatNotifications(
       params({ content: "[report.pdf](https://example.test/report.pdf)" }),
     );
@@ -227,6 +284,7 @@ describe("fanOutChatNotifications", () => {
     await fanOutChatNotifications(params());
 
     expect(workspaceFindUniqueMock).not.toHaveBeenCalled();
+    expect(messageFindUniqueMock).not.toHaveBeenCalled();
     expect(createNotificationMock).not.toHaveBeenCalled();
   });
 
@@ -264,6 +322,123 @@ describe("fanOutChatNotifications", () => {
         notificationType: "chat-room-message",
       },
     });
+  });
+
+  /**
+   * The delete takes the text off the rows that exist when it runs. Rows
+   * written after that are this loop's, and nothing else comes back for them,
+   * so the loop takes its own text back.
+   */
+  it("takes the text back when the message is deleted while it wrote", async () => {
+    messageFindUniqueMock
+      .mockResolvedValueOnce({ deletedAt: null, content: "door code 4417" })
+      .mockResolvedValueOnce({ deletedAt: new Date(), content: "" });
+    notificationFindManyMock.mockResolvedValue([
+      storedRow({
+        authorName: "Patrick",
+        roomName: "general",
+        messagePreview: "door code 4417",
+      }),
+    ]);
+
+    await fanOutChatNotifications(
+      params({
+        content: "door code 4417",
+        recipientUserIds: [ALICE_ID, BOB_ID],
+      }),
+    );
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(2);
+    expect(notificationFindManyMock).toHaveBeenCalledWith({
+      where: {
+        kind: NotificationKind.CHAT,
+        referenceId: ROOM_ID,
+        metadata: { contains: `"messageId":"${MESSAGE_ID}"` },
+      },
+      select: { id: true, messageParams: true, metadata: true },
+    });
+    expect(paramsWrittenTo(0)).toEqual({
+      authorName: "Patrick",
+      roomName: "general",
+    });
+  });
+
+  it("writes what the message now says when it is edited while it wrote", async () => {
+    messageFindUniqueMock
+      .mockResolvedValueOnce({ deletedAt: null, content: "meet at five" })
+      .mockResolvedValueOnce({ deletedAt: null, content: "meet at **six**" });
+    notificationFindManyMock.mockResolvedValue([
+      storedRow({
+        authorName: "Patrick",
+        roomName: "general",
+        messagePreview: "meet at five",
+      }),
+    ]);
+
+    await fanOutChatNotifications(params({ content: "meet at five" }));
+
+    expect(paramsWrittenTo(0)).toEqual({
+      authorName: "Patrick",
+      roomName: "general",
+      messagePreview: "meet at six",
+    });
+  });
+
+  /**
+   * The fan-out runs under `waitUntil`, so the instance may be suspended once
+   * its promise settles. A rewrite left running is a rewrite dropped, and its
+   * own catch would keep that silent.
+   */
+  it("does not finish before the text it takes back is gone", async () => {
+    const order: string[] = [];
+    messageFindUniqueMock
+      .mockResolvedValueOnce({ deletedAt: null, content: "door code 4417" })
+      .mockResolvedValueOnce({ deletedAt: new Date(), content: "" });
+    notificationFindManyMock.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      order.push("rewrite");
+      return [];
+    });
+
+    await fanOutChatNotifications(params({ content: "door code 4417" }));
+    order.push("done");
+
+    expect(order).toEqual(["rewrite", "done"]);
+  });
+
+  /**
+   * Both reads are of this message, by its own id. Reading the room instead
+   * finds no row, and the fan-out then writes every preview it should have
+   * held back and takes none of them away again.
+   */
+  it("reads the message it is about, by the id it was given", async () => {
+    await fanOutChatNotifications(params());
+
+    expect(messageFindUniqueMock).toHaveBeenNthCalledWith(1, {
+      where: { id: MESSAGE_ID },
+      select: { deletedAt: true },
+    });
+    expect(messageFindUniqueMock).toHaveBeenNthCalledWith(2, {
+      where: { id: MESSAGE_ID },
+      select: { content: true, deletedAt: true },
+    });
+  });
+
+  it("looks no further when the message still says what it wrote", async () => {
+    await fanOutChatNotifications(params());
+
+    expect(messageFindUniqueMock).toHaveBeenCalledTimes(2);
+    expect(notificationFindManyMock).not.toHaveBeenCalled();
+  });
+
+  /** Nothing was written, so there is nothing to take back or bring forward. */
+  it("does not look again when it wrote no preview at all", async () => {
+    messageSays("****");
+
+    await fanOutChatNotifications(params({ content: "****" }));
+
+    expect(messageFindUniqueMock).toHaveBeenCalledTimes(1);
+    expect(notificationFindManyMock).not.toHaveBeenCalled();
   });
 });
 
@@ -486,5 +661,394 @@ describe("fanOutChatNotifications, counting per room", () => {
     expect(notificationFindFirstMock).not.toHaveBeenCalled();
     expect(notificationUpdateManyMock).not.toHaveBeenCalled();
     expect(createNotificationMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/** A stored row carrying this message's text, the way the fan-out wrote it. */
+function storedRow(
+  messageParams: Record<string, unknown>,
+  messageId: string = MESSAGE_ID,
+) {
+  return {
+    id: "notification_1",
+    messageParams: JSON.stringify(messageParams),
+    metadata: JSON.stringify({ messageId, workspaceId: "workspace_1" }),
+  };
+}
+
+function paramsWrittenTo(call: number): Record<string, unknown> {
+  const data = notificationUpdateManyMock.mock.calls[call]?.[0]?.data as {
+    messageParams: string;
+  };
+
+  return JSON.parse(data.messageParams) as Record<string, unknown>;
+}
+
+describe("rewriteChatNotificationPreviews", () => {
+  const BASE = {
+    authorName: "Ada",
+    roomName: "general",
+    messagePreview: "meet at five",
+  };
+
+  /**
+   * The message row keeps no text after a delete. A copy left on a
+   * notification row would outlive it and stay readable over the API.
+   */
+  it("takes the text off the row when the message is deleted", async () => {
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(paramsWrittenTo(0)).toEqual({
+      authorName: "Ada",
+      roomName: "general",
+    });
+  });
+
+  it("leaves the rest of the row's params alone", async () => {
+    notificationFindManyMock.mockResolvedValue([
+      storedRow({ ...BASE, isGroup: true, count: 4 }),
+    ]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(paramsWrittenTo(0)).toEqual({
+      authorName: "Ada",
+      roomName: "general",
+      isGroup: true,
+      count: 4,
+    });
+  });
+
+  it("puts what the message now says on the row when it is edited", async () => {
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "meet at **six**",
+    });
+
+    expect(paramsWrittenTo(0)).toEqual({
+      authorName: "Ada",
+      roomName: "general",
+      messagePreview: "meet at six",
+    });
+  });
+
+  /**
+   * The reader was sent what the row holds. An edit brings that up to date;
+   * it does not put text on a row that was sent without any.
+   */
+  it("adds no text to a row that carried none", async () => {
+    notificationFindManyMock.mockResolvedValue([
+      storedRow({ authorName: "Ada", roomName: "general" }),
+    ]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "meet at six",
+    });
+
+    expect(notificationUpdateManyMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A counted row names the last message counted onto it, so matching the id
+   * as text only narrows the read. The parsed id is the answer.
+   */
+  it("leaves a row whose text came from another message", async () => {
+    notificationFindManyMock.mockResolvedValue([
+      storedRow(BASE, "550e8400-e29b-41d4-a716-4466554400ff"),
+    ]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Another message can count onto the row between the read and the write.
+   * The row then carries that message's text, which this delete must leave.
+   */
+  it("writes only to a row still carrying what it read", async () => {
+    const row = storedRow(BASE);
+    notificationFindManyMock.mockResolvedValue([row]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: row.id, messageParams: row.messageParams },
+      }),
+    );
+  });
+
+  /**
+   * One message writes one row per recipient, so the sweep has to reach all
+   * of them. Stopping at the first leaves the text on everyone else.
+   */
+  it("takes the text off every recipient's row", async () => {
+    notificationFindManyMock.mockResolvedValue([
+      { ...storedRow(BASE), id: "notification_1" },
+      { ...storedRow({ ...BASE, authorName: "Ben" }), id: "notification_2" },
+    ]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledTimes(2);
+    expect(paramsWrittenTo(1)).toEqual({
+      authorName: "Ben",
+      roomName: "general",
+    });
+  });
+
+  /**
+   * A row this sweep steps over is not a reason to stop: the rows after it
+   * belong to other readers, who each still hold a copy of the message.
+   */
+  it("keeps going past a row it steps over", async () => {
+    notificationFindManyMock.mockResolvedValue([
+      { ...storedRow({ authorName: "Ada", roomName: "general" }), id: "n_1" },
+      { ...storedRow(BASE), id: "n_2" },
+    ]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
+    expect(notificationUpdateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "n_2" }),
+      }),
+    );
+  });
+
+  /** Same reason: one row nobody can read is not the other readers' problem. */
+  it("keeps going past a row it cannot read", async () => {
+    notificationFindManyMock.mockResolvedValue([
+      {
+        id: "n_1",
+        messageParams: "{ not json",
+        metadata: JSON.stringify({ messageId: MESSAGE_ID }),
+      },
+      { ...storedRow(BASE), id: "n_2" },
+    ]);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
+    expect(notificationUpdateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "n_2" }),
+      }),
+    );
+  });
+
+  it("looks only at the chat rows of the room the message is in", async () => {
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          kind: NotificationKind.CHAT,
+          referenceId: ROOM_ID,
+          metadata: { contains: `"messageId":"${MESSAGE_ID}"` },
+        },
+      }),
+    );
+  });
+
+  /**
+   * The delete has already happened by the time this runs. Throwing here
+   * would tell the reader their delete failed.
+   */
+  /**
+   * A delete and an edit of the same message each read the row, then write it.
+   * If the edit writes between the delete's read and its write, the delete's
+   * guarded write matches nothing. Giving up there would leave the edited text
+   * of a deleted message on the row for good.
+   */
+  it("reads the row again and writes when another writer got there first", async () => {
+    const edited = {
+      authorName: "Ada",
+      roomName: "general",
+      messagePreview: "the edited text",
+    };
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+    notificationUpdateManyMock
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 });
+    notificationFindUniqueMock.mockResolvedValue(storedRow(edited));
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "notification_1" },
+      select: { id: true, messageParams: true, metadata: true },
+    });
+    // The row it names is the row it just read. Naming the params from before
+    // the read loses every attempt, and the text stays on the row for good.
+    expect(notificationUpdateManyMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: "notification_1", messageParams: JSON.stringify(edited) },
+      }),
+    );
+    expect(paramsWrittenTo(1)).toEqual({
+      authorName: "Ada",
+      roomName: "general",
+    });
+  });
+
+  /**
+   * A later message counted onto the row while this write lost, so the row
+   * now stands for that message. Its text belongs to the newer message.
+   */
+  it("leaves a row a newer message took over while it lost", async () => {
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+    notificationUpdateManyMock.mockResolvedValue({ count: 0 });
+    notificationFindUniqueMock.mockResolvedValue(
+      storedRow(BASE, "550e8400-e29b-41d4-a716-446655440009"),
+    );
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  /** One row matched is the write landing. Writing again would be noise. */
+  it("stops on a row as soon as the write lands", async () => {
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+    notificationUpdateManyMock.mockResolvedValue({ count: 1 });
+    notificationFindUniqueMock.mockResolvedValue(storedRow(BASE));
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The other order. The delete wiped the row first, so the edit finds no text
+   * to bring up to date and must not put any back.
+   */
+  it("adds no text back to a row another writer already wiped", async () => {
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+    notificationUpdateManyMock.mockResolvedValue({ count: 0 });
+    notificationFindUniqueMock.mockResolvedValue(
+      storedRow({ authorName: "Ada", roomName: "general" }),
+    );
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "meet at six",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  /** A row that keeps losing must not read forever. */
+  it("gives up on a row it keeps losing rather than reading forever", async () => {
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+    notificationUpdateManyMock.mockResolvedValue({ count: 0 });
+    notificationFindUniqueMock.mockResolvedValue(storedRow(BASE));
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledTimes(3);
+  });
+
+  /** A row deleted between the write and the read has nothing left to fix. */
+  it("stops on a row that is gone when it reads again", async () => {
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+    notificationUpdateManyMock.mockResolvedValue({ count: 0 });
+    notificationFindUniqueMock.mockResolvedValue(null);
+
+    await rewriteChatNotificationPreviews({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+
+    expect(notificationUpdateManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a failed read rather than failing the delete", async () => {
+    notificationFindManyMock.mockRejectedValue(new Error("db is down"));
+
+    await expect(
+      rewriteChatNotificationPreviews({
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+        content: "",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(captureExceptionMock).toHaveBeenCalled();
+  });
+
+  it("reports a failed write rather than failing the delete", async () => {
+    notificationFindManyMock.mockResolvedValue([storedRow(BASE)]);
+    notificationUpdateManyMock.mockRejectedValue(new Error("db is down"));
+
+    await expect(
+      rewriteChatNotificationPreviews({
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+        content: "",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(captureExceptionMock).toHaveBeenCalled();
   });
 });

--- a/apps/core/src/helpers/chat-notification-fanout.ts
+++ b/apps/core/src/helpers/chat-notification-fanout.ts
@@ -253,9 +253,21 @@ export async function fanOutChatNotifications(
     workspaceId = workspace?.id ?? null;
   }
 
+  // This runs after the response, so a reader can delete the message before
+  // it lands. The delete takes the text off the rows that exist by then, and
+  // writing the preview now would put it back with nothing left to take it
+  // off again. Read by primary key, next to the reads above.
+  const message = await prisma.chatRoomMessage.findUnique({
+    where: { id: params.messageId },
+    select: { deletedAt: true },
+  });
+
   // Built once rather than per reader: every recipient of one message is shown
   // the same preview, and the rule reads the whole body to get there.
-  const messagePreview = buildChatMessagePreview(params.content);
+  const messagePreview =
+    message === null || message.deletedAt !== null
+      ? ""
+      : buildChatMessagePreview(params.content);
 
   for (const userId of notifyUserIds) {
     const input: CreateNotificationInput = {
@@ -295,5 +307,170 @@ export async function fanOutChatNotifications(
         },
       });
     }
+  }
+
+  if (!messagePreview) {
+    return;
+  }
+
+  // The read above is one moment and the loop is another. A delete or an edit
+  // landing between them takes the text off the rows that exist by then and
+  // leaves it on every row written after. This fan-out is the last writer of
+  // those rows, so it is the one that has to look again.
+  const current = await prisma.chatRoomMessage.findUnique({
+    where: { id: params.messageId },
+    select: { content: true, deletedAt: true },
+  });
+  const saysNow =
+    current === null || current.deletedAt !== null ? "" : current.content;
+
+  if (saysNow === params.content) {
+    return;
+  }
+
+  await rewriteChatNotificationPreviews({
+    roomId: params.roomId,
+    messageId: params.messageId,
+    content: saysNow,
+  });
+}
+
+/** A row's stored params, or null when the row cannot be read. */
+function paramsOn(messageParams: string): Record<string, unknown> | null {
+  try {
+    const stored: unknown = JSON.parse(messageParams);
+
+    return typeof stored === "object" && stored !== null
+      ? (stored as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * How many times one row is read again after losing its guarded write.
+ *
+ * A write loses to another writer landing on the same row between the read
+ * and the write: another message counting onto it, or the other of an edit
+ * and a delete of this same message. The next attempt reads what the winner
+ * wrote and decides on that. Three is well past what one room can produce,
+ * and matches the bound the counting path uses.
+ */
+const REWRITE_ATTEMPTS = 3;
+
+/** A notification row, as much of it as a rewrite reads. */
+interface RewritableRow {
+  id: string;
+  messageParams: string;
+  metadata: string | null;
+}
+
+/**
+ * Put this message's preview on one row, or take it off.
+ *
+ * The write names the params it read, so it lands only while the row still
+ * carries what this rewrite decided about. Losing that race is not a failure:
+ * the row moved, so read it again and decide on what it says now. Giving up
+ * instead would leave a deleted message's text on the row whenever an edit of
+ * the same message wrote between this rewrite's read and its write.
+ */
+async function rewriteRow(
+  row: RewritableRow,
+  messageId: string,
+  preview: string,
+): Promise<void> {
+  let current = row;
+
+  for (let attempt = 0; attempt < REWRITE_ATTEMPTS; attempt += 1) {
+    if (messageIdOn(current.metadata) !== messageId) {
+      return;
+    }
+
+    // One unreadable row must not cost every other recipient their wipe, the
+    // same way `countOn` and `messageIdOn` read a row above. A row carrying
+    // no preview is left alone: this takes text back or brings it up to date,
+    // and never puts text somewhere it was not.
+    const stored = paramsOn(current.messageParams);
+    if (typeof stored?.messagePreview !== "string") {
+      return;
+    }
+
+    const { messagePreview: _previous, ...rest } = stored;
+    const written = await prisma.notification.updateMany({
+      where: { id: current.id, messageParams: current.messageParams },
+      data: {
+        messageParams: JSON.stringify(
+          preview ? { ...rest, messagePreview: preview } : rest,
+        ),
+      },
+    });
+
+    if (written.count > 0) {
+      return;
+    }
+
+    const reread = await prisma.notification.findUnique({
+      where: { id: current.id },
+      select: { id: true, messageParams: true, metadata: true },
+    });
+
+    if (reread === null) {
+      return;
+    }
+
+    current = reread;
+  }
+}
+
+/**
+ * Bring the copy of a message that rides its notifications up to date.
+ *
+ * A deleted message is wiped from its own row, and an edited one keeps only
+ * what it now says. The copy on a notification row would otherwise outlive
+ * both: it stays readable through the notifications API long after the
+ * message stopped saying it. Pass what the message says now; a delete passes
+ * an empty body, which takes the copy away.
+ *
+ * A preview is never added to a row that had none. The reader was already
+ * sent whatever the row holds, so this takes text back or brings it up to
+ * date, and never puts text somewhere it was not.
+ *
+ * Failure is reported rather than thrown: a reader deleting a message must
+ * not be told the delete failed because a copy of it survived.
+ */
+export async function rewriteChatNotificationPreviews(params: {
+  roomId: string;
+  messageId: string;
+  content: string;
+}): Promise<void> {
+  try {
+    // `metadata` is stored as JSON text, so the message is matched as text
+    // and the match confirmed by parsing below. Scoped to the room's own chat
+    // rows, and run only when a reader deletes or edits, which is rare beside
+    // posting. A counted row names the last message counted onto it, which is
+    // why the id is read from `metadata` rather than from `eventId`.
+    const rows = await prisma.notification.findMany({
+      where: {
+        kind: NotificationKind.CHAT,
+        referenceId: params.roomId,
+        metadata: { contains: `"messageId":"${params.messageId}"` },
+      },
+      select: { id: true, messageParams: true, metadata: true },
+    });
+
+    const preview = buildChatMessagePreview(params.content);
+
+    for (const row of rows) {
+      await rewriteRow(row, params.messageId, preview);
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      extra: {
+        roomId: params.roomId,
+        messageId: params.messageId,
+        notificationType: "chat_notification_preview_rewrite",
+      },
+    });
   }
 }

--- a/apps/core/src/helpers/chat-notification-fanout.ts
+++ b/apps/core/src/helpers/chat-notification-fanout.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/node";
-import { NotificationKind } from "@sokosumi/database";
+import { NotificationKind, type Prisma } from "@sokosumi/database";
 import { buildChatMessagePreview } from "@sokosumi/utils";
 
 import type { CreateNotificationInput } from "@/helpers/notifications";
@@ -331,7 +331,6 @@ export async function fanOutChatNotifications(
   await rewriteChatNotificationPreviews({
     roomId: params.roomId,
     messageId: params.messageId,
-    content: saysNow,
   });
 }
 
@@ -379,6 +378,7 @@ async function rewriteRow(
   row: RewritableRow,
   messageId: string,
   preview: string,
+  tx: Prisma.TransactionClient,
 ): Promise<void> {
   let current = row;
 
@@ -397,7 +397,7 @@ async function rewriteRow(
     }
 
     const { messagePreview: _previous, ...rest } = stored;
-    const written = await prisma.notification.updateMany({
+    const written = await tx.notification.updateMany({
       where: { id: current.id, messageParams: current.messageParams },
       data: {
         messageParams: JSON.stringify(
@@ -410,7 +410,7 @@ async function rewriteRow(
       return;
     }
 
-    const reread = await prisma.notification.findUnique({
+    const reread = await tx.notification.findUnique({
       where: { id: current.id },
       select: { id: true, messageParams: true, metadata: true },
     });
@@ -429,8 +429,8 @@ async function rewriteRow(
  * A deleted message is wiped from its own row, and an edited one keeps only
  * what it now says. The copy on a notification row would otherwise outlive
  * both: it stays readable through the notifications API long after the
- * message stopped saying it. Pass what the message says now; a delete passes
- * an empty body, which takes the copy away.
+ * message stopped saying it. Read the current body under a row lock so a
+ * delayed edit cannot replace a newer preview with its old request body.
  *
  * A preview is never added to a row that had none. The reader was already
  * sent whatever the row holds, so this takes text back or brings it up to
@@ -442,28 +442,45 @@ async function rewriteRow(
 export async function rewriteChatNotificationPreviews(params: {
   roomId: string;
   messageId: string;
-  content: string;
 }): Promise<void> {
   try {
-    // `metadata` is stored as JSON text, so the message is matched as text
-    // and the match confirmed by parsing below. Scoped to the room's own chat
-    // rows, and run only when a reader deletes or edits, which is rare beside
-    // posting. A counted row names the last message counted onto it, which is
-    // why the id is read from `metadata` rather than from `eventId`.
-    const rows = await prisma.notification.findMany({
-      where: {
-        kind: NotificationKind.CHAT,
-        referenceId: params.roomId,
-        metadata: { contains: `"messageId":"${params.messageId}"` },
-      },
-      select: { id: true, messageParams: true, metadata: true },
+    await prisma.$transaction(async (tx) => {
+      // Hold the message lock until its copies are updated. Message edits and
+      // deletes use this same row, so the preview follows their commit order.
+      await tx.$queryRaw`
+        SELECT "id" FROM "chat_room_message"
+        WHERE "id" = ${params.messageId}::uuid
+          AND "roomId" = ${params.roomId}::uuid
+        FOR UPDATE
+      `;
+      const message = await tx.chatRoomMessage.findUnique({
+        where: { id: params.messageId, roomId: params.roomId },
+        select: { content: true, deletedAt: true },
+      });
+
+      // `metadata` is stored as JSON text, so the message is matched as text
+      // and the match confirmed by parsing below. Scoped to the room's own chat
+      // rows, and run only when a reader deletes or edits, which is rare beside
+      // posting. A counted row names the last message counted onto it, which is
+      // why the id is read from `metadata` rather than from `eventId`.
+      const rows = await tx.notification.findMany({
+        where: {
+          kind: NotificationKind.CHAT,
+          referenceId: params.roomId,
+          metadata: { contains: `"messageId":"${params.messageId}"` },
+        },
+        select: { id: true, messageParams: true, metadata: true },
+        orderBy: { id: "asc" },
+      });
+
+      const preview = buildChatMessagePreview(
+        message === null || message.deletedAt !== null ? "" : message.content,
+      );
+
+      for (const row of rows) {
+        await rewriteRow(row, params.messageId, preview, tx);
+      }
     });
-
-    const preview = buildChatMessagePreview(params.content);
-
-    for (const row of rows) {
-      await rewriteRow(row, params.messageId, preview);
-    }
   } catch (error) {
     Sentry.captureException(error, {
       extra: {

--- a/apps/core/src/helpers/chat-notification-fanout.ts
+++ b/apps/core/src/helpers/chat-notification-fanout.ts
@@ -8,6 +8,7 @@ import {
   publishNotificationRow,
   resolveDelivery,
 } from "@/helpers/notifications";
+import { isPrismaTransactionConflict } from "@/helpers/prisma";
 import prisma from "@/lib/db/prisma";
 
 export interface FanOutChatNotificationsParams {
@@ -423,69 +424,92 @@ async function rewriteRow(
   }
 }
 
-/**
- * Bring the copy of a message that rides its notifications up to date.
- *
- * A deleted message is wiped from its own row, and an edited one keeps only
- * what it now says. The copy on a notification row would otherwise outlive
- * both: it stays readable through the notifications API long after the
- * message stopped saying it. Read the current body under a row lock so a
- * delayed edit cannot replace a newer preview with its old request body.
- *
- * A preview is never added to a row that had none. The reader was already
- * sent whatever the row holds, so this takes text back or brings it up to
- * date, and never puts text somewhere it was not.
- *
- * Failure is reported rather than thrown: a reader deleting a message must
- * not be told the delete failed because a copy of it survived.
- */
-export async function rewriteChatNotificationPreviews(params: {
+interface PreviewMessageSource {
   roomId: string;
   messageId: string;
-}): Promise<void> {
-  try {
-    await prisma.$transaction(async (tx) => {
-      // Hold the message lock until its copies are updated. Message edits and
-      // deletes use this same row, so the preview follows their commit order.
-      await tx.$queryRaw`
-        SELECT "id" FROM "chat_room_message"
-        WHERE "id" = ${params.messageId}::uuid
-          AND "roomId" = ${params.roomId}::uuid
-        FOR UPDATE
-      `;
-      const message = await tx.chatRoomMessage.findUnique({
-        where: { id: params.messageId, roomId: params.roomId },
-        select: { content: true, deletedAt: true },
+}
+
+const PREVIEW_TRANSACTION_ATTEMPTS = 3;
+
+/** Lock and reread the message for one recipient, including on each retry. */
+async function rewriteRowFromMessage(
+  row: RewritableRow,
+  source: PreviewMessageSource,
+): Promise<void> {
+  for (let attempt = 0; attempt < PREVIEW_TRANSACTION_ATTEMPTS; attempt += 1) {
+    try {
+      await prisma.$transaction(async (tx) => {
+        // Keep this lock until this recipient's copy is updated. Separate
+        // transactions prevent a slow room-wide sweep from rolling back all rows.
+        await tx.$queryRaw`
+          SELECT "id" FROM "chat_room_message"
+          WHERE "id" = ${source.messageId}::uuid
+            AND "roomId" = ${source.roomId}::uuid
+          FOR UPDATE
+        `;
+        const message = await tx.chatRoomMessage.findUnique({
+          where: { id: source.messageId, roomId: source.roomId },
+          select: { content: true, deletedAt: true },
+        });
+        const preview = buildChatMessagePreview(
+          message === null || message.deletedAt !== null ? "" : message.content,
+        );
+        await rewriteRow(row, source.messageId, preview, tx);
       });
-
-      // `metadata` is stored as JSON text, so the message is matched as text
-      // and the match confirmed by parsing below. Scoped to the room's own chat
-      // rows, and run only when a reader deletes or edits, which is rare beside
-      // posting. A counted row names the last message counted onto it, which is
-      // why the id is read from `metadata` rather than from `eventId`.
-      const rows = await tx.notification.findMany({
-        where: {
-          kind: NotificationKind.CHAT,
-          referenceId: params.roomId,
-          metadata: { contains: `"messageId":"${params.messageId}"` },
-        },
-        select: { id: true, messageParams: true, metadata: true },
-        orderBy: { id: "asc" },
-      });
-
-      const preview = buildChatMessagePreview(
-        message === null || message.deletedAt !== null ? "" : message.content,
-      );
-
-      for (const row of rows) {
-        await rewriteRow(row, params.messageId, preview, tx);
+      return;
+    } catch (error) {
+      const transactionExpired =
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "P2028";
+      if (
+        attempt + 1 === PREVIEW_TRANSACTION_ATTEMPTS ||
+        (!transactionExpired && !isPrismaTransactionConflict(error))
+      ) {
+        throw error;
       }
+    }
+  }
+}
+
+/**
+ * Refresh existing previews from the stored message, one recipient at a time.
+ * A failed recipient is reported without undoing or skipping other recipients.
+ * Rows without a preview stay without one.
+ */
+export async function rewriteChatNotificationPreviews(
+  params: PreviewMessageSource,
+): Promise<void> {
+  try {
+    // Counted rows reference their latest message in metadata, not eventId.
+    // This snapshot only selects candidates; each guarded write checks the row.
+    const rows = await prisma.notification.findMany({
+      where: {
+        kind: NotificationKind.CHAT,
+        referenceId: params.roomId,
+        metadata: { contains: `"messageId":"${params.messageId}"` },
+      },
+      select: { id: true, messageParams: true, metadata: true },
+      orderBy: { id: "asc" },
     });
+    for (const row of rows) {
+      try {
+        await rewriteRowFromMessage(row, params);
+      } catch (error) {
+        Sentry.captureException(error, {
+          extra: {
+            ...params,
+            notificationId: row.id,
+            notificationType: "chat_notification_preview_rewrite",
+          },
+        });
+      }
+    }
   } catch (error) {
     Sentry.captureException(error, {
       extra: {
-        roomId: params.roomId,
-        messageId: params.messageId,
+        ...params,
         notificationType: "chat_notification_preview_rewrite",
       },
     });

--- a/apps/core/src/helpers/chat-notification-preview.integration.test.ts
+++ b/apps/core/src/helpers/chat-notification-preview.integration.test.ts
@@ -1,0 +1,213 @@
+import { createPrismaClient } from "@sokosumi/database/client";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const { captureException, databaseUrlFor } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  databaseUrlFor(application: string) {
+    const configured = process.env.PREVIEW_INTEGRATION_DATABASE_URL;
+    if (!configured) return undefined;
+    const url = new URL(configured);
+    if (
+      url.hostname !== "127.0.0.1" ||
+      url.pathname !== "/notification_preview_test"
+    ) {
+      throw new Error(
+        "Preview integration tests require a dedicated local notification_preview_test database",
+      );
+    }
+    url.searchParams.set("application_name", application);
+    return url.toString();
+  },
+}));
+vi.mock("@sentry/node", () => ({ captureException }));
+vi.mock("@/helpers/notifications", () => ({}));
+vi.mock("@/lib/db/prisma", async () => {
+  const { createPrismaClient } = await import("@sokosumi/database/client");
+  const url = databaseUrlFor("preview-rewrite");
+  return { default: url ? createPrismaClient(url) : {} };
+});
+
+import prisma from "@/lib/db/prisma";
+import { rewriteChatNotificationPreviews } from "./chat-notification-fanout";
+
+// Uses a dedicated disposable database and minimal tables. Tests actual
+// Prisma/PostgreSQL locking, but does not validate production migrations.
+const databaseUrl = databaseUrlFor("preview-control");
+let ownsType = false;
+let ownsMessages = false;
+let ownsNotifications = false;
+const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
+const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440002";
+const NOTIFICATION_ID = "preview-lock-notification";
+const control = databaseUrl ? createPrismaClient(databaseUrl) : null;
+const writer = databaseUrl
+  ? createPrismaClient(databaseUrlFor("preview-writer")!)
+  : null;
+const observer = databaseUrl
+  ? createPrismaClient(databaseUrlFor("preview-observer")!)
+  : null;
+function deferred() {
+  let resolve = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+async function waitsForLock(application: string) {
+  const rows = await observer!.$queryRaw<Array<{ waiting: boolean }>>`
+    SELECT EXISTS (SELECT 1 FROM pg_stat_activity
+      WHERE application_name = ${application} AND wait_event_type = 'Lock') AS waiting
+  `;
+  return rows[0]?.waiting;
+}
+async function storedPreview() {
+  const rows = await observer!.$queryRaw<Array<{ messageParams: string }>>`
+    SELECT "messageParams" FROM notification WHERE id = ${NOTIFICATION_ID}
+  `;
+  return JSON.parse(rows[0]!.messageParams).messagePreview;
+}
+describe.skipIf(!databaseUrl)(
+  "chat notification preview PostgreSQL locking",
+  () => {
+    beforeAll(async () => {
+      await control!.$executeRawUnsafe(
+        `CREATE TYPE "NotificationKind" AS ENUM ('JOB', 'TASK', 'BILLING', 'SYSTEM', 'CHAT')`,
+      );
+      ownsType = true;
+      await control!.$executeRawUnsafe(`CREATE TABLE chat_room_message (
+      id uuid PRIMARY KEY, "roomId" uuid NOT NULL, content text NOT NULL, "deletedAt" timestamp
+    )`);
+      ownsMessages = true;
+      await control!.$executeRawUnsafe(`CREATE TABLE notification (
+      id text PRIMARY KEY, kind "NotificationKind" NOT NULL, "referenceId" text NOT NULL,
+      "messageParams" text NOT NULL, metadata text
+    )`);
+      ownsNotifications = true;
+      await control!.$executeRaw`
+      INSERT INTO chat_room_message (id, "roomId", content)
+      VALUES (${MESSAGE_ID}::uuid, ${ROOM_ID}::uuid, 'original')
+    `;
+      await control!.$executeRaw`
+      INSERT INTO notification (id, kind, "referenceId", "messageParams", metadata)
+      VALUES (${NOTIFICATION_ID}, 'CHAT', ${ROOM_ID}, '{}', ${JSON.stringify({ messageId: MESSAGE_ID })})
+    `;
+    });
+    beforeEach(async () => {
+      captureException.mockClear();
+      await control!
+        .$executeRaw`UPDATE chat_room_message SET content = 'original', "deletedAt" = NULL`;
+      await control!.$executeRaw`
+      UPDATE notification SET "messageParams" = ${JSON.stringify({ messagePreview: "original", count: 2 })}
+    `;
+    });
+    afterAll(async () => {
+      if (control) {
+        if (ownsNotifications)
+          await control.$executeRawUnsafe("DROP TABLE notification");
+        if (ownsMessages)
+          await control.$executeRawUnsafe("DROP TABLE chat_room_message");
+        if (ownsType)
+          await control.$executeRawUnsafe('DROP TYPE "NotificationKind"');
+      }
+      await Promise.all([
+        prisma.$disconnect(),
+        control?.$disconnect(),
+        writer?.$disconnect(),
+        observer?.$disconnect(),
+      ]);
+    });
+    it("uses committed content when an older edit callback runs last", async () => {
+      await writer!
+        .$executeRaw`UPDATE chat_room_message SET content = 'latest edit B'`;
+      await rewriteChatNotificationPreviews({
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+      });
+      await rewriteChatNotificationPreviews({
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+      });
+      expect(await storedPreview()).toBe("latest edit B");
+      expect(captureException).not.toHaveBeenCalled();
+    });
+    it.each(["edit", "delete"])(
+      "holds the message lock through the sweep before a competing %s",
+      async (operation) => {
+        const locked = deferred();
+        const release = deferred();
+        const blocker = control!.$transaction(
+          async (tx) => {
+            await tx.$queryRaw`SELECT id FROM notification WHERE id = ${NOTIFICATION_ID} FOR UPDATE`;
+            locked.resolve();
+            await release.promise;
+          },
+          { timeout: 10_000 },
+        );
+        await locked.promise;
+        const rewrite = rewriteChatNotificationPreviews({
+          roomId: ROOM_ID,
+          messageId: MESSAGE_ID,
+        });
+        let mutation: Promise<unknown> | undefined;
+        try {
+          await expect
+            .poll(() => waitsForLock("preview-rewrite"), { timeout: 2_000 })
+            .toBe(true);
+          mutation =
+            operation === "edit"
+              ? writer!
+                  .$executeRaw`UPDATE chat_room_message SET content = 'latest edit B'`.then(
+                  (result) => result,
+                )
+              : writer!
+                  .$executeRaw`UPDATE chat_room_message SET content = '', "deletedAt" = NOW()`.then(
+                  (result) => result,
+                );
+          await expect
+            .poll(() => waitsForLock("preview-writer"), { timeout: 2_000 })
+            .toBe(true);
+        } finally {
+          release.resolve();
+          await blocker;
+          await rewrite;
+          await mutation;
+        }
+        await rewriteChatNotificationPreviews({
+          roomId: ROOM_ID,
+          messageId: MESSAGE_ID,
+        });
+        expect(await storedPreview()).toBe(
+          operation === "edit" ? "latest edit B" : undefined,
+        );
+        expect(captureException).not.toHaveBeenCalled();
+      },
+    );
+    it("rewrites 100 recipient rows", async () => {
+      await control!.$executeRaw`
+      INSERT INTO notification (id, kind, "referenceId", "messageParams", metadata)
+      SELECT 'recipient-' || n, 'CHAT', ${ROOM_ID}, ${JSON.stringify({ messagePreview: "original" })},
+        ${JSON.stringify({ messageId: MESSAGE_ID })} FROM generate_series(1, 99) AS n
+    `;
+      await writer!
+        .$executeRaw`UPDATE chat_room_message SET content = 'latest edit B'`;
+      await rewriteChatNotificationPreviews({
+        roomId: ROOM_ID,
+        messageId: MESSAGE_ID,
+      });
+      const rows = await observer!.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*) AS count FROM notification
+      WHERE "messageParams"::jsonb->>'messagePreview' = 'latest edit B'
+    `;
+      expect(rows[0]?.count).toBe(100n);
+      expect(captureException).not.toHaveBeenCalled();
+    });
+  },
+);

--- a/apps/core/src/helpers/chat-notification-preview.integration.test.ts
+++ b/apps/core/src/helpers/chat-notification-preview.integration.test.ts
@@ -209,5 +209,32 @@ describe.skipIf(!databaseUrl)(
       expect(rows[0]?.count).toBe(100n);
       expect(captureException).not.toHaveBeenCalled();
     });
+    it("clears every preview when recipient writes are slow", async () => {
+      await control!.$executeRaw`
+        INSERT INTO notification (id, kind, "referenceId", "messageParams", metadata)
+        SELECT 'recipient-' || n, 'CHAT', ${ROOM_ID}, ${JSON.stringify({ messagePreview: "original" })},
+          ${JSON.stringify({ messageId: MESSAGE_ID })} FROM generate_series(1, 99) AS n ON CONFLICT (id) DO NOTHING
+      `;
+      await control!.$executeRawUnsafe(`CREATE FUNCTION slow_preview_write() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN PERFORM pg_sleep(0.06); RETURN NEW; END $$`);
+      await control!.$executeRawUnsafe(`CREATE TRIGGER slow_preview_write BEFORE UPDATE ON notification
+        FOR EACH ROW EXECUTE FUNCTION slow_preview_write()`);
+      try {
+        await writer!
+          .$executeRaw`UPDATE chat_room_message SET content = '', "deletedAt" = NOW()`;
+        const request = { roomId: ROOM_ID, messageId: MESSAGE_ID };
+        await rewriteChatNotificationPreviews(request);
+        const rows = await observer!.$queryRaw<Array<{ count: bigint }>>`
+          SELECT COUNT(*) AS count FROM notification WHERE "messageParams"::jsonb ? 'messagePreview'
+        `;
+        expect(rows[0]?.count).toBe(0n);
+        expect(captureException).not.toHaveBeenCalled();
+      } finally {
+        await control!.$executeRawUnsafe(
+          "DROP TRIGGER slow_preview_write ON notification",
+        );
+        await control!.$executeRawUnsafe("DROP FUNCTION slow_preview_write()");
+      }
+    }, 15_000);
   },
 );

--- a/apps/core/src/helpers/chat-room-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-room-message-notifications.test.ts
@@ -32,6 +32,13 @@ vi.mock("@/lib/db/prisma", () => ({
     user: { findMany: userFindManyMock },
     // The fan-out looks for a row to count onto before it writes one.
     notification: { findFirst: notificationFindFirstMock },
+    // It reads the message too, so a body deleted while it ran is not
+    // written back onto the notifications.
+    chatRoomMessage: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue({ deletedAt: null, content: "ship it" }),
+    },
   },
 }));
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.test.ts
@@ -57,6 +57,14 @@ vi.mock("@/helpers/chat-room-pinned-message-realtime", () => ({
   publishChatRoomPinnedMessageRealtime: vi.fn().mockResolvedValue(undefined),
 }));
 
+const { rewriteChatNotificationPreviewsMock } = vi.hoisted(() => ({
+  rewriteChatNotificationPreviewsMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/helpers/chat-notification-fanout", () => ({
+  rewriteChatNotificationPreviews: rewriteChatNotificationPreviewsMock,
+}));
+
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
 const USER_ID = "user_123";
@@ -167,6 +175,85 @@ describe("DELETE /chat-rooms/:id/messages/:messageId", () => {
     mentionUpdateManyMock.mockResolvedValue({ count: 0 });
     pinDeleteManyMock.mockResolvedValue({ count: 0 });
     pinCountMock.mockResolvedValue(0);
+  });
+
+  /**
+   * The body is wiped from the message row, so the copy of it that rode this
+   * message's notifications has to go the same way. It stays readable through
+   * the notifications API otherwise.
+   */
+  it("takes the message's text off its notifications", async () => {
+    const app = createApp(userAuthContext);
+
+    await app.request(`/${ROOM_ID}/messages/${MESSAGE_ID}`, {
+      method: "DELETE",
+    });
+
+    expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+  });
+
+  /**
+   * A wipe that fails is only reported, so the rows keep the text and the
+   * reader's one way back is to delete again. A repeat delete has to try.
+   */
+  it("tries again when the message was already deleted", async () => {
+    messageUpdateManyMock.mockResolvedValue({ count: 0 });
+    const app = createApp(userAuthContext);
+
+    await app.request(`/${ROOM_ID}/messages/${MESSAGE_ID}`, {
+      method: "DELETE",
+    });
+
+    expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+  });
+
+  /**
+   * A uuid is matched without case by the message's own column and with case
+   * by the notification's, which stores it as text. Taking the ids off the
+   * row rather than off the path keeps the two reads looking at one message.
+   */
+  it("names the message by the ids on its row, not the ones in the path", async () => {
+    const app = createApp(userAuthContext);
+
+    const response = await app.request(
+      `/${ROOM_ID.toUpperCase()}/messages/${MESSAGE_ID.toUpperCase()}`,
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "",
+    });
+  });
+
+  /**
+   * The reader is answered once the text is gone. Answering first would send
+   * them back to a list that still carries it.
+   */
+  it("answers only once the wipe has run", async () => {
+    const order: string[] = [];
+    rewriteChatNotificationPreviewsMock.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      order.push("wipe");
+    });
+    const app = createApp(userAuthContext);
+
+    await app.request(`/${ROOM_ID}/messages/${MESSAGE_ID}`, {
+      method: "DELETE",
+    });
+    order.push("answer");
+
+    expect(order).toEqual(["wipe", "answer"]);
   });
 
   it("soft-deletes the author message and returns a tombstone", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.test.ts
@@ -192,7 +192,6 @@ describe("DELETE /chat-rooms/:id/messages/:messageId", () => {
     expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
   });
 
@@ -211,7 +210,6 @@ describe("DELETE /chat-rooms/:id/messages/:messageId", () => {
     expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
   });
 
@@ -232,7 +230,6 @@ describe("DELETE /chat-rooms/:id/messages/:messageId", () => {
     expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "",
     });
   });
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
-
+import { rewriteChatNotificationPreviews } from "@/helpers/chat-notification-fanout";
 import {
   publishChatRoomMessageRealtime,
   publishChatRoomMessageRealtimeById,
@@ -172,6 +172,17 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       );
     }
     await Promise.all(publishes);
+
+    // The body is wiped from the message row, so the copy of it that rides
+    // this message's notifications goes with it. Run on a repeat delete too:
+    // a wipe that failed is only reported, and deleting again is the one way
+    // back. The ids come off the row, because a uuid the caller wrote in
+    // capitals still matches the message and would match no notification.
+    await rewriteChatNotificationPreviews({
+      roomId: message.roomId,
+      messageId: message.id,
+      content: "",
+    });
 
     if (unpinned) {
       await publishChatRoomPinnedMessageRealtime({

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
@@ -181,7 +181,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     await rewriteChatNotificationPreviews({
       roomId: message.roomId,
       messageId: message.id,
-      content: "",
     });
 
     if (unpinned) {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.test.ts
@@ -207,7 +207,6 @@ describe("PATCH /chats/rooms/:id/messages/:messageId", () => {
     expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "hello fixed",
     });
   });
 
@@ -229,7 +228,6 @@ describe("PATCH /chats/rooms/:id/messages/:messageId", () => {
     expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
       roomId: ROOM_ID,
       messageId: MESSAGE_ID,
-      content: "hello fixed",
     });
   });
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.test.ts
@@ -50,6 +50,14 @@ vi.mock("@/helpers/chat-room-message-realtime", () => ({
   publishChatRoomMessageRealtime: vi.fn().mockResolvedValue(undefined),
 }));
 
+const { rewriteChatNotificationPreviewsMock } = vi.hoisted(() => ({
+  rewriteChatNotificationPreviewsMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/helpers/chat-notification-fanout", () => ({
+  rewriteChatNotificationPreviews: rewriteChatNotificationPreviewsMock,
+}));
+
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
 const USER_ID = "user_123";
@@ -187,6 +195,65 @@ describe("PATCH /chats/rooms/:id/messages/:messageId", () => {
     expect(body.data.editedAt).toBe("2026-07-01T12:05:00.000Z");
     expect(scheduleUnfurlsMock).toHaveBeenCalledWith(MESSAGE_ID);
     expect(waitUntilMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The notifications for this message carry what it used to say, and the
+   * reader can still read them. An edit brings that copy up to date.
+   */
+  it("puts what the message now says on its notifications", async () => {
+    await patchMessage({ content: "hello fixed" });
+
+    expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "hello fixed",
+    });
+  });
+
+  /**
+   * A uuid is matched without case by the message's own column and with case
+   * by the notification's, which stores it as text.
+   */
+  it("names the message by the ids on its row, not the ones in the path", async () => {
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID.toUpperCase()}/messages/${MESSAGE_ID.toUpperCase()}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "hello fixed" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(rewriteChatNotificationPreviewsMock).toHaveBeenCalledWith({
+      roomId: ROOM_ID,
+      messageId: MESSAGE_ID,
+      content: "hello fixed",
+    });
+  });
+
+  /**
+   * The reader is answered once the copy is up to date. Answering first would
+   * send them back to a list that still carries what the message used to say.
+   */
+  it("answers only once the rewrite has run", async () => {
+    const order: string[] = [];
+    rewriteChatNotificationPreviewsMock.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      order.push("rewrite");
+    });
+
+    await patchMessage({ content: "hello fixed" });
+    order.push("answer");
+
+    expect(order).toEqual(["rewrite", "answer"]);
+  });
+
+  it("leaves the notifications alone when the content did not change", async () => {
+    await patchMessage({ content: "hello" });
+
+    expect(rewriteChatNotificationPreviewsMock).not.toHaveBeenCalled();
   });
 
   it("returns current DTO without bumping editedAt when content is unchanged", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { waitUntil } from "@vercel/functions";
 
+import { rewriteChatNotificationPreviews } from "@/helpers/chat-notification-fanout";
 import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { forbidden, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -124,6 +125,14 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     await publishChatRoomMessageRealtime(message, "update");
 
     if (contentChanged) {
+      // The row would otherwise keep what the message used to say. The ids
+      // come off the row: a uuid the caller wrote in capitals still matches
+      // the message, and would match no notification.
+      await rewriteChatNotificationPreviews({
+        roomId: message.roomId,
+        messageId: message.id,
+        content: body.content,
+      });
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));
     }
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
@@ -131,7 +131,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       await rewriteChatNotificationPreviews({
         roomId: message.roomId,
         messageId: message.id,
-        content: body.content,
       });
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));
     }


### PR DESCRIPTION
## What this changes

The layer below puts a preview of the message on every recipient's
notification. That copy outlived the message: deleting a message wipes the
body from the message row, and nothing touched the copy, which stayed
readable through `GET /v1/notifications`. An edit left the text the message
used to say.

The delete route now clears the preview from the notifications that carry
that message, and the edit route rewrites it.

A row that carried no preview is left alone. The reader was already sent
whatever the row holds, so this takes text back or brings it up to date, and
never puts text somewhere it was not.

## Notes for the reviewer

A counted room keeps one unread row per reader and counts later messages onto
it, so the row's `eventId` names the first message of the run while its
`metadata.messageId` names the last. The rows are therefore found by the
message id in `metadata`, matched as text in the query and confirmed by
parsing. The layer below indexes that read.

The write names the params it read, so a message that counts onto the row
between the read and the write keeps its own text there. Losing that race is
not a failure, though, so the row is read again and decided on afresh, up to
three times, the way the counting path is bounded. Without the retry, a delete
whose write lost to an edit of the same message would leave the edited text of
a deleted message on the row for good.

Every attempt after the first decides on what that row now holds: it names the
params it just read, and it stops on a row a newer message has been counted
onto, whose text is not this one's to take. Naming the first read's params
instead would lose all three attempts and leave the text standing.

The ids come off the message row rather than off the request path. A uuid
written in capitals still matches the message, whose id is a uuid column, and
would match no notification, whose ids are stored as text.

A failure is reported to Sentry rather than thrown: the message is already
deleted by the time this runs, and a reader must not be told their delete
failed because a copy of it survived. A repeat delete therefore sweeps again,
because deleting again is the reader's one way back from a sweep that failed.

The fan-out runs after its own response, so a message can be deleted before
its notifications are written. It now reads the message before building the
preview and writes none for a message already gone, which is the other half
of the same promise.

That read is one moment and the loop that follows is another. A delete or an
edit landing between them takes the text off the rows that exist by then and
leaves it on every row the loop writes after. The fan-out is the last writer
of those rows, so it reads the message once more when it is done and takes
its own text back, or brings it up to date. Only when it wrote a preview at
all: a fan-out that wrote none has nothing to take back, and skips the second
read.

## User-facing impact

A message deleted for everyone stops being readable through the notifications
API. An edited message reads as it now says.

## Verification

- `pnpm --filter core test` — 5024 passed, 6 skipped, 477 files, no failures
- Every assertion here was written against a mutant of the code it covers, and
  each mutant fails at least one test: both route calls and both sets of ids,
  both awaited calls, the repeat-delete sweep, the row sweep and both of the
  rows it steps over, the defensive parse, the two row guards, the
  named-params write on the first attempt and on the retries, the guard that
  stops on a row a newer message took over, the bound that stops as soon as a
  write lands, the empty-preview branch, the room scope of the query,
  both halves of the deleted-message check, both reads of the message and the
  id each one names, the post-loop rewrite and the room it names, the retry
  and its bound, the re-read of a row that is gone, and both the read and the
  write inside the reported failure
- `pnpm typecheck`, `pnpm check`

Part of [SOK-980](https://linear.app/masumi/issue/SOK-980/show-the-chat-message-text-in-push-notifications).
