### PR TITLE
fix(tasks): restore normal task scheduling

### DIFF
--- a/apps/core/src/routes/v1/tasks/[id]/schedule/delete.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/schedule/delete.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/middleware/auth", async (importOriginal) => {
 
 const {
   prismaTransactionMock,
+  memberFindFirstMock,
   requireTaskOwnershipMock,
   lockCalendarScopeMock,
   lockTaskRowsMock,
@@ -25,6 +26,7 @@ const {
   taskUpdateMock,
 } = vi.hoisted(() => ({
   prismaTransactionMock: vi.fn(),
+  memberFindFirstMock: vi.fn(),
   requireTaskOwnershipMock: vi.fn(),
   lockCalendarScopeMock: vi.fn(),
   lockTaskRowsMock: vi.fn(),
@@ -35,10 +37,6 @@ const {
 
 vi.mock("@/helpers/access-control", () => ({
   requireMutableTaskOwnership: requireTaskOwnershipMock,
-}));
-
-vi.mock("@/helpers/calendar-beta-access", () => ({
-  requireCalendarBetaAccess: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/helpers/calendar-locks", () => ({
@@ -54,6 +52,7 @@ vi.mock("@/helpers/task-schedule-occurrence-index", () => ({
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     $transaction: prismaTransactionMock,
+    member: { findFirst: memberFindFirstMock },
   },
 }));
 
@@ -142,6 +141,7 @@ function createApp(
 describe("DELETE /tasks/{id}/schedule", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    memberFindFirstMock.mockResolvedValue({ id: "member_123" });
     requireTaskOwnershipMock.mockResolvedValue({
       id: "tsk_123",
       status: TaskStatus.READY,
@@ -158,6 +158,20 @@ describe("DELETE /tasks/{id}/schedule", () => {
         task: { update: taskUpdateMock },
       }),
     );
+  });
+
+  it("allows task schedule removal outside the Calendar beta", async () => {
+    memberFindFirstMock.mockResolvedValue(null);
+
+    const response = await createApp().request(
+      "http://localhost/tsk_123/schedule",
+      {
+        method: "DELETE",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(requireTaskOwnershipMock).toHaveBeenCalled();
   });
 
   it("returns 403 for coworker context even when X-Context-User-Id matches owner", async () => {

--- a/apps/core/src/routes/v1/tasks/[id]/schedule/delete.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/schedule/delete.ts
@@ -3,7 +3,6 @@ import { TaskStatus } from "@sokosumi/database";
 import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
 
 import { requireMutableTaskOwnership } from "@/helpers/access-control";
-import { requireCalendarBetaAccess } from "@/helpers/calendar-beta-access";
 import { lockCalendarScope, lockTaskRows } from "@/helpers/calendar-locks";
 import { conflict } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -44,7 +43,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { authContext } = c.var;
     const userContext = requireOwnerUserContext(authContext);
-    await requireCalendarBetaAccess(userContext.userId, prisma);
     const { id } = c.req.valid("param");
     const existingTask = await requireMutableTaskOwnership(
       userContext,

--- a/apps/core/src/routes/v1/tasks/[id]/schedule/put.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/schedule/put.test.ts
@@ -180,7 +180,7 @@ describe("PUT /tasks/{id}/schedule", () => {
     );
   });
 
-  it("returns 403 outside the Calendar beta", async () => {
+  it("allows task scheduling outside the Calendar beta", async () => {
     memberFindFirstMock.mockResolvedValue(null);
 
     const response = await createApp().request(
@@ -195,8 +195,8 @@ describe("PUT /tasks/{id}/schedule", () => {
       },
     );
 
-    expect(response.status).toBe(403);
-    expect(requireTaskCollaborationMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(requireTaskCollaborationMock).toHaveBeenCalled();
   });
 
   it("returns 403 when the member has no assigned organization seat", async () => {

--- a/apps/core/src/routes/v1/tasks/[id]/schedule/put.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/schedule/put.ts
@@ -3,7 +3,6 @@ import { TaskStatus } from "@sokosumi/database";
 import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
 
 import { requireTaskCollaboration } from "@/helpers/access-control";
-import { requireCalendarBetaAccess } from "@/helpers/calendar-beta-access";
 import { lockCalendarScope, lockTaskRows } from "@/helpers/calendar-locks";
 import { badRequest, conflict, forbidden } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -67,7 +66,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { authContext } = c.var;
     const userContext = requireOwnerUserContext(authContext);
-    await requireCalendarBetaAccess(userContext.userId, prisma);
     const { id } = c.req.valid("param");
     const body = c.req.valid("json");
     const schedule = getTaskScheduleInput(body);

--- a/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
@@ -366,7 +366,8 @@ describe("TaskForm", () => {
     }
   });
 
-  it("hides scheduling controls outside the Calendar beta", () => {
+  it("opens task scheduling outside the Calendar beta", async () => {
+    const user = userEvent.setup();
     calendarBetaAccessMock.enabled = false;
 
     render(
@@ -381,9 +382,11 @@ describe("TaskForm", () => {
       />,
     );
 
-    expect(
-      screen.queryByRole("button", { name: baseLabels.openSchedule }),
-    ).not.toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: baseLabels.openSchedule }),
+    );
+
+    expect(screen.getByText("timezone")).toBeInTheDocument();
   });
 
   function getHiddenFileInput(container: HTMLElement): HTMLInputElement {

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -52,7 +52,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useCalendarBetaAccess } from "@/contexts/calendar-beta-access-context";
 import { useOSDetection } from "@/hooks/use-os-detection";
 import {
   type CreateTaskResult,
@@ -228,7 +227,6 @@ export function TaskForm({
   onCreatedChange,
 }: TaskFormProps) {
   const router = useRouter();
-  const calendarBetaEnabled = useCalendarBetaAccess();
   const { showCalendarClientUpgradeModal } = useGlobalModalsContext();
   const tSchedule = useTranslations("App.Tasks.Schedule");
   const formatter = useFormatter();
@@ -1252,7 +1250,7 @@ export function TaskForm({
           ) : null}
         </div>
 
-        {showTaskStep && calendarBetaEnabled ? (
+        {showTaskStep ? (
           <TaskScheduleModal
             open={isScheduleModalOpen}
             onOpenChange={setIsScheduleModalOpen}
@@ -1288,19 +1286,17 @@ export function TaskForm({
             <div className="flex items-center gap-3 sm:ml-auto">
               {mode === "create" ? (
                 <>
-                  {calendarBetaEnabled ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      disabled={createdTask !== null || !isSchedulableAssignee}
-                      aria-label={labels.openSchedule}
-                      aria-pressed={hasSchedule}
-                      onClick={() => setIsScheduleModalOpen(true)}
-                    >
-                      <CalendarClock className="size-4" aria-hidden />
-                    </Button>
-                  ) : null}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    disabled={createdTask !== null || !isSchedulableAssignee}
+                    aria-label={labels.openSchedule}
+                    aria-pressed={hasSchedule}
+                    onClick={() => setIsScheduleModalOpen(true)}
+                  >
+                    <CalendarClock className="size-4" aria-hidden />
+                  </Button>
                   <Button
                     type="button"
                     variant="outline"
@@ -1347,19 +1343,17 @@ export function TaskForm({
                 </>
               ) : (
                 <>
-                  {calendarBetaEnabled ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      disabled={createdTask !== null || !isSchedulableAssignee}
-                      aria-label={labels.openSchedule}
-                      aria-pressed={hasSchedule}
-                      onClick={() => setIsScheduleModalOpen(true)}
-                    >
-                      <CalendarClock className="size-4" aria-hidden />
-                    </Button>
-                  ) : null}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    disabled={createdTask !== null || !isSchedulableAssignee}
+                    aria-label={labels.openSchedule}
+                    aria-pressed={hasSchedule}
+                    onClick={() => setIsScheduleModalOpen(true)}
+                  >
+                    <CalendarClock className="size-4" aria-hidden />
+                  </Button>
                   {shouldShowEditToggle ? (
                     <Button
                       type="button"


### PR DESCRIPTION
## Summary

- restore the schedule control and modal in the normal Tasks form for users outside the Calendar beta
- remove Calendar beta enforcement from the existing task schedule PUT and DELETE endpoints
- keep Calendar-only scheduled creation and Calendar schedule editing beta-gated

## User impact

Users without Calendar beta access can again schedule, reschedule, and remove schedules from normal Tasks without gaining access to Calendar beta surfaces.

## Verification

- `pnpm check`
- `pnpm --filter web typecheck`
- `pnpm --filter core typecheck`
- `pnpm --filter web test "src/app/(app)/tasks/components/task-form.test.tsx"`
- `pnpm --filter core test "src/routes/v1/tasks/[id]/schedule/put.test.ts"`
- `pnpm --filter core test "src/routes/v1/tasks/[id]/schedule/delete.test.ts"`
- `pnpm --filter core test "src/routes/v1/tasks/scheduled/post.test.ts"`

Full `pnpm test` could not complete in this shared agent checkout because Turbo and Prisma attempted writes to the read-only shared cache and `node_modules`; CI runs with a writable install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task scheduling is now available without Calendar beta access.
  * Scheduling controls and setup options are visible for both new and existing tasks.
* **Bug Fixes**
  * Users can create, update, and remove task schedules without unnecessary beta-access restrictions.
  * Task ownership and collaboration checks continue to apply during scheduling actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->