### PR TITLE
fix(web): preserve thread state during notification deep links

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-route-error-boundary.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-route-error-boundary.test.ts
@@ -3,6 +3,26 @@ import { describe, expect, it } from "vitest";
 import { chatRouteErrorBoundaryKey } from "../chat-route-error-boundary.client";
 
 describe("chatRouteErrorBoundaryKey", () => {
+  it("preserves the room when a notification message is consumed or changed", () => {
+    const pathname = "/chat/rooms/room-1";
+    const roomKey = chatRouteErrorBoundaryKey(pathname);
+
+    for (const search of ["message=reply-1", "message=reply-2", ""]) {
+      expect(
+        chatRouteErrorBoundaryKey(pathname, new URLSearchParams(search)),
+      ).toBe(roomKey);
+    }
+  });
+
+  it("keeps other query parameters when consuming a notification message", () => {
+    expect(
+      chatRouteErrorBoundaryKey(
+        "/chat/rooms/room-1",
+        new URLSearchParams("message=reply-1&notice=room-unavailable"),
+      ),
+    ).toBe("/chat/rooms/room-1?notice=room-unavailable");
+  });
+
   it("uses pathname alone when there is no search", () => {
     expect(chatRouteErrorBoundaryKey("/")).toBe("/");
     expect(chatRouteErrorBoundaryKey("/", new URLSearchParams())).toBe("/");

--- a/apps/web/src/app/(app)/chat/components/chat-route-error-boundary.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-route-error-boundary.client.tsx
@@ -3,20 +3,24 @@
 import { usePathname, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import DefaultErrorBoundary from "@/components/default-error-boundary";
+import { CHAT_MESSAGE_PARAM } from "@/lib/utils/notification-href";
 
 import { ChatErrorFallback } from "./chat-error-fallback";
 
 type SearchParamsLike = { toString(): string } | null | undefined;
 
 /**
- * Remount key for the page error boundary. Pathname + search so a notice
- * query on Welcome remounts separately from bare `/`.
+ * Keep message jumps within the mounted room. Consuming the message parameter
+ * must not discard its thread state or the lookup still in flight.
+ * Other query changes, such as Welcome notices, still reset the boundary.
  */
 export function chatRouteErrorBoundaryKey(
   pathname: string,
   searchParams?: SearchParamsLike,
 ): string {
-  const search = searchParams?.toString() ?? "";
+  const params = new URLSearchParams(searchParams?.toString() ?? "");
+  params.delete(CHAT_MESSAGE_PARAM);
+  const search = params.toString();
   return search.length > 0 ? `${pathname}?${search}` : pathname;
 }
 


### PR DESCRIPTION
VERIFIED (source trace): The notification hook removes `?message=...` before its async thread jump completes. The error boundary included that parameter in its key, so URL cleanup remounted the room and discarded its state.

Exclude `CHAT_MESSAGE_PARAM` from the boundary key. Keep pathname and other query parameters in the key. Add regression tests for consuming or changing the message parameter and preserving other parameters.

Validation:
- VERIFIED: Before the fix, regression tests reported `2 failed | 3 passed (5)`.
- VERIFIED: Targeted tests reported `35 passed (35)`.
- VERIFIED: `pnpm --filter web test` reported `657 passed (657)` test files and `4793 passed | 1 skipped (4794)` tests.
- VERIFIED: `pnpm check` reported `Checked 3961 files in 809ms. No fixes applied.`
- VERIFIED: Commit hooks passed with `19 successful, 19 total` typecheck tasks. Stale local Next.js route types were moved aside after route type regeneration.
- REPORTED: Independent source review found no findings.

Browser verification remains pending. Tests cover key stability and jump logic; they do not prove the deployed thread UI.
