### PR TITLE
feat(web): center project detail in max-w-6xl with brand sidebar

### DIFF
--- a/apps/web/src/app/(app)/projects/[projectId]/calendar/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/calendar/page.test.tsx
@@ -116,6 +116,11 @@ describe("ProjectCalendarPage", () => {
     expect(
       screen.getByRole("link", { name: "backToProject" }).className,
     ).not.toContain("hidden");
+    const shell = screen
+      .getByRole("link", { name: "backToProject" })
+      .closest(".max-w-7xl");
+    expect(shell).toHaveClass("mx-auto", "w-full", "max-w-7xl", "py-6");
+    expect(shell).not.toHaveClass("max-w-6xl");
     expect(workspaceCalendarMock).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: PROJECT.id,

--- a/apps/web/src/app/(app)/projects/[projectId]/calendar/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/calendar/page.tsx
@@ -4,7 +4,7 @@ import { connection } from "next/server";
 import { getLocale, getTranslations } from "next-intl/server";
 import { WorkspaceCalendar } from "@/app/calendar/components/workspace-calendar";
 import { ProjectDetailHeader } from "@/app/projects/components/project-detail-header";
-import { PROJECTS_DETAIL_SHELL_CLASS } from "@/app/projects/constants";
+import { PROJECTS_CALENDAR_SHELL_CLASS } from "@/app/projects/constants";
 import { getSession } from "@/lib/auth/auth.server";
 import { isBetaAccessEmail } from "@/lib/beta-access";
 import { TaskStatus } from "@/lib/clients/generated/core";
@@ -66,7 +66,7 @@ export default async function ProjectCalendarPage({
   const sourceId = `project:${project.id}`;
 
   return (
-    <div className={PROJECTS_DETAIL_SHELL_CLASS}>
+    <div className={PROJECTS_CALENDAR_SHELL_CLASS}>
       <ProjectDetailHeader
         backHref={`/projects/${project.id}`}
         backLabel={t("backToProject")}

--- a/apps/web/src/app/(app)/projects/[projectId]/calendar/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/calendar/page.tsx
@@ -4,6 +4,7 @@ import { connection } from "next/server";
 import { getLocale, getTranslations } from "next-intl/server";
 import { WorkspaceCalendar } from "@/app/calendar/components/workspace-calendar";
 import { ProjectDetailHeader } from "@/app/projects/components/project-detail-header";
+import { PROJECTS_DETAIL_SHELL_CLASS } from "@/app/projects/constants";
 import { getSession } from "@/lib/auth/auth.server";
 import { isBetaAccessEmail } from "@/lib/beta-access";
 import { TaskStatus } from "@/lib/clients/generated/core";
@@ -65,7 +66,7 @@ export default async function ProjectCalendarPage({
   const sourceId = `project:${project.id}`;
 
   return (
-    <div className="min-h-full w-full px-4 py-6 md:px-6">
+    <div className={PROJECTS_DETAIL_SHELL_CLASS}>
       <ProjectDetailHeader
         backHref={`/projects/${project.id}`}
         backLabel={t("backToProject")}

--- a/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
@@ -124,15 +124,14 @@ describe("ProjectDetailPage", () => {
 
     const { container } = render(html);
     expect(container.firstChild).toHaveClass(
-      "w-[calc(100%+2rem)]",
-      "-mx-4",
+      "mx-auto",
+      "w-full",
+      "max-w-6xl",
       "py-6",
-      "md:mx-0",
-      "md:w-full",
-      "md:px-6",
     );
-    expect(container.firstChild).not.toHaveClass("px-4");
-    expect(container.firstChild).not.toHaveClass("w-full");
+    expect(container.firstChild).not.toHaveClass("-mx-4");
+    expect(container.firstChild).not.toHaveClass("w-[calc(100%+2rem)]");
+    expect(container.firstChild).not.toHaveClass("md:px-6");
     expect(container.querySelector(".max-w-4xl")).toBeNull();
     expect(
       screen.getByRole("heading", { name: "Launch plan" }),
@@ -157,16 +156,27 @@ describe("ProjectDetailPage", () => {
     expect(screen.getByTestId("brand-card")).toBeInTheDocument();
     expect(screen.getByTestId("memory-stat")).toBeInTheDocument();
     expect(screen.getByTestId("needs-attention-section")).toBeInTheDocument();
-    const memory = screen.getByTestId("memory-stat");
-    const needsAttention = screen.getByTestId("needs-attention-section");
+
+    const layoutGrid = container.querySelector(
+      ".lg\\:grid-cols-\\[minmax\\(0\\,1fr\\)_minmax\\(16rem\\,20rem\\)\\]",
+    );
+    expect(layoutGrid).toBeTruthy();
+
+    const mainColumn = screen
+      .getByRole("heading", { name: "Launch plan" })
+      .closest(".space-y-8");
+    const aside = screen.getByTestId("brand-card").closest("aside");
+    expect(mainColumn).toBeTruthy();
+    expect(aside).toBeTruthy();
+    expect(aside?.contains(screen.getByTestId("memory-stat"))).toBe(true);
     expect(
-      needsAttention.compareDocumentPosition(memory) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(needsAttention.parentElement?.className).toContain("order-4");
-    expect(needsAttention.parentElement?.className).toContain("xl:order-3");
-    expect(memory.parentElement?.className).toContain("order-3");
-    expect(memory.parentElement?.className).toContain("xl:order-4");
+      mainColumn?.contains(screen.getByTestId("needs-attention-section")),
+    ).toBe(true);
+    expect(mainColumn?.contains(screen.getByTestId("brand-card"))).toBe(false);
+    expect(layoutGrid?.className).not.toContain("order-");
+    expect(layoutGrid?.className).not.toContain("xl:grid-cols-3");
+    expect(layoutGrid?.className).not.toContain("xl:col-span-2");
+
     expect(container.innerHTML).not.toContain(
       "bg-muted/30 border-border/50 rounded-none border p-4",
     );
@@ -176,7 +186,7 @@ describe("ProjectDetailPage", () => {
     expect(workspaceHeading).toBeInTheDocument();
     const workspaceSection = workspaceHeading.closest("section");
     expect(workspaceSection?.className).toContain("space-y-3");
-    expect(workspaceSection?.className).toContain("xl:col-span-2");
+    expect(workspaceSection?.className).not.toContain("xl:col-span-2");
     expect(workspaceSection?.querySelector(".grid")?.className).toContain(
       "md:grid-cols-4",
     );
@@ -185,12 +195,7 @@ describe("ProjectDetailPage", () => {
     );
     expect(workspaceSection?.className).not.toContain("px-4");
     expect(workspaceSection?.className).not.toContain("md:px-0");
-    const overviewGrid = workspaceSection?.parentElement;
-    expect(overviewGrid?.className).toContain("grid");
-    expect(overviewGrid?.className).toContain("px-4");
-    expect(overviewGrid?.className).toContain("md:px-0");
-    expect(overviewGrid?.className).toContain("xl:grid-cols-3");
-    expect((container.firstChild as HTMLElement).childElementCount).toBe(1);
+    expect(mainColumn?.contains(workspaceSection!)).toBe(true);
     expect(container.querySelectorAll('[aria-disabled="true"]')).toHaveLength(
       6,
     );
@@ -261,9 +266,9 @@ describe("ProjectDetailPage", () => {
     );
     const latestUpdate = screen.getByTestId("project-latest-update");
     const briefing = screen.getByTestId("project-briefing");
-    expect(latestUpdate.parentElement).toBe(briefing.parentElement);
-    expect(briefing.parentElement?.className).toContain("xl:col-span-2");
-    expect(briefing.parentElement?.className).not.toContain("xl:col-span-3");
+    const mainColumn = latestHeading.closest(".space-y-8");
+    expect(mainColumn?.contains(latestUpdate)).toBe(true);
+    expect(mainColumn?.contains(briefing)).toBe(true);
     expect(screen.getByText(/Shipped/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
@@ -162,17 +162,45 @@ describe("ProjectDetailPage", () => {
     );
     expect(layoutGrid).toBeTruthy();
 
-    const mainColumn = screen
+    const introColumn = screen
       .getByRole("heading", { name: "Launch plan" })
       .closest(".space-y-8");
     const aside = screen.getByTestId("brand-card").closest("aside");
-    expect(mainColumn).toBeTruthy();
+    const needsAttentionColumn = screen
+      .getByTestId("needs-attention-section")
+      .closest(".space-y-8");
+    expect(introColumn).toBeTruthy();
     expect(aside).toBeTruthy();
+    expect(needsAttentionColumn).toBeTruthy();
     expect(aside?.contains(screen.getByTestId("memory-stat"))).toBe(true);
+    expect(aside?.contains(screen.getByTestId("brand-card"))).toBe(true);
+    expect(aside?.contains(screen.getByTestId("needs-attention-section"))).toBe(
+      false,
+    );
+    expect(introColumn?.contains(screen.getByTestId("brand-card"))).toBe(false);
     expect(
-      mainColumn?.contains(screen.getByTestId("needs-attention-section")),
+      needsAttentionColumn?.contains(
+        screen.getByTestId("needs-attention-section"),
+      ),
     ).toBe(true);
-    expect(mainColumn?.contains(screen.getByTestId("brand-card"))).toBe(false);
+    expect(
+      introColumn?.contains(screen.getByTestId("needs-attention-section")),
+    ).toBe(false);
+
+    const briefingHeading = screen.getByRole("heading", {
+      name: "App.Projects.Detail.briefing",
+    });
+    const brandCard = screen.getByTestId("brand-card");
+    const needsAttention = screen.getByTestId("needs-attention-section");
+    expect(
+      briefingHeading.compareDocumentPosition(brandCard) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      brandCard.compareDocumentPosition(needsAttention) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
     expect(layoutGrid?.className).not.toContain("order-");
     expect(layoutGrid?.className).not.toContain("xl:grid-cols-3");
     expect(layoutGrid?.className).not.toContain("xl:col-span-2");
@@ -195,7 +223,7 @@ describe("ProjectDetailPage", () => {
     );
     expect(workspaceSection?.className).not.toContain("px-4");
     expect(workspaceSection?.className).not.toContain("md:px-0");
-    expect(mainColumn?.contains(workspaceSection!)).toBe(true);
+    expect(needsAttentionColumn?.contains(workspaceSection!)).toBe(true);
     expect(container.querySelectorAll('[aria-disabled="true"]')).toHaveLength(
       6,
     );
@@ -266,9 +294,9 @@ describe("ProjectDetailPage", () => {
     );
     const latestUpdate = screen.getByTestId("project-latest-update");
     const briefing = screen.getByTestId("project-briefing");
-    const mainColumn = latestHeading.closest(".space-y-8");
-    expect(mainColumn?.contains(latestUpdate)).toBe(true);
-    expect(mainColumn?.contains(briefing)).toBe(true);
+    const introColumn = latestHeading.closest(".space-y-8");
+    expect(introColumn?.contains(latestUpdate)).toBe(true);
+    expect(introColumn?.contains(briefing)).toBe(true);
     expect(screen.getByText(/Shipped/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.test.tsx
@@ -158,9 +158,10 @@ describe("ProjectDetailPage", () => {
     expect(screen.getByTestId("needs-attention-section")).toBeInTheDocument();
 
     const layoutGrid = container.querySelector(
-      ".lg\\:grid-cols-\\[minmax\\(0\\,1fr\\)_minmax\\(16rem\\,20rem\\)\\]",
+      ".xl\\:grid-cols-\\[minmax\\(0\\,1fr\\)_minmax\\(16rem\\,20rem\\)\\]",
     );
     expect(layoutGrid).toBeTruthy();
+    expect(layoutGrid?.className).not.toContain("lg:grid-cols-");
 
     const introColumn = screen
       .getByRole("heading", { name: "Launch plan" })
@@ -171,6 +172,7 @@ describe("ProjectDetailPage", () => {
       .closest(".space-y-8");
     expect(introColumn).toBeTruthy();
     expect(aside).toBeTruthy();
+    expect(aside?.className).toContain("xl:row-span-2");
     expect(needsAttentionColumn).toBeTruthy();
     expect(aside?.contains(screen.getByTestId("memory-stat"))).toBe(true);
     expect(aside?.contains(screen.getByTestId("brand-card"))).toBe(true);

--- a/apps/web/src/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.tsx
@@ -14,7 +14,6 @@ import { ProjectModuleTiles } from "@/app/projects/components/project-module-til
 import { ProjectNeedsAttentionSection } from "@/app/projects/components/project-needs-attention-section";
 import {
   PROJECTS_DETAIL_SHELL_CLASS,
-  PROJECTS_DETAIL_TOP_CLASS,
   PROJECTS_DETAIL_WORKSPACE_CLASS,
 } from "@/app/projects/constants";
 import { buildTaskStatusLabels } from "@/app/tasks/utils/task-status-labels";
@@ -51,115 +50,91 @@ export default async function ProjectDetailPage({
 
   return (
     <div className={PROJECTS_DETAIL_SHELL_CLASS}>
-      <div className={PROJECTS_DETAIL_TOP_CLASS}>
-        <ProjectDetailHeader
-          projectName={project.name}
-          projectLogo={project.logo}
-          websiteUrl={project.websiteUrl}
-          backLabel={t("back")}
-          metadata={[
-            {
-              label: t("header.updated"),
-              value: formatShortDateTime(project.updatedAt, locale),
-            },
-            {
-              label: t("header.created"),
-              value: formatShortDateTime(project.createdAt, locale),
-            },
-          ]}
-          actions={
-            <ProjectDetailActions
-              projectId={project.id}
-              labels={{
-                moreActions: t("actions.moreActions"),
-                edit: t("actions.edit"),
-                delete: t("actions.delete"),
-                deleteDialog: {
-                  title: t("deleteDialog.title"),
-                  description: t("deleteDialog.description"),
-                  confirm: t("deleteDialog.confirm"),
-                  cancel: t("deleteDialog.cancel"),
-                  error: t("errors.delete"),
+      <ProjectBrandProvider
+        key={project.designMd?.url ?? "project-brand-empty"}
+        projectId={project.id}
+        initialDesignMd={project.designMd}
+        websiteUrl={project.websiteUrl}
+      >
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)]">
+          <div className="min-w-0 space-y-8">
+            <ProjectDetailHeader
+              projectName={project.name}
+              projectLogo={project.logo}
+              websiteUrl={project.websiteUrl}
+              backLabel={t("back")}
+              metadata={[
+                {
+                  label: t("header.updated"),
+                  value: formatShortDateTime(project.updatedAt, locale),
                 },
-              }}
-            />
-          }
-        />
-
-        <ProjectBrandProvider
-          key={project.designMd?.url ?? "project-brand-empty"}
-          projectId={project.id}
-          initialDesignMd={project.designMd}
-          websiteUrl={project.websiteUrl}
-        >
-          <div className="mt-6 grid grid-cols-1 gap-8 px-4 md:px-0 xl:grid-cols-3">
-            <div className="order-1 space-y-8 xl:order-1 xl:col-span-2">
-              {project.latestUpdate ? (
-                <ProjectLatestUpdate
-                  title={t("latestUpdate")}
-                  content={project.latestUpdate.content}
-                  showMoreLabel={t("showMore")}
-                  showLessLabel={t("showLess")}
+                {
+                  label: t("header.created"),
+                  value: formatShortDateTime(project.createdAt, locale),
+                },
+              ]}
+              actions={
+                <ProjectDetailActions
+                  projectId={project.id}
+                  labels={{
+                    moreActions: t("actions.moreActions"),
+                    edit: t("actions.edit"),
+                    delete: t("actions.delete"),
+                    deleteDialog: {
+                      title: t("deleteDialog.title"),
+                      description: t("deleteDialog.description"),
+                      confirm: t("deleteDialog.confirm"),
+                      cancel: t("deleteDialog.cancel"),
+                      error: t("errors.delete"),
+                    },
+                  }}
                 />
-              ) : null}
-              <ProjectBriefing
-                title={t("briefing")}
-                briefing={project.briefing}
-                emptyLabel={t("emptyBriefing")}
-                emptyActionLabel={t("writeBriefing")}
-                editHref={`/projects/${project.id}/edit`}
+              }
+            />
+
+            {project.latestUpdate ? (
+              <ProjectLatestUpdate
+                title={t("latestUpdate")}
+                content={project.latestUpdate.content}
                 showMoreLabel={t("showMore")}
                 showLessLabel={t("showLess")}
               />
-            </div>
+            ) : null}
 
-            <div className="order-2 xl:order-2">
-              <ProjectBrandCard
-                projectId={project.id}
-                projectName={project.name}
-                logo={project.logo}
-                websiteUrl={project.websiteUrl}
-              />
-            </div>
+            <ProjectBriefing
+              title={t("briefing")}
+              briefing={project.briefing}
+              emptyLabel={t("emptyBriefing")}
+              emptyActionLabel={t("writeBriefing")}
+              editHref={`/projects/${project.id}/edit`}
+              showMoreLabel={t("showMore")}
+              showLessLabel={t("showLess")}
+            />
 
-            <div className="order-4 xl:order-3 xl:col-span-2">
-              <ProjectNeedsAttentionSection
-                projectId={project.id}
-                taskCount={attention.taskCount}
-                jobCount={attention.jobCount}
-                items={attention.items}
-                labels={{
-                  needsAttention: t("needsAttention.title"),
-                  empty: t("needsAttention.empty"),
-                  viewAllTasks: t("tasks.viewAll"),
-                  viewAllJobs: t("jobs.viewAll"),
-                  counts: {
-                    tasks: tListStats("tasks"),
-                    jobs: tListStats("jobs"),
-                  },
-                  kind: {
-                    task: tHistory("kind.task"),
-                    job: tHistory("kind.job"),
-                  },
-                  taskStatus: taskStatusLabels,
-                  locale,
-                }}
-              />
-            </div>
+            <ProjectNeedsAttentionSection
+              projectId={project.id}
+              taskCount={attention.taskCount}
+              jobCount={attention.jobCount}
+              items={attention.items}
+              labels={{
+                needsAttention: t("needsAttention.title"),
+                empty: t("needsAttention.empty"),
+                viewAllTasks: t("tasks.viewAll"),
+                viewAllJobs: t("jobs.viewAll"),
+                counts: {
+                  tasks: tListStats("tasks"),
+                  jobs: tListStats("jobs"),
+                },
+                kind: {
+                  task: tHistory("kind.task"),
+                  job: tHistory("kind.job"),
+                },
+                taskStatus: taskStatusLabels,
+                locale,
+              }}
+            />
 
-            <div className="order-3 xl:order-4">
-              <ProjectMemoryRow
-                projectId={project.id}
-                contextMd={project.contextMd}
-                contextMdUpdating={project.contextMdUpdating}
-                memoryEnabled={project.memoryEnabled}
-                memoryModel={project.memoryModel}
-              />
-            </div>
-
-            <section
-              className={`order-5 xl:order-5 xl:col-span-2 ${PROJECTS_DETAIL_WORKSPACE_CLASS}`}
-            >
+            <section className={PROJECTS_DETAIL_WORKSPACE_CLASS}>
               <h2 className="text-muted-foreground text-xs font-medium">
                 {t("modules.title")}
               </h2>
@@ -208,8 +183,24 @@ export default async function ProjectDetailPage({
               />
             </section>
           </div>
-        </ProjectBrandProvider>
-      </div>
+
+          <aside className="min-w-0 space-y-8">
+            <ProjectBrandCard
+              projectId={project.id}
+              projectName={project.name}
+              logo={project.logo}
+              websiteUrl={project.websiteUrl}
+            />
+            <ProjectMemoryRow
+              projectId={project.id}
+              contextMd={project.contextMd}
+              contextMdUpdating={project.contextMdUpdating}
+              memoryEnabled={project.memoryEnabled}
+              memoryModel={project.memoryModel}
+            />
+          </aside>
+        </div>
+      </ProjectBrandProvider>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.tsx
@@ -110,7 +110,25 @@ export default async function ProjectDetailPage({
               showMoreLabel={t("showMore")}
               showLessLabel={t("showLess")}
             />
+          </div>
 
+          <aside className="min-w-0 space-y-8">
+            <ProjectBrandCard
+              projectId={project.id}
+              projectName={project.name}
+              logo={project.logo}
+              websiteUrl={project.websiteUrl}
+            />
+            <ProjectMemoryRow
+              projectId={project.id}
+              contextMd={project.contextMd}
+              contextMdUpdating={project.contextMdUpdating}
+              memoryEnabled={project.memoryEnabled}
+              memoryModel={project.memoryModel}
+            />
+          </aside>
+
+          <div className="min-w-0 space-y-8">
             <ProjectNeedsAttentionSection
               projectId={project.id}
               taskCount={attention.taskCount}
@@ -183,22 +201,6 @@ export default async function ProjectDetailPage({
               />
             </section>
           </div>
-
-          <aside className="min-w-0 space-y-8">
-            <ProjectBrandCard
-              projectId={project.id}
-              projectName={project.name}
-              logo={project.logo}
-              websiteUrl={project.websiteUrl}
-            />
-            <ProjectMemoryRow
-              projectId={project.id}
-              contextMd={project.contextMd}
-              contextMdUpdating={project.contextMdUpdating}
-              memoryEnabled={project.memoryEnabled}
-              memoryModel={project.memoryModel}
-            />
-          </aside>
         </div>
       </ProjectBrandProvider>
     </div>

--- a/apps/web/src/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[projectId]/page.tsx
@@ -56,7 +56,7 @@ export default async function ProjectDetailPage({
         initialDesignMd={project.designMd}
         websiteUrl={project.websiteUrl}
       >
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)]">
+        <div className="grid grid-cols-1 gap-8 xl:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)]">
           <div className="min-w-0 space-y-8">
             <ProjectDetailHeader
               projectName={project.name}
@@ -112,7 +112,7 @@ export default async function ProjectDetailPage({
             />
           </div>
 
-          <aside className="min-w-0 space-y-8">
+          <aside className="min-w-0 space-y-8 xl:row-span-2">
             <ProjectBrandCard
               projectId={project.id}
               projectName={project.name}

--- a/apps/web/src/app/(app)/projects/components/project-brand-card.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-brand-card.test.tsx
@@ -134,7 +134,9 @@ describe("ProjectBrandCard", () => {
     const card = screen.getByTestId("project-brand-card");
     expect(card.className).not.toContain("bg-muted/30");
     expect(card.className).not.toMatch(/\bborder\b/);
-    expect(screen.getByRole("heading", { name: "Brand" })).toBeInTheDocument();
+    const brandHeading = screen.getByRole("heading", { name: "Brand" });
+    expect(brandHeading).toBeInTheDocument();
+    expect(brandHeading.parentElement?.textContent).not.toContain("Ready");
     expect(screen.getByText("Ready")).toBeInTheDocument();
 
     await openBrandMenu(user);

--- a/apps/web/src/app/(app)/projects/components/project-brand-card.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-brand-card.tsx
@@ -226,102 +226,102 @@ export function ProjectBrandCard({
           <h2 className="text-muted-foreground/60 text-xs font-medium">
             {t("brand")}
           </h2>
-          <div className="flex items-center gap-2">
-            <Badge variant="outline" className="gap-1.5 text-xs">
-              {generation.isRunning ? (
-                <Loader2 className="size-3 animate-spin" aria-hidden />
-              ) : designMd ? (
-                <span
-                  className="bg-semantic-success size-1.5 rounded-full"
-                  aria-hidden
-                />
-              ) : null}
-              {generation.isRunning
-                ? t("brandCard.generating")
-                : designMd
-                  ? t("brandCard.ready")
-                  : t("brandCard.notSet")}
-            </Badge>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-8"
-                  aria-label={t("brandCard.moreActions")}
-                >
-                  <MoreHorizontal className="size-4" aria-hidden />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  disabled={!hasWebsite || menuBusy}
-                  onSelect={() => {
-                    handleGenerate();
-                  }}
-                >
-                  {generation.isRunning ? (
-                    <Loader2 className="size-4 animate-spin" aria-hidden />
-                  ) : (
-                    <RefreshCw className="size-4" aria-hidden />
-                  )}
-                  {t("brandCard.generate")}
-                </DropdownMenuItem>
-                {designMd ? (
-                  <>
-                    <DropdownMenuItem asChild>
-                      <a
-                        href={designMd.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <ExternalLink className="size-4" aria-hidden />
-                        {t("brandCard.open")}
-                      </a>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <Link href={`/projects/${projectId}/design-md/edit`}>
-                        <FileText className="size-4" aria-hidden />
-                        {t("brandCard.edit")}
-                      </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      variant="destructive"
-                      disabled={menuBusy}
-                      onSelect={(event) => {
-                        event.preventDefault();
-                        setIsRemoveDialogOpen(true);
-                      }}
-                    >
-                      <Trash2 className="size-4" aria-hidden />
-                      {t("brandCard.remove")}
-                    </DropdownMenuItem>
-                  </>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                aria-label={t("brandCard.moreActions")}
+              >
+                <MoreHorizontal className="size-4" aria-hidden />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                disabled={!hasWebsite || menuBusy}
+                onSelect={() => {
+                  handleGenerate();
+                }}
+              >
+                {generation.isRunning ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden />
                 ) : (
+                  <RefreshCw className="size-4" aria-hidden />
+                )}
+                {t("brandCard.generate")}
+              </DropdownMenuItem>
+              {designMd ? (
+                <>
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={designMd.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLink className="size-4" aria-hidden />
+                      {t("brandCard.open")}
+                    </a>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link href={`/projects/${projectId}/design-md/edit`}>
+                      <FileText className="size-4" aria-hidden />
+                      {t("brandCard.edit")}
+                    </Link>
+                  </DropdownMenuItem>
                   <DropdownMenuItem
+                    variant="destructive"
                     disabled={menuBusy}
-                    onSelect={() => {
-                      setShowUpload(true);
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      setIsRemoveDialogOpen(true);
                     }}
                   >
-                    <Upload className="size-4" aria-hidden />
-                    {t("brandCard.upload")}
+                    <Trash2 className="size-4" aria-hidden />
+                    {t("brandCard.remove")}
                   </DropdownMenuItem>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+                </>
+              ) : (
+                <DropdownMenuItem
+                  disabled={menuBusy}
+                  onSelect={() => {
+                    setShowUpload(true);
+                  }}
+                >
+                  <Upload className="size-4" aria-hidden />
+                  {t("brandCard.upload")}
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
-        <div className="flex min-w-0 items-center gap-3">
-          <ProjectAvatar name={projectName} logo={logo} className="size-10" />
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium">{projectName}</p>
-            <p className="text-muted-foreground mt-0.5 truncate text-xs">
-              DESIGN.md
-            </p>
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <ProjectAvatar name={projectName} logo={logo} className="size-10" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">{projectName}</p>
+              <p className="text-muted-foreground mt-0.5 truncate text-xs">
+                DESIGN.md
+              </p>
+            </div>
           </div>
+          <Badge variant="outline" className="shrink-0 gap-1.5 text-xs">
+            {generation.isRunning ? (
+              <Loader2 className="size-3 animate-spin" aria-hidden />
+            ) : designMd ? (
+              <span
+                className="bg-semantic-success size-1.5 rounded-full"
+                aria-hidden
+              />
+            ) : null}
+            {generation.isRunning
+              ? t("brandCard.generating")
+              : designMd
+                ? t("brandCard.ready")
+                : t("brandCard.notSet")}
+          </Badge>
         </div>
 
         {!hasWebsite ? (

--- a/apps/web/src/app/(app)/projects/components/project-detail-header.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-detail-header.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { ProjectDetailHeader } from "@/app/projects/components/project-detail-header";
 
 describe("ProjectDetailHeader", () => {
-  it("pads on mobile and places metadata as a full-width sibling row", () => {
+  it("places metadata as a full-width sibling row below the title", () => {
     const { container } = render(
       <ProjectDetailHeader
         projectName="Example project"
@@ -19,8 +19,8 @@ describe("ProjectDetailHeader", () => {
     );
 
     const root = container.firstElementChild;
-    expect(root?.className).toContain("px-4");
-    expect(root?.className).toContain("md:px-0");
+    expect(root?.className).not.toContain("px-4");
+    expect(root?.className).not.toContain("md:px-0");
 
     const back = screen.getByRole("link", { name: "Back" });
     expect(back).toHaveAttribute("href", "/projects");

--- a/apps/web/src/app/(app)/projects/components/project-detail-header.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-detail-header.tsx
@@ -33,7 +33,7 @@ export function ProjectDetailHeader({
   const websiteHostname = websiteUrl ? getHostname(websiteUrl) : null;
 
   return (
-    <div className="space-y-4 px-4 md:px-0">
+    <div className="space-y-4">
       <Link
         href={backHref}
         className={`text-muted-foreground hover:text-foreground items-center gap-1.5 text-sm transition-colors ${

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
@@ -136,7 +136,6 @@ describe("ProjectNeedsAttentionSection", () => {
     const listBox = screen
       .getByTestId("project-needs-attention")
       .querySelector(":scope > div:last-child");
-    // Mobile edge-to-edge bleed out of main p-4 / detail column padding.
     expect(listBox).toHaveClass(
       ...PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/),
     );

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ProjectNeedsAttentionSection } from "@/app/projects/components/project-needs-attention-section";
+import { PROJECTS_DETAIL_LIST_LAYOUT_CLASS } from "@/app/projects/constants";
 import {
   type HistoryItem,
   type HistoryJobItem,
@@ -135,7 +136,10 @@ describe("ProjectNeedsAttentionSection", () => {
     const listBox = screen
       .getByTestId("project-needs-attention")
       .querySelector(":scope > div:last-child");
-    expect(listBox).toHaveClass("-mx-4", "md:mx-0");
+    expect(listBox).toHaveClass(
+      ...PROJECTS_DETAIL_LIST_LAYOUT_CLASS.split(/\s+/),
+    );
+    expect(listBox).not.toHaveClass("-mx-4", "md:mx-0");
   });
 
   it("shows empty copy when there are no attention items", () => {
@@ -156,6 +160,9 @@ describe("ProjectNeedsAttentionSection", () => {
     const listBox = screen
       .getByTestId("project-needs-attention")
       .querySelector(":scope > div:last-child");
-    expect(listBox).toHaveClass("-mx-4", "md:mx-0");
+    expect(listBox).toHaveClass(
+      ...PROJECTS_DETAIL_LIST_LAYOUT_CLASS.split(/\s+/),
+    );
+    expect(listBox).not.toHaveClass("-mx-4", "md:mx-0");
   });
 });

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
@@ -136,9 +136,7 @@ describe("ProjectNeedsAttentionSection", () => {
     const listBox = screen
       .getByTestId("project-needs-attention")
       .querySelector(":scope > div:last-child");
-    expect(listBox).toHaveClass(
-      ...PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/),
-    );
+    expect(listBox).toHaveClass(...PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/));
     expect(listBox).toHaveClass("-mx-4", "md:mx-0");
   });
 
@@ -160,9 +158,7 @@ describe("ProjectNeedsAttentionSection", () => {
     const listBox = screen
       .getByTestId("project-needs-attention")
       .querySelector(":scope > div:last-child");
-    expect(listBox).toHaveClass(
-      ...PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/),
-    );
+    expect(listBox).toHaveClass(...PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/));
     expect(listBox).toHaveClass("-mx-4", "md:mx-0");
   });
 });

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ProjectNeedsAttentionSection } from "@/app/projects/components/project-needs-attention-section";
-import { PROJECTS_DETAIL_LIST_LAYOUT_CLASS } from "@/app/projects/constants";
+import { PROJECTS_BROWSE_LAYOUT_CLASS } from "@/app/projects/constants";
 import {
   type HistoryItem,
   type HistoryJobItem,
@@ -136,10 +136,11 @@ describe("ProjectNeedsAttentionSection", () => {
     const listBox = screen
       .getByTestId("project-needs-attention")
       .querySelector(":scope > div:last-child");
+    // Mobile edge-to-edge bleed out of main p-4 / detail column padding.
     expect(listBox).toHaveClass(
-      ...PROJECTS_DETAIL_LIST_LAYOUT_CLASS.split(/\s+/),
+      ...PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/),
     );
-    expect(listBox).not.toHaveClass("-mx-4", "md:mx-0");
+    expect(listBox).toHaveClass("-mx-4", "md:mx-0");
   });
 
   it("shows empty copy when there are no attention items", () => {
@@ -161,8 +162,8 @@ describe("ProjectNeedsAttentionSection", () => {
       .getByTestId("project-needs-attention")
       .querySelector(":scope > div:last-child");
     expect(listBox).toHaveClass(
-      ...PROJECTS_DETAIL_LIST_LAYOUT_CLASS.split(/\s+/),
+      ...PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/),
     );
-    expect(listBox).not.toHaveClass("-mx-4", "md:mx-0");
+    expect(listBox).toHaveClass("-mx-4", "md:mx-0");
   });
 });

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.tsx
@@ -7,7 +7,7 @@ import {
 import { ProjectResourceCountPills } from "@/app/projects/components/project-resource-count-pills";
 import {
   PROJECTS_BROWSE_DIVIDE_CLASS,
-  PROJECTS_DETAIL_LIST_LAYOUT_CLASS,
+  PROJECTS_BROWSE_LAYOUT_CLASS,
 } from "@/app/projects/constants";
 import { TaskStatusBadge } from "@/app/tasks/components/task-status-badge";
 import { JobStatusBadge } from "@/components/jobs/job-status-badge";
@@ -76,7 +76,7 @@ export function ProjectNeedsAttentionSection({
         </div>
       </div>
 
-      <div className={PROJECTS_DETAIL_LIST_LAYOUT_CLASS}>
+      <div className={PROJECTS_BROWSE_LAYOUT_CLASS}>
         {items.length === 0 ? (
           <div className="text-muted-foreground/50 flex items-center justify-center py-16 text-sm">
             {labels.empty}

--- a/apps/web/src/app/(app)/projects/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/constants.test.ts
@@ -5,7 +5,6 @@ import {
   PROJECTS_BROWSE_LAYOUT_CLASS,
   PROJECTS_DETAIL_LIST_LAYOUT_CLASS,
   PROJECTS_DETAIL_SHELL_CLASS,
-  PROJECTS_DETAIL_TOP_CLASS,
   PROJECTS_DETAIL_WORKSPACE_CLASS,
   PROJECTS_LIST_CARD_MIN_H_CLASS,
   PROJECTS_LIST_ROW_LAYOUT_CLASS,
@@ -66,7 +65,6 @@ describe("projects mobile padding shells", () => {
     expect(shell).not.toContain("w-[calc(100%+2rem)]");
     expect(shell).not.toContain("md:px-6");
 
-    expect(PROJECTS_DETAIL_TOP_CLASS).toBe("w-full");
     expect(workspace).toEqual(["space-y-3"]);
   });
 });

--- a/apps/web/src/app/(app)/projects/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/constants.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   PROJECTS_BROWSE_DIVIDE_CLASS,
   PROJECTS_BROWSE_LAYOUT_CLASS,
-  PROJECTS_DETAIL_LIST_LAYOUT_CLASS,
   PROJECTS_DETAIL_SHELL_CLASS,
   PROJECTS_DETAIL_WORKSPACE_CLASS,
   PROJECTS_LIST_CARD_MIN_H_CLASS,
@@ -33,13 +32,13 @@ describe("projects list CLS layout constants", () => {
     expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:rounded-xl");
   });
 
-  it("exports detail list layout with muted surface and md border/radius", () => {
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("bg-muted/30");
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("md:rounded-xl");
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("md:border");
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).not.toContain("-mx-4");
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).not.toContain("md:mx-0");
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).not.toContain("-mx-6");
+  it("browse list chrome bleeds edge-to-edge on mobile (shared by needs-attention)", () => {
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("bg-muted/30");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("-mx-4");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:mx-0");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:rounded-xl");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:border");
+    expect(PROJECTS_BROWSE_LAYOUT_CLASS).not.toContain("-mx-6");
   });
 });
 

--- a/apps/web/src/app/(app)/projects/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/constants.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   PROJECTS_BROWSE_DIVIDE_CLASS,
   PROJECTS_BROWSE_LAYOUT_CLASS,
+  PROJECTS_CALENDAR_SHELL_CLASS,
   PROJECTS_DETAIL_SHELL_CLASS,
   PROJECTS_DETAIL_WORKSPACE_CLASS,
   PROJECTS_LIST_CARD_MIN_H_CLASS,
@@ -65,6 +66,16 @@ describe("projects mobile padding shells", () => {
     expect(shell).not.toContain("md:px-6");
 
     expect(workspace).toEqual(["space-y-3"]);
+  });
+
+  it("calendar shell keeps max-w-7xl so the week canvas is not clipped", () => {
+    const shell = PROJECTS_CALENDAR_SHELL_CLASS.split(/\s+/);
+
+    expect(shell).toContain("mx-auto");
+    expect(shell).toContain("w-full");
+    expect(shell).toContain("max-w-7xl");
+    expect(shell).toContain("py-6");
+    expect(shell).not.toContain("max-w-6xl");
   });
 });
 

--- a/apps/web/src/app/(app)/projects/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/constants.test.ts
@@ -34,12 +34,12 @@ describe("projects list CLS layout constants", () => {
     expect(PROJECTS_BROWSE_LAYOUT_CLASS).toContain("md:rounded-xl");
   });
 
-  it("exports detail list layout with mobile bleed out of overview px-4", () => {
+  it("exports detail list layout with muted surface and md border/radius", () => {
     expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("bg-muted/30");
     expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("md:rounded-xl");
     expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("md:border");
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("-mx-4");
-    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).toContain("md:mx-0");
+    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).not.toContain("-mx-4");
+    expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).not.toContain("md:mx-0");
     expect(PROJECTS_DETAIL_LIST_LAYOUT_CLASS).not.toContain("-mx-6");
   });
 });
@@ -54,17 +54,17 @@ describe("projects mobile padding shells", () => {
     expect(PROJECTS_PAGE_SHELL_CLASS).not.toContain("calc(100%");
   });
 
-  it("detail shell cancels main p-4 on both edges; workspace shares overview grid rhythm", () => {
+  it("detail shell is a centered max-w-6xl container; workspace stacks heading + tiles", () => {
     const shell = PROJECTS_DETAIL_SHELL_CLASS.split(/\s+/);
     const workspace = PROJECTS_DETAIL_WORKSPACE_CLASS.split(/\s+/);
 
-    expect(shell).toContain("-mx-4");
-    expect(shell).toContain("w-[calc(100%+2rem)]");
-    expect(shell).toContain("md:mx-0");
-    expect(shell).toContain("md:w-full");
-    expect(shell).toContain("md:px-6");
-    expect(shell).not.toContain("px-4");
-    expect(shell).not.toContain("px-2");
+    expect(shell).toContain("mx-auto");
+    expect(shell).toContain("w-full");
+    expect(shell).toContain("max-w-6xl");
+    expect(shell).toContain("py-6");
+    expect(shell).not.toContain("-mx-4");
+    expect(shell).not.toContain("w-[calc(100%+2rem)]");
+    expect(shell).not.toContain("md:px-6");
 
     expect(PROJECTS_DETAIL_TOP_CLASS).toBe("w-full");
     expect(workspace).toEqual(["space-y-3"]);

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -7,8 +7,7 @@ export const PROJECTS_PAGE_LIMIT = 20;
 
 /**
  * Projects index + Instant shell. Keep app-main `p-4` with no extra page
- * horizontal pad (do not `-mx-4` here). Detail cancels the shell separately
- * for edge-to-edge chrome.
+ * horizontal pad (do not `-mx-4` here).
  */
 export const PROJECTS_PAGE_SHELL_CLASS = "w-full";
 
@@ -18,13 +17,7 @@ export const PROJECTS_PAGE_SHELL_CLASS = "w-full";
 export const PROJECTS_DETAIL_SHELL_CLASS = "mx-auto w-full max-w-6xl py-6";
 
 /**
- * Detail header + briefing/brand/tasks/jobs/memory: full bleed under the
- * canceled shell (no extra horizontal pad on mobile).
- */
-export const PROJECTS_DETAIL_TOP_CLASS = "w-full";
-
-/**
- * Workspace modules (`modules.title`): stacks heading + tiles in the overview grid.
+ * Workspace modules (`modules.title`): stacks heading + tiles in the main column.
  */
 export const PROJECTS_DETAIL_WORKSPACE_CLASS = "space-y-3";
 

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -31,13 +31,10 @@ export const PROJECTS_LIST_CARD_MIN_H_CLASS = "min-h-[320px]";
 /**
  * Primary browse outer chrome: divided list at all breakpoints (Tasks/Drive rhythm).
  * Square corners on mobile; `md:rounded-xl` + border on desktop.
- * Shared by live `ProjectsView` and Instant skeleton.
+ * Shared by live `ProjectsView`, Instant skeleton, and project needs-attention list.
  */
 export const PROJECTS_BROWSE_LAYOUT_CLASS =
   "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
-
-export const PROJECTS_DETAIL_LIST_LAYOUT_CLASS =
-  "bg-muted/30 border-border/50 overflow-hidden rounded-none border-0 md:rounded-xl md:border";
 
 /**
  * Inner divide wrapper for browse rows. Shared by live list and Instant skeleton.

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -13,11 +13,9 @@ export const PROJECTS_PAGE_LIMIT = 20;
 export const PROJECTS_PAGE_SHELL_CLASS = "w-full";
 
 /**
- * Project detail outer shell. Cancel main `p-4` on mobile so the top block can
- * go edge-to-edge; same calc width as the index shell. Desktop keeps a wider gutter.
+ * Project detail outer shell: centered max-w-6xl container inside main `p-4`.
  */
-export const PROJECTS_DETAIL_SHELL_CLASS =
-  "min-h-full w-[calc(100%+2rem)] -mx-4 py-6 md:mx-0 md:w-full md:px-6";
+export const PROJECTS_DETAIL_SHELL_CLASS = "mx-auto w-full max-w-6xl py-6";
 
 /**
  * Detail header + briefing/brand/tasks/jobs/memory: full bleed under the
@@ -46,7 +44,7 @@ export const PROJECTS_BROWSE_LAYOUT_CLASS =
   "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
 
 export const PROJECTS_DETAIL_LIST_LAYOUT_CLASS =
-  "bg-muted/30 border-border/50 -mx-4 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border";
+  "bg-muted/30 border-border/50 overflow-hidden rounded-none border-0 md:rounded-xl md:border";
 
 /**
  * Inner divide wrapper for browse rows. Shared by live list and Instant skeleton.

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -16,10 +16,6 @@ export const PROJECTS_PAGE_SHELL_CLASS = "w-full";
  */
 export const PROJECTS_DETAIL_SHELL_CLASS = "mx-auto w-full max-w-6xl py-6";
 
-/**
- * Project calendar route shell. Wider than detail so `WorkspaceCalendar`'s
- * `max-w-7xl` canvas is not clipped by the overview shell.
- */
 export const PROJECTS_CALENDAR_SHELL_CLASS = "mx-auto w-full max-w-7xl py-6";
 
 /**

--- a/apps/web/src/app/(app)/projects/constants.ts
+++ b/apps/web/src/app/(app)/projects/constants.ts
@@ -17,6 +17,12 @@ export const PROJECTS_PAGE_SHELL_CLASS = "w-full";
 export const PROJECTS_DETAIL_SHELL_CLASS = "mx-auto w-full max-w-6xl py-6";
 
 /**
+ * Project calendar route shell. Wider than detail so `WorkspaceCalendar`'s
+ * `max-w-7xl` canvas is not clipped by the overview shell.
+ */
+export const PROJECTS_CALENDAR_SHELL_CLASS = "mx-auto w-full max-w-7xl py-6";
+
+/**
  * Workspace modules (`modules.title`): stacks heading + tiles in the main column.
  */
 export const PROJECTS_DETAIL_WORKSPACE_CLASS = "space-y-3";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

On mobile, project detail stacked Brand and Memory after the full main column, so they sat under modules. Context should sit after Briefing and before Needs attention. Desktop keeps the right rail via CSS grid auto-placement of three siblings.

Brand status also moved onto the identity row (avatar / name / DESIGN.md) so Ready / Generating / Not set reads with the brand artifact, not the section chrome.

## Scope

- `apps/web/src/app/(app)/projects/[projectId]/page.tsx` — three-sibling grid (intro, aside, main); split at `xl:`; aside `xl:row-span-2`
- `apps/web/src/app/(app)/projects/[projectId]/calendar/page.tsx` — `PROJECTS_CALENDAR_SHELL_CLASS` (`max-w-7xl`) so the week canvas is not clipped
- `apps/web/src/app/(app)/projects/components/project-brand-card.tsx` — status Badge on the info row
- Matching page, calendar, constants, and brand-card tests
- Needs-attention list chrome restored to browse bleed (`PROJECTS_BROWSE_LAYOUT_CLASS`)

Out of scope: sticky rail, named grid-area wrappers, Core/API changes.

## Tradeoffs

Rejected duplicate Brand mounts (`lg:hidden` / `hidden lg:block`) because `ProjectBrandProvider` auto-starts generation. Rejected `order-*` because page tests and a11y treat source order as mobile order. Named-area layout wrappers lost to the three-sibling auto-placement shape (same mobile/desktop result, less code). Codex review moved the two-column split from `lg:` back to `xl:` so module tiles stay readable with the app sidebar; aside spans both desktop rows to avoid a gap under a short Briefing.

## Blast Radius

Web project detail and project calendar shells only. One Brand card mount. Desktop column template unchanged aside from the `xl` breakpoint and row span.

## Verification

- Local targeted Vitest green for page, calendar, and constants (`0ac109917`)
- Codex P2 threads on #4262 addressed and resolved
- Computer-use skipped per request; CI re-runs on push
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82a1bea8-8902-4f41-83ab-81da033f3dd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82a1bea8-8902-4f41-83ab-81da033f3dd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Redesigned project detail pages with a centered, spacious two-column layout and desktop sidebar.
  * Updated project brand cards to group status information and actions more clearly.
  * Added a success indicator when project brand documentation is available.
  * Improved the needs-attention section’s responsive layout and edge-to-edge mobile presentation.
  * Refined project detail header spacing for a cleaner layout.

* **Tests**
  * Updated coverage to reflect the revised project layouts, styling, and brand card behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->