### PR TITLE
fix(chat): restore realtime and unread updates

### DIFF
--- a/apps/web/src/app/(app)/chat/utils/classic-outbound-queue.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/classic-outbound-queue.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 
 import {
   type ClassicOutboundJob,
   type ClassicOutboundQueueRefs,
+  clearClassicOutboundQueue,
   drainClassicOutboundQueue,
   enqueueClassicOutboundJob,
 } from "./classic-outbound-queue";
@@ -59,6 +60,138 @@ function message(id: string): ChatRoomMessage {
 }
 
 describe("drainClassicOutboundQueue", () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("releases a stalled send and retains its idempotency key for explicit retry", async () => {
+    vi.useFakeTimers();
+    const refs = makeRefs();
+    const late = Promise.withResolvers<{ ok: true; value: ChatRoomMessage }>();
+    const retry = Promise.withResolvers<{ ok: true; value: ChatRoomMessage }>();
+    enqueueClassicOutboundJob(refs, job("a"), () => undefined);
+    enqueueClassicOutboundJob(refs, job("b"), () => undefined);
+    const send = vi
+      .fn()
+      .mockReturnValueOnce(late.promise)
+      .mockResolvedValueOnce({ ok: true, value: message("server-b") })
+      .mockReturnValueOnce(retry.promise);
+    const onFailure = vi.fn();
+    const onSuccess = vi.fn();
+    const params = {
+      refs,
+      send,
+      onFailure,
+      onSuccess,
+      unknownFailureMessage: "Failed",
+    };
+    const firstDrain = drainClassicOutboundQueue(params);
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith(job("a"), "Failed");
+    await firstDrain;
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(refs.jobsRef.current.get("a")).toEqual(job("a"));
+    expect(refs.runningRef.current).toBe(false);
+
+    const retryJob = refs.jobsRef.current.get("a");
+    expect(retryJob).toBeDefined();
+    enqueueClassicOutboundJob(refs, retryJob!, () => undefined);
+    const retryDrain = drainClassicOutboundQueue(params);
+    late.resolve({ ok: true, value: message("late-original") });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(refs.jobsRef.current.has("a")).toBe(true);
+    expect(refs.runningRef.current).toBe(true);
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send.mock.calls[2]?.[0].clientMessageId).toBe("a");
+
+    retry.resolve({ ok: true, value: message("retry-confirmed") });
+    await retryDrain;
+    expect(onSuccess).toHaveBeenCalledTimes(2);
+    expect(onSuccess.mock.calls[1]?.[1].id).toBe("retry-confirmed");
+    expect(refs.jobsRef.current.has("a")).toBe(false);
+  });
+
+  it("starts a new room queue without waiting for the old room's pending send", async () => {
+    const refs = makeRefs();
+    const old = Promise.withResolvers<{ ok: true; value: ChatRoomMessage }>();
+    const current = Promise.withResolvers<{
+      ok: true;
+      value: ChatRoomMessage;
+    }>();
+    const send = vi
+      .fn()
+      .mockReturnValueOnce(old.promise)
+      .mockReturnValueOnce(current.promise)
+      .mockResolvedValue({ ok: true, value: message("server-c") });
+    const onFailure = vi.fn();
+    const onSuccess = vi.fn();
+    const params = {
+      refs,
+      send,
+      onFailure,
+      onSuccess,
+      unknownFailureMessage: "Failed",
+    };
+    enqueueClassicOutboundJob(refs, job("a"), () => undefined);
+    const oldDrain = drainClassicOutboundQueue(params);
+    clearClassicOutboundQueue(refs);
+    enqueueClassicOutboundJob(
+      refs,
+      { ...job("b"), roomId: "room-2" },
+      () => undefined,
+    );
+    const currentDrain = drainClassicOutboundQueue(params);
+    expect(send).toHaveBeenCalledTimes(2);
+
+    old.resolve({ ok: true, value: message("old-room") });
+    await oldDrain;
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(refs.runningRef.current).toBe(true);
+    enqueueClassicOutboundJob(
+      refs,
+      { ...job("c"), roomId: "room-2" },
+      () => void drainClassicOutboundQueue(params),
+    );
+    expect(send).toHaveBeenCalledTimes(2);
+    current.resolve({ ok: true, value: message("new-room") });
+    await currentDrain;
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(onSuccess.mock.calls.map((call) => call[0].clientMessageId)).toEqual(
+      ["b", "c"],
+    );
+    expect(refs.runningRef.current).toBe(false);
+  });
+
+  it("keeps normal sends in order before the deadline", async () => {
+    vi.useFakeTimers();
+    const refs = makeRefs();
+    const first = Promise.withResolvers<{ ok: true; value: ChatRoomMessage }>();
+    enqueueClassicOutboundJob(refs, job("a"), () => undefined);
+    enqueueClassicOutboundJob(refs, job("b"), () => undefined);
+    const send = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce({ ok: true, value: message("server-b") });
+    const onSuccess = vi.fn();
+    const drained = drainClassicOutboundQueue({
+      refs,
+      send,
+      onSuccess,
+      onFailure: vi.fn(),
+      unknownFailureMessage: "Failed",
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(send).toHaveBeenCalledTimes(1);
+    first.resolve({ ok: true, value: message("server-a") });
+    await drained;
+    expect(onSuccess.mock.calls.map((call) => call[0].clientMessageId)).toEqual(
+      ["a", "b"],
+    );
+  });
+
   it("dequeues before send so a throw does not re-loop the same head", async () => {
     const refs = makeRefs();
     enqueueClassicOutboundJob(refs, job("a"), () => undefined);

--- a/apps/web/src/app/(app)/chat/utils/classic-outbound-queue.ts
+++ b/apps/web/src/app/(app)/chat/utils/classic-outbound-queue.ts
@@ -1,4 +1,8 @@
 import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+import { raceWithTimeout } from "@/lib/utils/race-with-timeout";
+
+const CLASSIC_OUTBOUND_SEND_TIMEOUT_MS = 30_000;
+const activeRuns = new WeakMap<ClassicOutboundQueueRefs, symbol>();
 
 /** Framework-neutral mutable box (React refs satisfy this shape). */
 export interface MutableContainer<T> {
@@ -43,6 +47,8 @@ export async function drainClassicOutboundQueue(params: {
     return;
   }
   refs.runningRef.current = true;
+  const run = Symbol();
+  activeRuns.set(refs, run);
   try {
     while (refs.queueRef.current.length > 0) {
       const clientMessageId = refs.queueRef.current[0];
@@ -57,7 +63,13 @@ export async function drainClassicOutboundQueue(params: {
       // Always dequeue this head once we start it — throws must not re-loop.
       refs.queueRef.current.shift();
       try {
-        const result = await send(job);
+        // A timeout releases this local queue, not the underlying server
+        // action. Retain the same clientMessageId for an explicit safe retry.
+        const result = await raceWithTimeout(
+          send(job),
+          CLASSIC_OUTBOUND_SEND_TIMEOUT_MS,
+        );
+        if (activeRuns.get(refs) !== run) return;
         if (!result.ok) {
           onFailure(job, result.error.message);
           continue;
@@ -65,13 +77,18 @@ export async function drainClassicOutboundQueue(params: {
         refs.jobsRef.current.delete(clientMessageId);
         onSuccess(job, result.value);
       } catch {
+        if (activeRuns.get(refs) !== run) return;
         onFailure(job, unknownFailureMessage);
       }
     }
   } finally {
-    refs.runningRef.current = false;
-    if (refs.queueRef.current.length > 0) {
-      void drainClassicOutboundQueue(params);
+    // A room change can start another run before this old request settles.
+    if (activeRuns.get(refs) === run) {
+      activeRuns.delete(refs);
+      refs.runningRef.current = false;
+      if (refs.queueRef.current.length > 0) {
+        void drainClassicOutboundQueue(params);
+      }
     }
   }
 }
@@ -91,6 +108,8 @@ export function enqueueClassicOutboundJob(
 export function clearClassicOutboundQueue(
   refs: ClassicOutboundQueueRefs,
 ): void {
+  activeRuns.delete(refs);
+  refs.runningRef.current = false;
   refs.queueRef.current = [];
   refs.jobsRef.current.clear();
 }

--- a/apps/web/src/app/api/ably/auth/route.test.ts
+++ b/apps/web/src/app/api/ably/auth/route.test.ts
@@ -1,0 +1,92 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getSessionMock, headersMock, fetchMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  headersMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/auth.server", () => ({ getSession: getSessionMock }));
+vi.mock("next/headers", () => ({ headers: headersMock }));
+vi.mock("@/lib/clients/utils/core-api-base-url", () => ({
+  getCoreApiBaseUrl: () => "http://core.test/v1",
+}));
+
+import { POST } from "./route";
+
+function createRequest() {
+  return new NextRequest(
+    "https://web.test/api/ably/auth?clientInstanceId=inst_test01",
+    { method: "POST" },
+  );
+}
+
+describe("POST /api/ably/auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    headersMock.mockResolvedValue(new Headers({ cookie: "session=abc" }));
+    // The session helper reports null on both outages and expired sessions.
+    getSessionMock.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses Core's authenticated token endpoint without a second session lookup", async () => {
+    const tokenRequest = {
+      keyName: "app.key",
+      capability: "{}",
+      timestamp: 1,
+      nonce: "n",
+      mac: "m",
+    };
+    fetchMock.mockResolvedValue(Response.json({ data: tokenRequest }));
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(tokenRequest);
+    expect(getSessionMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL(
+        "http://core.test/v1/realtime/ably-token?clientInstanceId=inst_test01",
+      ),
+      expect.objectContaining({
+        headers: { cookie: "session=abc", Accept: "application/json" },
+      }),
+    );
+  });
+
+  it("preserves Core session rejection as 401", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "stale-user" } });
+    fetchMock.mockResolvedValue(new Response("Unauthorized", { status: 401 }));
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it.each([403, 429, 500, 503])(
+    "keeps Core %i retryable instead of reporting session loss",
+    async (status) => {
+      fetchMock.mockResolvedValue(new Response("Core error", { status }));
+
+      const response = await POST(createRequest());
+
+      expect(response.status).toBe(502);
+    },
+  );
+
+  it("keeps transport failure retryable instead of reporting session loss", async () => {
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/apps/web/src/app/api/ably/auth/route.ts
+++ b/apps/web/src/app/api/ably/auth/route.ts
@@ -1,14 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server";
 
 import createAuthTokenRequest from "@/lib/ably/auth";
-import { getSession } from "@/lib/auth/auth.server";
+import { CoreApiRequestError } from "@/lib/clients/core.request";
 
 export async function POST(request: NextRequest) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   try {
     const clientInstanceId =
       request.nextUrl.searchParams.get("clientInstanceId");
@@ -16,6 +11,10 @@ export async function POST(request: NextRequest) {
     // Ably authUrl expects the raw TokenRequest body (not Core { data, meta }).
     return NextResponse.json(tokenRequest);
   } catch (error) {
+    // Core authenticates the forwarded cookie. Only its 401 proves session loss.
+    if (error instanceof CoreApiRequestError && error.status === 401) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
     console.error("Failed to mint Ably token via Core:", error);
     return NextResponse.json(
       { error: "Failed to create Ably token" },

--- a/apps/web/src/app/api/chat/rooms/route.test.ts
+++ b/apps/web/src/app/api/chat/rooms/route.test.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CoreApiRequestError } from "@/lib/clients/core.request";
+
+const { getSessionMock, listRoomsMock, listArchivedMock, listPendingMock } =
+  vi.hoisted(() => ({
+    getSessionMock: vi.fn(),
+    listRoomsMock: vi.fn(),
+    listArchivedMock: vi.fn(),
+    listPendingMock: vi.fn(),
+  }));
+vi.mock("@/lib/auth/auth.server", () => ({ getSession: getSessionMock }));
+vi.mock("@/lib/services/chat-room.service", () => ({
+  chatRoomService: {
+    listRooms: listRoomsMock,
+    listArchivedRooms: listArchivedMock,
+    listPendingInvitations: listPendingMock,
+  },
+}));
+
+import { GET } from "./route";
+
+function request(collection: string) {
+  return new NextRequest(
+    `https://app.test/api/chat/rooms?collection=${collection}`,
+  );
+}
+
+describe("GET /api/chat/rooms", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    listRoomsMock.mockResolvedValue({
+      rooms: [{ id: "room-1" }],
+      nextCursor: null,
+    });
+    listArchivedMock.mockResolvedValue({ rooms: [], nextCursor: null });
+    listPendingMock.mockResolvedValue([]);
+  });
+
+  it("uses the existing full room list without waiting for invitations", async () => {
+    listPendingMock.mockReturnValue(new Promise(() => {}));
+    const result = await GET(request("active"));
+    expect(result.status).toBe(200);
+    expect(result.headers.get("cache-control")).toBe("no-store");
+    expect(await result.json()).toMatchObject({
+      data: [{ id: "room-1" }],
+      meta: { pagination: { nextCursor: null } },
+    });
+    expect(listRoomsMock).toHaveBeenCalledOnce();
+    expect(listArchivedMock).not.toHaveBeenCalled();
+    expect(listPendingMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["archived", "invitations"])(
+    "only fetches the %s collection",
+    async (collection) => {
+      const result = await GET(request(collection));
+      expect(result.status).toBe(200);
+      expect(listRoomsMock).not.toHaveBeenCalled();
+      expect(
+        collection === "archived" ? listArchivedMock : listPendingMock,
+      ).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("rejects unknown collections before fetching", async () => {
+    expect((await GET(request("everything"))).status).toBe(400);
+    expect(listRoomsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns JSON 401 without a sign-in redirect", async () => {
+    getSessionMock.mockResolvedValue(null);
+    const result = await GET(request("active"));
+    expect(result.status).toBe(401);
+    expect(result.headers.get("location")).toBeNull();
+    expect(await result.json()).toEqual({ error: "Unauthorized" });
+    expect(listRoomsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns JSON failure if the service throws a redirect", async () => {
+    listRoomsMock.mockRejectedValue(
+      Object.assign(new Error("NEXT_REDIRECT"), {
+        digest: "NEXT_REDIRECT;replace;/signin;307;",
+      }),
+    );
+    const result = await GET(request("active"));
+    expect(result.status).toBe(502);
+    expect(result.headers.get("location")).toBeNull();
+    expect(await result.json()).toEqual({ error: "Chat rooms unavailable" });
+  });
+
+  it("preserves Core failure status without exposing error details", async () => {
+    listRoomsMock.mockRejectedValue(
+      new CoreApiRequestError("private backend details", { status: 503 }),
+    );
+    const result = await GET(request("active"));
+    expect(result.status).toBe(503);
+    expect(await result.json()).toEqual({ error: "Chat rooms unavailable" });
+  });
+});

--- a/apps/web/src/app/api/chat/rooms/route.ts
+++ b/apps/web/src/app/api/chat/rooms/route.ts
@@ -1,0 +1,54 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { getSession } from "@/lib/auth/auth.server";
+import { CoreApiRequestError } from "@/lib/clients/core.request";
+import { chatRoomService } from "@/lib/services/chat-room.service";
+
+/** Background reads bypass the server action queue used by chat mutations. */
+export async function GET(request: NextRequest) {
+  const collection = request.nextUrl.searchParams.get("collection");
+  if (
+    collection !== "active" &&
+    collection !== "archived" &&
+    collection !== "invitations"
+  ) {
+    return NextResponse.json({ error: "Invalid collection" }, { status: 400 });
+  }
+
+  try {
+    if (!(await getSession())) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const meta = { timestamp: new Date(), requestId: crypto.randomUUID() };
+    const headers = { "Cache-Control": "no-store" };
+    if (collection === "invitations") {
+      const data = await chatRoomService.listPendingInvitations();
+      return NextResponse.json({ data, meta }, { headers });
+    }
+
+    const page = await (collection === "active"
+      ? chatRoomService.listRooms()
+      : chatRoomService.listArchivedRooms());
+    return NextResponse.json(
+      {
+        data: page.rooms,
+        meta: {
+          ...meta,
+          pagination: {
+            cursor: null,
+            nextCursor: page.nextCursor,
+            limit: page.rooms.length,
+          },
+        },
+      },
+      { headers },
+    );
+  } catch (error) {
+    // Core's server client may throw a sign-in redirect. A background read
+    // must return a failed response, never sign-in HTML as successful data.
+    const status =
+      error instanceof CoreApiRequestError && error.status ? error.status : 502;
+    return NextResponse.json({ error: "Chat rooms unavailable" }, { status });
+  }
+}

--- a/apps/web/src/components/chat/__tests__/organization-chat-list-harness.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-harness.tsx
@@ -108,6 +108,18 @@ vi.mock("../organization-chat-list.actions", () => ({
   })),
 }));
 
+vi.mock("../fetch-sidebar-room-collection", () => ({
+  fetchSidebarRoomCollection: async (collection: string) => {
+    const result =
+      collection === "active"
+        ? await listRoomsMock()
+        : collection === "invitations"
+          ? await listPendingMock()
+          : { ok: true, value: { rooms: [], nextCursor: null } };
+    return result.ok ? result.value : null;
+  },
+}));
+
 vi.mock("@/components/ui/sheet", () => ({
   SheetClose: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));

--- a/apps/web/src/components/chat/fetch-sidebar-room-collection.test.ts
+++ b/apps/web/src/components/chat/fetch-sidebar-room-collection.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchSidebarRoomCollection } from "./fetch-sidebar-room-collection";
+
+const fetchMock = vi.fn();
+const timestamp = "2026-09-08T10:00:00.000Z";
+
+function response(data: unknown[]) {
+  return new Response(
+    JSON.stringify({
+      data,
+      meta: {
+        timestamp,
+        requestId: "request-1",
+        pagination: { nextCursor: null },
+      },
+    }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("sidebar collection GET requests", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    fetchMock.mockReset();
+  });
+
+  it("uses a GET outside the action queue and restores generated room dates", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue(
+      response([
+        {
+          id: "room-1",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          starredAt: timestamp,
+          mutedAt: null,
+        },
+      ]),
+    );
+    const page = await fetchSidebarRoomCollection("active");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/chat/rooms?collection=active",
+      {
+        cache: "no-store",
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+      },
+    );
+    expect(page?.rooms[0]).toMatchObject({
+      createdAt: new Date(timestamp),
+      updatedAt: new Date(timestamp),
+      starredAt: new Date(timestamp),
+      mutedAt: null,
+    });
+    expect(page?.nextCursor).toBeNull();
+  });
+
+  it("restores invitation dates", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue(
+      response([
+        { id: "invite-1", createdAt: timestamp, expiresAt: timestamp },
+      ]),
+    );
+    expect(await fetchSidebarRoomCollection("invitations")).toEqual([
+      {
+        id: "invite-1",
+        createdAt: new Date(timestamp),
+        expiresAt: new Date(timestamp),
+      },
+    ]);
+  });
+
+  it.each([401, 502])(
+    "retains existing rows when HTTP %s is returned",
+    async (status) => {
+      vi.stubGlobal("fetch", fetchMock);
+      fetchMock.mockResolvedValue(new Response("{}", { status }));
+      expect(await fetchSidebarRoomCollection("active")).toBeNull();
+    },
+  );
+
+  it("rejects sign-in HTML and malformed JSON", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue(new Response("<html>Sign in</html>"));
+    expect(await fetchSidebarRoomCollection("active")).toBeNull();
+    fetchMock.mockResolvedValue(new Response("{}"));
+    expect(await fetchSidebarRoomCollection("active")).toBeNull();
+  });
+
+  it("aborts a stalled read so a later poll can succeed", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", fetchMock);
+    let signal: AbortSignal | undefined;
+    fetchMock.mockImplementationOnce((_url: string, options: RequestInit) => {
+      signal = options.signal ?? undefined;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+    const stalled = fetchSidebarRoomCollection("active");
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(signal?.aborted).toBe(true);
+    expect(await stalled).toBeNull();
+
+    fetchMock.mockResolvedValue(response([]));
+    expect(await fetchSidebarRoomCollection("active")).toEqual({
+      rooms: [],
+      nextCursor: null,
+    });
+  });
+});

--- a/apps/web/src/components/chat/fetch-sidebar-room-collection.ts
+++ b/apps/web/src/components/chat/fetch-sidebar-room-collection.ts
@@ -1,0 +1,52 @@
+import type {
+  ChatRoom,
+  ChatRoomInvitation,
+} from "@/lib/clients/generated/core";
+import {
+  getChatsInvitationsResponseTransformer,
+  getChatsRoomsResponseTransformer,
+} from "@/lib/clients/generated/core/transformers.gen";
+
+const SIDEBAR_ROOM_REQUEST_TIMEOUT_MS = 20_000;
+
+interface SidebarRoomsPage {
+  rooms: ChatRoom[];
+  nextCursor: string | null;
+}
+
+export function fetchSidebarRoomCollection(
+  collection: "invitations",
+): Promise<ChatRoomInvitation[] | null>;
+export function fetchSidebarRoomCollection(
+  collection: "active" | "archived",
+): Promise<SidebarRoomsPage | null>;
+export async function fetchSidebarRoomCollection(
+  collection: "active" | "archived" | "invitations",
+): Promise<SidebarRoomsPage | ChatRoomInvitation[] | null> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(
+    () => controller.abort(),
+    SIDEBAR_ROOM_REQUEST_TIMEOUT_MS,
+  );
+  try {
+    const response = await fetch(`/api/chat/rooms?collection=${collection}`, {
+      cache: "no-store",
+      redirect: "error",
+      signal: controller.signal,
+    });
+    if (!response.ok || response.redirected) return null;
+    const data: unknown = await response.json();
+    if (collection === "invitations") {
+      return (await getChatsInvitationsResponseTransformer(data)).data;
+    }
+    const page = await getChatsRoomsResponseTransformer(data);
+    return {
+      rooms: page.data,
+      nextCursor: page.meta.pagination.nextCursor,
+    };
+  } catch {
+    return null;
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}

--- a/apps/web/src/components/chat/room-read-overlay.test.ts
+++ b/apps/web/src/components/chat/room-read-overlay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   applyRoomReadOverlays,
@@ -29,6 +29,68 @@ function room(overrides: {
 
 afterEach(() => {
   clearRoomReadOverlays();
+  vi.useRealTimers();
+});
+
+describe("stalled attention changes", () => {
+  it.each([false, true])(
+    "lets fresh polls replace an expired pending change (markedUnread=%s)",
+    (markedUnread) => {
+      vi.useFakeTimers();
+      const previous = room({ unreadCount: 2 });
+      beginRoomAttentionChange(room({ markedUnread }), previous);
+      vi.advanceTimersByTime(30_000);
+
+      const fresh = room({ unreadCount: 3 });
+      expect(
+        reconcileRoomAttention([fresh], beginRoomAttentionRefresh()),
+      ).toEqual([fresh]);
+    },
+  );
+
+  it("restores the last settled attention on remount after a pending read expires", () => {
+    vi.useFakeTimers();
+    beginRoomAttentionChange(room({}), room({ unreadCount: 2 }));
+    vi.advanceTimersByTime(30_000);
+
+    expect(applyRoomReadOverlays([room({})])[0].unreadCount).toBe(2);
+  });
+
+  it("rejects a late response after expiry, before any poll has observed it", () => {
+    vi.useFakeTimers();
+    const token = beginRoomAttentionChange(room({}), room({ unreadCount: 2 }));
+    vi.advanceTimersByTime(30_000);
+
+    expect(settleRoomAttentionChange("room-1", token, room({}))).toBe(false);
+    expect(applyRoomReadOverlays([room({})])[0].unreadCount).toBe(2);
+  });
+
+  it("does not extend pending lifetime when read events repeat", () => {
+    vi.useFakeTimers();
+    beginRoomAttentionChange(room({}), room({ unreadCount: 2 }));
+    vi.advanceTimersByTime(20_000);
+    rememberRoomRead(room({}));
+    vi.advanceTimersByTime(10_000);
+
+    const fresh = room({ unreadCount: 3 });
+    expect(
+      reconcileRoomAttention([fresh], beginRoomAttentionRefresh()),
+    ).toEqual([fresh]);
+  });
+
+  it("preserves rollback when a new operation replaces an expired read", () => {
+    vi.useFakeTimers();
+    const oldToken = beginRoomAttentionChange(
+      room({}),
+      room({ unreadCount: 2 }),
+    );
+    vi.advanceTimersByTime(30_000);
+    const newToken = beginRoomAttentionChange(room({ markedUnread: true }));
+
+    expect(settleRoomAttentionChange("room-1", oldToken, room({}))).toBe(false);
+    expect(settleRoomAttentionChange("room-1", newToken, null)).toBe(true);
+    expect(applyRoomReadOverlays([room({})])[0].unreadCount).toBe(2);
+  });
 });
 
 describe("room-read-overlay", () => {

--- a/apps/web/src/components/chat/room-read-overlay.ts
+++ b/apps/web/src/components/chat/room-read-overlay.ts
@@ -5,8 +5,11 @@ interface RoomReadOverlay {
   unreadMentionCount: number;
   markedUnread: boolean;
   revision: number;
-  pendingToken: number | null;
-  rollbackAttention: RoomAttentionFields | null;
+  pending: {
+    token: number;
+    expiresAt: number;
+    rollbackAttention: RoomAttentionFields;
+  } | null;
 }
 
 interface RoomAttentionFields {
@@ -18,6 +21,8 @@ interface RoomAttentionFields {
 }
 
 const overlaysByRoomId = new Map<string, RoomReadOverlay>();
+// A stalled mutation must not suppress authoritative sidebar polls indefinitely.
+const PENDING_ATTENTION_TIMEOUT_MS = 30_000;
 let revision = 0;
 
 function toUpdatedAtMs(updatedAt: string | Date): number {
@@ -28,8 +33,7 @@ function toUpdatedAtMs(updatedAt: string | Date): number {
 function storeAttention(
   room: RoomAttentionFields,
   nextRevision: number,
-  pendingToken: number | null = null,
-  rollbackAttention: RoomAttentionFields | null = null,
+  pending: RoomReadOverlay["pending"] = null,
 ): void {
   overlaysByRoomId.set(room.id, {
     updatedAtMs: toUpdatedAtMs(room.updatedAt),
@@ -37,9 +41,19 @@ function storeAttention(
     unreadMentionCount: room.unreadMentionCount,
     markedUnread: room.markedUnread,
     revision: nextRevision,
-    pendingToken,
-    rollbackAttention,
+    pending,
   });
+}
+
+function getRoomReadOverlay(roomId: string): RoomReadOverlay | undefined {
+  const overlay = overlaysByRoomId.get(roomId);
+  if (overlay?.pending && Date.now() >= overlay.pending.expiresAt) {
+    // Keep the original revision so a fresh poll can replace the rollback.
+    // Removing the pending token also prevents late responses from settling it.
+    storeAttention(overlay.pending.rollbackAttention, overlay.revision);
+    return overlaysByRoomId.get(roomId);
+  }
+  return overlay;
 }
 
 function applyAttention<T extends RoomAttentionFields>(
@@ -56,7 +70,7 @@ function applyAttention<T extends RoomAttentionFields>(
 
 /** Event listeners may repeat an optimistic snapshot without settling it. */
 export function rememberRoomRead(room: RoomAttentionFields): void {
-  const overlay = overlaysByRoomId.get(room.id);
+  const overlay = getRoomReadOverlay(room.id);
   storeAttention(
     {
       ...room,
@@ -66,8 +80,7 @@ export function rememberRoomRead(room: RoomAttentionFields): void {
       ),
     },
     ++revision,
-    overlay?.pendingToken ?? null,
-    overlay?.rollbackAttention ?? null,
+    overlay?.pending ?? null,
   );
 }
 
@@ -77,8 +90,8 @@ export function beginRoomAttentionChange(
 ): number {
   // Overlapping operations share the last settled attention, never an
   // optimistic snapshot from a superseded operation or a remounted caller.
-  const previousOverlay = overlaysByRoomId.get(room.id);
-  const rollbackAttention = previousOverlay?.rollbackAttention ?? {
+  const previousOverlay = getRoomReadOverlay(room.id);
+  const rollbackAttention = previousOverlay?.pending?.rollbackAttention ?? {
     ...applyRoomReadOverlays([previousRoom])[0],
     updatedAt: new Date(
       Math.max(
@@ -88,7 +101,11 @@ export function beginRoomAttentionChange(
     ),
   };
   const token = ++revision;
-  storeAttention(room, token, token, rollbackAttention);
+  storeAttention(room, token, {
+    token,
+    expiresAt: Date.now() + PENDING_ATTENTION_TIMEOUT_MS,
+    rollbackAttention,
+  });
   return token;
 }
 
@@ -98,16 +115,14 @@ export function settleRoomAttentionChange(
   token: number,
   room: RoomAttentionFields | null,
 ): boolean {
-  const overlay = overlaysByRoomId.get(roomId);
-  if (overlay?.pendingToken !== token) {
+  const overlay = getRoomReadOverlay(roomId);
+  if (overlay?.pending?.token !== token) {
     return false;
   }
   if (room) {
     storeAttention(room, ++revision);
-  } else if (overlay.rollbackAttention) {
-    storeAttention(overlay.rollbackAttention, ++revision);
   } else {
-    forgetRoomRead(roomId);
+    storeAttention(overlay.pending.rollbackAttention, ++revision);
   }
   return true;
 }
@@ -134,10 +149,10 @@ export function reconcileRoomAttention<T extends RoomAttentionFields>(
   requestRevision: number,
 ): T[] {
   return rooms.map((room) => {
-    const overlay = overlaysByRoomId.get(room.id);
+    const overlay = getRoomReadOverlay(room.id);
     if (
       overlay &&
-      (overlay.pendingToken !== null || overlay.revision > requestRevision)
+      (overlay.pending !== null || overlay.revision > requestRevision)
     ) {
       return applyAttention(room, overlay);
     }
@@ -151,10 +166,10 @@ export function applyRoomReadOverlays<T extends RoomAttentionFields>(
   rooms: readonly T[],
 ): T[] {
   return rooms.map((room) => {
-    const overlay = overlaysByRoomId.get(room.id);
+    const overlay = getRoomReadOverlay(room.id);
     if (
       !overlay ||
-      (overlay.pendingToken === null &&
+      (overlay.pending === null &&
         toUpdatedAtMs(room.updatedAt) > overlay.updatedAtMs)
     ) {
       return room;

--- a/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
@@ -37,6 +37,13 @@ interface MountOptions {
   paintOnly?: boolean;
 }
 
+interface RoomListProps {
+  rooms: ChatRoom[];
+  archivedRooms: ChatRoom[];
+  organizationId?: string;
+  currentUserId?: string;
+}
+
 /**
  * The collections must keep the same identity across renders. The hook replaces
  * its rows whenever a collection is a new reference, so a fresh `[]` literal per
@@ -48,17 +55,18 @@ function mount({
   archivedRooms = NO_ROOMS,
   paintOnly = false,
 }: MountOptions = {}) {
+  const initialProps: RoomListProps = { rooms, archivedRooms };
   return renderHook(
-    (props: { rooms: ChatRoom[]; archivedRooms: ChatRoom[] }) =>
+    (props: RoomListProps) =>
       useOrganizationChatRooms({
         rooms: props.rooms,
         archivedRooms: props.archivedRooms,
         pendingInvitations: NO_INVITATIONS,
-        currentUserId: "user-1",
-        organizationId: "org-1",
+        currentUserId: props.currentUserId ?? "user-1",
+        organizationId: props.organizationId ?? "org-1",
         paintOnly,
       }),
-    { initialProps: { rooms, archivedRooms } },
+    { initialProps },
   );
 }
 
@@ -284,6 +292,47 @@ describe("authoritative sidebar refresh", () => {
     clearRoomReadOverlays();
   });
 
+  it("updates unread while an invitation request stays pending", async () => {
+    const original = channel("room");
+    listRoomsMock.mockResolvedValue(
+      emptyListResult([{ ...original, unreadCount: 3 }]),
+    );
+    listPendingMock.mockReturnValue(new Promise(() => {}));
+    const { result } = mount({ rooms: [original] });
+
+    await waitFor(() =>
+      expect(result.current.roomRows[0]?.unreadCount).toBe(3),
+    );
+  });
+
+  it("keeps the last rows after a rejected request and retries on focus", async () => {
+    const original = channel("room");
+    listRoomsMock.mockRejectedValueOnce(new Error("network offline"));
+    const { result } = mount({ rooms: [original] });
+    await act(async () => undefined);
+    expect(result.current.roomRows).toEqual([original]);
+
+    listRoomsMock.mockResolvedValue(
+      emptyListResult([{ ...original, unreadCount: 2 }]),
+    );
+    await act(async () => window.dispatchEvent(new Event("focus")));
+    expect(result.current.roomRows[0]?.unreadCount).toBe(2);
+  });
+
+  it("accepts an older active response when a newer refresh only loads invitations", async () => {
+    const original = channel("room");
+    const older = Promise.withResolvers<ReturnType<typeof emptyListResult>>();
+    listRoomsMock
+      .mockReturnValueOnce(older.promise)
+      .mockResolvedValueOnce({ ok: false });
+    const { result } = mount({ rooms: [original] });
+    await act(async () => window.dispatchEvent(new Event("focus")));
+    await act(async () =>
+      older.resolve(emptyListResult([{ ...original, unreadCount: 4 }])),
+    );
+    expect(result.current.roomRows[0]?.unreadCount).toBe(4);
+  });
+
   it("applies successful polls that take longer than the polling interval", async () => {
     vi.useFakeTimers();
     const original = channel("slow-room");
@@ -358,6 +407,61 @@ describe("authoritative sidebar refresh", () => {
     await act(async () => older.resolve(emptyListResult([original])));
     expect(result.current.roomRows[0]?.unreadCount).toBe(1);
   });
+
+  it("does not restore a removed room from an older poll", async () => {
+    const original = channel("removed");
+    const pending = Promise.withResolvers<ReturnType<typeof emptyListResult>>();
+    listRoomsMock.mockReturnValueOnce(pending.promise);
+    const { result } = mount({ rooms: [original] });
+    act(() =>
+      window.dispatchEvent(
+        new CustomEvent(ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT, {
+          detail: { removedRoomId: original.id },
+        }),
+      ),
+    );
+    expect(result.current.roomRows).toEqual([]);
+    await act(async () => pending.resolve(emptyListResult([original])));
+    expect(result.current.roomRows).toEqual([]);
+  });
+
+  it.each([
+    { trigger: "focus", organizationId: "org-2", currentUserId: "user-1" },
+    { trigger: "focus", organizationId: "org-1", currentUserId: "user-2" },
+    {
+      trigger: ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
+      organizationId: "org-2",
+      currentUserId: "user-1",
+    },
+    {
+      trigger: ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
+      organizationId: "org-1",
+      currentUserId: "user-2",
+    },
+  ])(
+    "cancels $trigger requests after switching to $organizationId/$currentUserId",
+    async ({ trigger, organizationId, currentUserId }) => {
+      const original = channel("previous-room");
+      const replacement = channel("current-room");
+      const pending =
+        Promise.withResolvers<ReturnType<typeof emptyListResult>>();
+      listRoomsMock
+        .mockResolvedValueOnce(emptyListResult([original]))
+        .mockReturnValueOnce(pending.promise)
+        .mockResolvedValue({ ok: false });
+      const { result, rerender } = mount({ rooms: [original] });
+      await act(async () => undefined);
+      await act(async () => window.dispatchEvent(new Event(trigger)));
+      rerender({
+        rooms: [replacement],
+        archivedRooms: NO_ROOMS,
+        organizationId,
+        currentUserId,
+      });
+      await act(async () => pending.resolve(emptyListResult([original])));
+      expect(result.current.roomRows).toEqual([replacement]);
+    },
+  );
 
   it("keeps the joined room when an invitation refresh overtakes a pending poll", async () => {
     const pendingPoll =

--- a/apps/web/src/components/chat/use-organization-chat-rooms.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.ts
@@ -2,21 +2,17 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { listPendingChatRoomInvitationsAction } from "@/app/chat/actions";
 import type {
   ChatRoom,
   ChatRoomInvitation,
 } from "@/lib/clients/generated/core";
 
+import { fetchSidebarRoomCollection } from "./fetch-sidebar-room-collection";
 import { publishMembershipVisibleRooms } from "./membership-visible-rooms-store";
 import {
   ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
   type OrganizationChatRoomsChangedDetail,
 } from "./organization-chat-events";
-import {
-  listOrganizationArchivedChatRoomsAction,
-  listOrganizationChatRoomsAction,
-} from "./organization-chat-list.actions";
 import {
   applyRoomReadOverlays,
   beginRoomAttentionRefresh,
@@ -25,30 +21,6 @@ import {
 } from "./room-read-overlay";
 
 const ORGANIZATION_CHAT_POLL_MS = 15_000;
-
-/**
- * Fetch the three sidebar collections in one round trip.
- *
- * Without an organization there are no archived rooms to ask for, so that leg
- * resolves empty rather than calling Core.
- */
-async function fetchSidebarRoomData(hasOrganization: boolean) {
-  return Promise.all([
-    listOrganizationChatRoomsAction(),
-    hasOrganization
-      ? listOrganizationArchivedChatRoomsAction()
-      : Promise.resolve({
-          ok: true as const,
-          value: {
-            rooms: [] as ChatRoom[],
-            nextCursor: null as string | null,
-          },
-        }),
-    listPendingChatRoomInvitationsAction(),
-  ]);
-}
-
-type SidebarRoomData = Awaited<ReturnType<typeof fetchSidebarRoomData>>;
 
 interface UseOrganizationChatRoomsOptions {
   rooms: ChatRoom[];
@@ -90,6 +62,8 @@ export function useOrganizationChatRooms({
 }: UseOrganizationChatRoomsOptions) {
   const hasOrganization = Boolean(organizationId);
   const latestAppliedRefreshRef = useRef(0);
+  const latestArchivedRefreshRef = useRef(0);
+  const latestInvitationsRefreshRef = useRef(0);
   const [roomRows, setRoomRows] = useState(() => applyRoomReadOverlays(rooms));
   const [archivedRows, setArchivedRows] = useState(archivedRooms);
   const [pendingRows, setPendingRows] = useState(pendingInvitations);
@@ -121,6 +95,7 @@ export function useOrganizationChatRooms({
    */
   const upsertRoomToTop = useCallback((room: ChatRoom) => {
     latestAppliedRefreshRef.current = beginRoomAttentionRefresh();
+    latestArchivedRefreshRef.current = latestAppliedRefreshRef.current;
     setRoomRows((current) => {
       const without = current.filter((row) => row.id !== room.id);
       return applyRoomReadOverlays([room, ...without]);
@@ -155,32 +130,44 @@ export function useOrganizationChatRooms({
     [],
   );
 
-  /**
-   * Write the collections one refresh returned, skipping the calls that failed.
-   *
-   * A half-failed refresh must leave the sections it could not reach as they
-   * were, or a reader watches a section they can still see go empty.
-   */
-  const applySidebarRoomData = useCallback(
-    (
-      [activeResult, archivedResult, pendingResult]: SidebarRoomData,
-      requestRevision: number,
-    ) => {
-      if (requestRevision < latestAppliedRefreshRef.current) return;
-      if (activeResult.ok || archivedResult.ok || pendingResult.ok) {
-        latestAppliedRefreshRef.current = requestRevision;
+  /** Each collection can recover without waiting for another collection. */
+  const refreshRooms = useCallback(
+    (isCancelled: () => boolean) => {
+      const requestRevision = beginRoomAttentionRefresh();
+      void fetchSidebarRoomCollection("active")
+        .then((page) => {
+          if (!isCancelled() && page)
+            replaceAllRooms(page.rooms, requestRevision);
+        })
+        .catch(() => {});
+      if (hasOrganization) {
+        void fetchSidebarRoomCollection("archived")
+          .then((page) => {
+            if (
+              isCancelled() ||
+              !page ||
+              requestRevision < latestArchivedRefreshRef.current
+            )
+              return;
+            latestArchivedRefreshRef.current = requestRevision;
+            setArchivedRows(page.rooms);
+          })
+          .catch(() => {});
       }
-      if (activeResult.ok) {
-        replaceAllRooms(activeResult.value.rooms, requestRevision);
-      }
-      if (archivedResult.ok) {
-        setArchivedRows(archivedResult.value.rooms);
-      }
-      if (pendingResult.ok) {
-        setPendingRows(pendingResult.value);
-      }
+      void fetchSidebarRoomCollection("invitations")
+        .then((invitations) => {
+          if (
+            isCancelled() ||
+            !invitations ||
+            requestRevision < latestInvitationsRefreshRef.current
+          )
+            return;
+          latestInvitationsRefreshRef.current = requestRevision;
+          setPendingRows(invitations);
+        })
+        .catch(() => {});
     },
-    [replaceAllRooms],
+    [hasOrganization, replaceAllRooms],
   );
 
   useEffect(() => {
@@ -190,31 +177,21 @@ export function useOrganizationChatRooms({
 
     let cancelled = false;
 
-    const refreshRooms = async () => {
-      const requestRevision = beginRoomAttentionRefresh();
-      const data = await fetchSidebarRoomData(hasOrganization);
-      if (cancelled || requestRevision < latestAppliedRefreshRef.current) {
-        return;
-      }
-      applySidebarRoomData(data, requestRevision);
-    };
+    const refresh = () => refreshRooms(() => cancelled);
 
     // Mobile sheet remounts the list with stale RSC props; refresh immediately
     // so Core can replace attention from earlier visits and other tabs.
-    void refreshRooms();
+    refresh();
 
-    const intervalId = window.setInterval(
-      refreshRooms,
-      ORGANIZATION_CHAT_POLL_MS,
-    );
-    window.addEventListener("focus", refreshRooms);
+    const intervalId = window.setInterval(refresh, ORGANIZATION_CHAT_POLL_MS);
+    window.addEventListener("focus", refresh);
 
     return () => {
       cancelled = true;
       window.clearInterval(intervalId);
-      window.removeEventListener("focus", refreshRooms);
+      window.removeEventListener("focus", refresh);
     };
-  }, [applySidebarRoomData, hasOrganization, organizationId, paintOnly]);
+  }, [currentUserId, organizationId, paintOnly, refreshRooms]);
 
   useEffect(() => {
     if (paintOnly) {
@@ -269,6 +246,8 @@ export function useOrganizationChatRooms({
         .detail;
       const removedRoomId = detail?.removedRoomId;
       if (removedRoomId) {
+        latestAppliedRefreshRef.current = beginRoomAttentionRefresh();
+        latestArchivedRefreshRef.current = latestAppliedRefreshRef.current;
         setRoomRows((current) =>
           applyRoomReadOverlays(
             current.filter((row) => row.id !== removedRoomId),
@@ -286,13 +265,7 @@ export function useOrganizationChatRooms({
         return;
       }
 
-      const requestRevision = beginRoomAttentionRefresh();
-      void fetchSidebarRoomData(hasOrganization).then((data) => {
-        if (cancelled || requestRevision < latestAppliedRefreshRef.current) {
-          return;
-        }
-        applySidebarRoomData(data, requestRevision);
-      });
+      refreshRooms(() => cancelled);
     };
 
     window.addEventListener(
@@ -306,7 +279,7 @@ export function useOrganizationChatRooms({
         handleRoomsChanged,
       );
     };
-  }, [applySidebarRoomData, hasOrganization, paintOnly, upsertRoomToTop]);
+  }, [currentUserId, organizationId, paintOnly, refreshRooms, upsertRoomToTop]);
 
   useEffect(() => {
     if (paintOnly) {

--- a/apps/web/src/lib/ably/auth.client.test.ts
+++ b/apps/web/src/lib/ably/auth.client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   AblyBrowserAuthError,
@@ -11,6 +11,38 @@ describe("fetchAblyBrowserAuthTokenRequest", () => {
   beforeEach(() => {
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("aborts stalled browser auth requests so retries do not leave fetches running", async () => {
+    const controller = new AbortController();
+    const timeoutMock = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValue(controller.signal);
+    fetchMock.mockImplementation((_url: string, options: RequestInit) => {
+      if (!options.signal) {
+        return Promise.reject(new Error("Missing abort signal"));
+      }
+      return new Promise((_resolve, reject) => {
+        options.signal?.addEventListener("abort", () =>
+          reject(options.signal?.reason),
+        );
+      });
+    });
+    const request = fetchAblyBrowserAuthTokenRequest("inst_test01");
+    const outcome = expect(request).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    controller.abort(
+      new DOMException("Auth deadline exceeded", "TimeoutError"),
+    );
+
+    await outcome;
+    expect(timeoutMock).toHaveBeenCalledWith(10_000);
   });
 
   it("POSTs to /api/ably/auth with cookies and clientInstanceId", async () => {

--- a/apps/web/src/lib/ably/auth.client.ts
+++ b/apps/web/src/lib/ably/auth.client.ts
@@ -1,6 +1,8 @@
 import type { TokenRequest } from "ably";
 
 const ABLY_BROWSER_AUTH_PATH = "/api/ably/auth";
+// Allow the Core token request its five-second deadline plus proxy overhead.
+const ABLY_BROWSER_AUTH_TIMEOUT_MS = 10_000;
 
 export class AblyBrowserAuthError extends Error {
   readonly status: number;
@@ -27,6 +29,7 @@ export async function fetchAblyBrowserAuthTokenRequest(
       Accept: "application/json",
     },
     cache: "no-store",
+    signal: AbortSignal.timeout(ABLY_BROWSER_AUTH_TIMEOUT_MS),
   });
 
   if (response.status === 401) {

--- a/apps/web/src/lib/ably/auth.test.ts
+++ b/apps/web/src/lib/ably/auth.test.ts
@@ -77,9 +77,10 @@ describe("createAuthTokenRequest", () => {
       text: async () => "unauthorized",
     });
 
-    await expect(createAuthTokenRequest()).rejects.toThrow(
-      /Core Ably token mint failed \(401\)/,
-    );
+    await expect(createAuthTokenRequest()).rejects.toMatchObject({
+      status: 401,
+      message: "Core Ably token mint failed (401): unauthorized",
+    });
   });
 
   it("throws when Core omits data", async () => {

--- a/apps/web/src/lib/ably/auth.ts
+++ b/apps/web/src/lib/ably/auth.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { headers } from "next/headers";
 
+import { CoreApiRequestError } from "@/lib/clients/core.request";
 import { getCoreApiBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 import { joinCoreApiPath } from "@/lib/clients/utils/core-api-base-url.shared";
 
@@ -40,8 +41,9 @@ export default async function createAuthTokenRequest(options?: {
 
   if (!response.ok) {
     const detail = await response.text().catch(() => "");
-    throw new Error(
+    throw new CoreApiRequestError(
       `Core Ably token mint failed (${response.status})${detail ? `: ${detail}` : ""}`,
+      { status: response.status },
     );
   }
 

--- a/apps/web/src/lib/ably/realtime-singleton.client.test.ts
+++ b/apps/web/src/lib/ably/realtime-singleton.client.test.ts
@@ -178,6 +178,30 @@ describe("getAblyRealtimeClient", () => {
     expect(consoleErrorMock).toHaveBeenCalled();
   });
 
+  it("does not let a retired client's late 401 close its replacement", async () => {
+    let rejectOldAuth: ((value: Response) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          rejectOldAuth = resolve;
+        }),
+    );
+    getAblyRealtimeClient();
+    const oldAuth = invokeAuthCallback();
+
+    fetchMock.mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+    await invokeAuthCallback();
+    const replacement = getAblyRealtimeClient();
+    const replacementClose = RealtimeMock.mock.instances[1]?.close;
+    rejectOldAuth?.(new Response("Unauthorized", { status: 401 }));
+    await oldAuth;
+
+    expect(globalThis.__sokosumiAblyRealtimeClient).toBe(replacement);
+    expect(replacementClose).not.toHaveBeenCalled();
+  });
+
   it("recreates a client after a 401 so a later remount can reconnect", async () => {
     fetchMock.mockResolvedValue({
       ok: false,

--- a/apps/web/src/lib/ably/realtime-singleton.client.ts
+++ b/apps/web/src/lib/ably/realtime-singleton.client.ts
@@ -23,14 +23,16 @@ function setGlobalAblyRealtimeClient(client: Ably.Realtime): void {
   globalThis.__sokosumiAblyRealtimeClient = client;
 }
 
-function clearSharedAblyRealtimeClient(): void {
-  const existing = getGlobalAblyRealtimeClient();
-  globalThis.__sokosumiAblyRealtimeClient = undefined;
-  existing?.close();
+function clearSharedAblyRealtimeClient(client: Ably.Realtime): void {
+  if (getGlobalAblyRealtimeClient() === client) {
+    globalThis.__sokosumiAblyRealtimeClient = undefined;
+  }
+  client.close();
 }
 
 function createAblyAuthCallback(
   clientInstanceId: string,
+  onSessionLost: () => void,
 ): NonNullable<Ably.AuthOptions["authCallback"]> {
   return (_tokenParams, callback) => {
     void fetchAblyBrowserAuthTokenRequest(clientInstanceId).then(
@@ -39,7 +41,7 @@ function createAblyAuthCallback(
       },
       (error: unknown) => {
         if (error instanceof AblyBrowserAuthError && error.status === 401) {
-          clearSharedAblyRealtimeClient();
+          onSessionLost();
         } else {
           console.error("Ably auth request failed", error);
         }
@@ -58,7 +60,9 @@ export function getAblyRealtimeClient(): Ably.Realtime {
 
   const clientInstanceId = getOrCreateAblyClientInstanceId();
   const realtimeClient = new Ably.Realtime({
-    authCallback: createAblyAuthCallback(clientInstanceId),
+    authCallback: createAblyAuthCallback(clientInstanceId, () => {
+      clearSharedAblyRealtimeClient(realtimeClient);
+    }),
     echoMessages: false,
     // Plugins are constructor-only in ably-js, so push rides the shared client
     // rather than a second one. Every route reaches this module through a

--- a/apps/web/src/lib/ably/use-chat-room-realtime.test.tsx
+++ b/apps/web/src/lib/ably/use-chat-room-realtime.test.tsx
@@ -1,30 +1,43 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { authorizeMock, getMock, channelsByName, ablyClient } = vi.hoisted(
-  () => {
-    const authorize = vi.fn();
-    const get = vi.fn();
-    return {
-      authorizeMock: authorize,
-      getMock: get,
-      channelsByName: new Map<
-        string,
-        {
-          name: string;
-          subscribe: ReturnType<typeof vi.fn>;
-          unsubscribe: ReturnType<typeof vi.fn>;
-          detach: ReturnType<typeof vi.fn>;
-        }
-      >(),
-      // Stable client identity — new object each useAbly() would full-reset attach.
-      ablyClient: {
-        auth: { authorize },
-        channels: { get },
+const {
+  authorizeMock,
+  getMock,
+  channelsByName,
+  ablyClient,
+  connectedListeners,
+} = vi.hoisted(() => {
+  const authorize = vi.fn();
+  const get = vi.fn();
+  const connectedListeners = new Set<() => void>();
+  return {
+    connectedListeners,
+    authorizeMock: authorize,
+    getMock: get,
+    channelsByName: new Map<
+      string,
+      {
+        name: string;
+        subscribe: ReturnType<typeof vi.fn>;
+        unsubscribe: ReturnType<typeof vi.fn>;
+        detach: ReturnType<typeof vi.fn>;
+      }
+    >(),
+    // Stable client identity — new object each useAbly() would full-reset attach.
+    ablyClient: {
+      connection: {
+        state: "connected",
+        on: (_event: string, listener: () => void) =>
+          connectedListeners.add(listener),
+        off: (_event: string, listener: () => void) =>
+          connectedListeners.delete(listener),
       },
-    };
-  },
-);
+      auth: { authorize },
+      channels: { get },
+    },
+  };
+});
 
 vi.mock("ably/react", () => ({
   useAbly: () => ablyClient,
@@ -70,6 +83,8 @@ describe("useChatRoomRealtime", () => {
     authorizeMock.mockReset();
     getMock.mockReset();
     channelsByName.clear();
+    connectedListeners.clear();
+    ablyClient.connection.state = "connected";
     authorizeMock.mockResolvedValue(tokenWithRooms("room-a", "room-b"));
     getMock.mockImplementation((name: string) => channelFor(name));
     vi.useRealTimers();
@@ -135,6 +150,127 @@ describe("useChatRoomRealtime", () => {
     expect(getMock).toHaveBeenCalledWith("chat_control:user_user_1");
     expect(getMock).not.toHaveBeenCalledWith("chat_rooms:room_room-a");
   });
+
+  it.each(["connected", "online"])(
+    "retries a failed room sync on %s without a focus event",
+    async (event) => {
+      const onError = vi.fn();
+      authorizeMock.mockRejectedValueOnce(
+        new Error("token temporarily unavailable"),
+      );
+      const { unmount } = renderHook(() =>
+        useChatRoomRealtime({
+          roomIds: ["room-a"],
+          currentUserId: "user_1",
+          onError,
+        }),
+      );
+      await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        if (event === "connected") {
+          for (const listener of connectedListeners) listener();
+        } else {
+          window.dispatchEvent(new Event("online"));
+        }
+      });
+      expect(channelFor("chat_rooms:room_room-a").subscribe).toHaveBeenCalled();
+      expect(authorizeMock).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        for (const listener of connectedListeners) listener();
+        window.dispatchEvent(new Event("online"));
+      });
+      expect(authorizeMock).toHaveBeenCalledTimes(2);
+      unmount();
+      expect(connectedListeners.size).toBe(0);
+    },
+  );
+
+  it("retries transient auth failure while the socket remains connected, then stops retrying", async () => {
+    vi.useFakeTimers();
+    authorizeMock.mockRejectedValueOnce(
+      new Error("token temporarily unavailable"),
+    );
+    const { unmount } = renderHook(() =>
+      useChatRoomRealtime({
+        roomIds: ["room-a"],
+        currentUserId: "user_1",
+      }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(channelFor("chat_rooms:room_room-a").subscribe).toHaveBeenCalled();
+    expect(authorizeMock).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(authorizeMock).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it("does not retry a closed client on a timer", async () => {
+    vi.useFakeTimers();
+    ablyClient.connection.state = "closed";
+    authorizeMock.mockRejectedValue(new Error("session is gone"));
+    const { unmount } = renderHook(() =>
+      useChatRoomRealtime({
+        roomIds: ["room-a"],
+        currentUserId: "user_1",
+      }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(authorizeMock).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("cancels pending auth retries on unmount", async () => {
+    vi.useFakeTimers();
+    authorizeMock.mockRejectedValue(new Error("token temporarily unavailable"));
+    const { unmount } = renderHook(() =>
+      useChatRoomRealtime({
+        roomIds: ["room-a"],
+        currentUserId: "user_1",
+      }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(authorizeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["closing", "closed", "failed"])(
+    "does not let a scheduled retry reopen a client that becomes %s",
+    async (state) => {
+      vi.useFakeTimers();
+      authorizeMock.mockRejectedValue(
+        new Error("token temporarily unavailable"),
+      );
+      const { unmount } = renderHook(() =>
+        useChatRoomRealtime({
+          roomIds: ["room-a"],
+          currentUserId: "user_1",
+        }),
+      );
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      ablyClient.connection.state = state;
+      await act(async () => {
+        window.dispatchEvent(new Event("online"));
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+      expect(authorizeMock).toHaveBeenCalledTimes(1);
+      unmount();
+    },
+  );
 
   it("on membership change, only detaches removed and subscribes added rooms", async () => {
     authorizeMock.mockResolvedValue(

--- a/apps/web/src/lib/ably/use-chat-room-realtime.tsx
+++ b/apps/web/src/lib/ably/use-chat-room-realtime.tsx
@@ -26,6 +26,7 @@ import { personalizeChatRoomMessageEvent } from "./personalize-chat-room-message
 import { safeDetachChannel, safeSubscribeChannel } from "./safe-detach-channel";
 
 const CHAT_ROOM_MESSAGE_EVENT_NAME = "chat_room_message";
+const CHAT_ROOM_AUTH_RETRY_MS = 15_000;
 
 interface UseChatRoomRealtimeOptions {
   /** Membership room ids to attach (all rooms for sidebar/live parity). */
@@ -48,7 +49,8 @@ interface UseChatRoomRealtimeOptions {
  * Remote membership revoke (SOK-742): Core publishes
  * `chat_membership_revoked` on `chat_control:user_{id}`; client detaches the
  * room immediately then re-authorizes so token caps drop. Thin backstop
- * (SOK-747): focus and visibility→visible only — no periodic re-auth interval.
+ * (SOK-747): focus and visibility→visible. Failed syncs retry after recovery
+ * or a short delay; healthy subscriptions never re-authorize on a timer.
  */
 export function useChatRoomRealtime({
   roomIds,
@@ -130,6 +132,8 @@ export function useChatRoomRealtime({
     /** Coalesce focus+visibility+revoke so two applies never interleave. */
     let syncInFlight = false;
     let syncQueued = false;
+    let syncNeedsRetry = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | undefined;
     const locallyRevokedRoomIds = locallyRevokedRoomIdsRef.current;
 
     function detachRoomLocally(roomId: string) {
@@ -148,6 +152,8 @@ export function useChatRoomRealtime({
     }
 
     async function runSyncOnce() {
+      clearTimeout(retryTimeout);
+      syncNeedsRetry = false;
       const generation = ++syncGenerationRef.current;
       const propIds = new Set(
         [...new Set(roomIdsRef.current)].filter((id) => id.length > 0),
@@ -167,6 +173,18 @@ export function useChatRoomRealtime({
       } catch (error) {
         if (generation !== syncGenerationRef.current) {
           return;
+        }
+        syncNeedsRetry = true;
+        // A transient token failure can leave the socket connected, so there
+        // may be no later connection event to retry the missing room channels.
+        if (
+          ably.connection.state !== "closing" &&
+          ably.connection.state !== "closed" &&
+          ably.connection.state !== "failed"
+        ) {
+          retryTimeout = setTimeout(() => {
+            onRecovered();
+          }, CHAT_ROOM_AUTH_RETRY_MS);
         }
         const err =
           error instanceof Error
@@ -288,15 +306,30 @@ export function useChatRoomRealtime({
         void syncMembershipChannels();
       }
     };
+    const onRecovered = () => {
+      if (
+        syncNeedsRetry &&
+        ably.connection.state !== "closing" &&
+        ably.connection.state !== "closed" &&
+        ably.connection.state !== "failed"
+      ) {
+        void syncMembershipChannels();
+      }
+    };
 
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("online", onRecovered);
+    ably.connection.on("connected", onRecovered);
 
     return () => {
       syncGenerationRef.current += 1;
       syncQueued = false;
+      clearTimeout(retryTimeout);
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("online", onRecovered);
+      ably.connection.off("connected", onRecovered);
       controlChannel.unsubscribe(
         CHAT_MEMBERSHIP_REVOKED_EVENT_NAME,
         handleMembershipRevoked,


### PR DESCRIPTION
VERIFIED: Temporary Core auth failures remain retryable. Only a Core `401` closes the owning Ably client. Missing room subscriptions retry after recovery. Pending unread changes expire after 30 seconds. Sidebar collections use independent GET requests and reject stale responses after room removal or workspace changes.

VERIFIED: Classic chat sends leave the pending state after a 30-second local deadline. Room changes release the old local queue. Late results cannot change a newer queue. Explicit Retry keeps the original `clientMessageId`, which Core uses to prevent duplicate messages.

## Validation

- VERIFIED: Chat and Ably suite: `Test Files 51 passed (51)`, `Tests 476 passed (476)`. Outbound message suite: `Tests 13 passed (13)`.
- VERIFIED: Commit hooks passed: repository typecheck `19 successful, 19 total` (`17 cached`), plus repository Biome check.
- VERIFIED: Core message-post suite: `Tests 26 passed (26)`, including retry idempotency.
- VERIFIED: Restoring the original recovery sources produced `22 failed | 71 passed (93)` and `1 error`.
- REPORTED: Before the queue fix, its new regression tests produced `2 failed | 3 passed (5)`. Independent adversarial review finished with no findings.

## Live observations and limits

VERIFIED: The affected Zen tab logged Ably token callback timeouts and fallback-host timeouts. Two messages showed Sending indicators. Both indicators later cleared without an investigator reload. An inspected successful request returned a message list, not a send confirmation.

The exact cause of the live send delay remains undetermined. The queue deadline releases local state; it cannot cancel or unblock an underlying Next server action. Tests simulate failures and recovery. These changes have not been deployed.
