### PR TITLE
chore(apple): set CFBundleDisplayName

### DIFF
--- a/apps/apple/Sokosumi.xcodeproj/project.pbxproj
+++ b/apps/apple/Sokosumi.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Sokosumi-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Sokosumi;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -398,6 +399,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Sokosumi-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Sokosumi;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Sets the Mac app target Display Name to Sokosumi in Xcode (Debug and Release). Same string already lives in `Sokosumi-Info.plist` as `CFBundleDisplayName`.

Verification: `pnpm check` and `pnpm typecheck` on commit (pre-commit hook). Diff is two `INFOPLIST_KEY_CFBundleDisplayName` lines in `apps/apple/Sokosumi.xcodeproj/project.pbxproj`.