### PR TITLE
feat(core): add routes to delete and clear notifications

### DIFF
--- a/apps/core/src/helpers/notification-item.ts
+++ b/apps/core/src/helpers/notification-item.ts
@@ -1,0 +1,29 @@
+import type { Notification } from "@sokosumi/database";
+
+/**
+ * A stored notification as the API answers with it: JSON columns parsed, and
+ * the storage-only fields left behind.
+ *
+ * One copy, because the list, the mark-read route and the delete route all
+ * return the same shape and must not drift apart.
+ */
+export function mapNotificationToItem(notification: Notification) {
+  return {
+    id: notification.id,
+    userId: notification.userId,
+    kind: notification.kind,
+    referenceId: notification.referenceId,
+    eventId: notification.eventId,
+    messageKey: notification.messageKey,
+    messageParams: JSON.parse(notification.messageParams) as Record<
+      string,
+      unknown
+    >,
+    metadata: notification.metadata
+      ? (JSON.parse(notification.metadata) as Record<string, unknown>)
+      : null,
+    isRead: notification.isRead,
+    readAt: notification.readAt,
+    createdAt: notification.createdAt,
+  };
+}

--- a/apps/core/src/routes/v1/notifications/[id]/delete.ts
+++ b/apps/core/src/routes/v1/notifications/[id]/delete.ts
@@ -1,0 +1,87 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+import { notFound } from "@/helpers/error";
+import { mapNotificationToItem } from "@/helpers/notification-item";
+import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
+import { ok } from "@/helpers/response";
+import prisma from "@/lib/db/prisma";
+import {
+  type OpenAPIHonoWithAuth,
+  withOrganizationSlugHeaderParameter,
+} from "@/lib/hono";
+import { requireOwnerUserContext } from "@/middleware/auth";
+import { notificationItemSchema } from "@/schemas/notification.schema";
+
+const paramsSchema = z.object({
+  id: z.string().openapi({
+    param: { name: "id", in: "path" },
+    description: "Notification ID",
+    example: "cm123456789abcdefghij",
+  }),
+});
+
+const route = withOrganizationSlugHeaderParameter(
+  createRoute({
+    method: "delete",
+    path: "/{id}",
+    description:
+      "Delete a single notification for the interactive session user. The row is looked up by id and reader together, so another reader's notification reads as missing rather than as forbidden. Deleting is not marking read: nothing else the notification points at is changed. The row is gone for good; there is no undo and no way to restore it.",
+    tags: ["Notifications"],
+    request: {
+      params: paramsSchema,
+    },
+    responses: {
+      200: jsonSuccessResponse(notificationItemSchema, "Notification deleted", {
+        data: {
+          id: "cm123456789abcdefghij",
+          userId: "cm123456789abcdefghij",
+          kind: "JOB",
+          referenceId: "cm123456789abcdefghij",
+          eventId: "cm123456789abcdefghij",
+          messageKey: "Notifications.Job.completed",
+          messageParams: {
+            agentName: "Research Agent",
+            jobName: "Market Analysis",
+          },
+          metadata: { agentId: "agent_123", projectId: "proj_456" },
+          isRead: false,
+          readAt: null,
+          createdAt: "2026-06-16T14:00:00.000Z",
+        },
+        meta: {
+          timestamp: "2026-06-16T15:00:00.000Z",
+          requestId: "550e8400-e29b-41d4-a716-446655440000",
+        },
+      }),
+      401: jsonErrorResponse("Unauthorized"),
+      404: jsonErrorResponse("Not Found"),
+      500: jsonErrorResponse("Internal Server Error"),
+    },
+  }),
+);
+
+export default function mount(app: OpenAPIHonoWithAuth) {
+  app.openapi(route, async (c) => {
+    const userContext = requireOwnerUserContext(c.var.authContext);
+    const { id } = c.req.valid("param");
+
+    const where = { id, userId: userContext.userId };
+
+    // Read before deleting, because the response carries the row that went and
+    // the app reads its unread state from there.
+    const notification = await prisma.notification.findFirst({ where });
+
+    if (!notification) {
+      throw notFound("Notification not found");
+    }
+
+    // deleteMany rather than delete: a row that goes between the two queries
+    // is the result this route asked for, not an error to report.
+    await prisma.notification.deleteMany({ where });
+
+    return ok(
+      c,
+      notificationItemSchema.parse(mapNotificationToItem(notification)),
+    );
+  });
+}

--- a/apps/core/src/routes/v1/notifications/[id]/read/patch.ts
+++ b/apps/core/src/routes/v1/notifications/[id]/read/patch.ts
@@ -4,6 +4,7 @@ import { CHAT_ROOM_MESSAGE_MESSAGE_KEY } from "@sokosumi/utils";
 import { waitUntil } from "@vercel/functions";
 
 import { forbidden, notFound } from "@/helpers/error";
+import { mapNotificationToItem } from "@/helpers/notification-item";
 import { publishClearedNotifications } from "@/helpers/notifications";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -114,25 +115,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       waitUntil(publishClearedNotifications([updated.id]));
     }
 
-    const result = {
-      id: updated.id,
-      userId: updated.userId,
-      kind: updated.kind,
-      referenceId: updated.referenceId,
-      eventId: updated.eventId,
-      messageKey: updated.messageKey,
-      messageParams: JSON.parse(updated.messageParams) as Record<
-        string,
-        unknown
-      >,
-      metadata: updated.metadata
-        ? (JSON.parse(updated.metadata) as Record<string, unknown>)
-        : null,
-      isRead: updated.isRead,
-      readAt: updated.readAt,
-      createdAt: updated.createdAt,
-    };
-
-    return ok(c, notificationItemSchema.parse(result));
+    return ok(c, notificationItemSchema.parse(mapNotificationToItem(updated)));
   });
 }

--- a/apps/core/src/routes/v1/notifications/delete.ts
+++ b/apps/core/src/routes/v1/notifications/delete.ts
@@ -1,0 +1,56 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+import { notificationFeedWhere } from "@/helpers/notification-feed";
+import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
+import { ok } from "@/helpers/response";
+import prisma from "@/lib/db/prisma";
+import {
+  type OpenAPIHonoWithAuth,
+  withOrganizationSlugHeaderParameter,
+} from "@/lib/hono";
+import { requireOwnerUserContext } from "@/middleware/auth";
+
+const responseSchema = z
+  .object({
+    count: z.number().int().min(0).openapi({
+      description: "Number of notifications deleted",
+      example: 10,
+    }),
+  })
+  .openapi("ClearNotificationsResponse");
+
+const route = withOrganizationSlugHeaderParameter(
+  createRoute({
+    method: "delete",
+    path: "/",
+    description:
+      "Delete every in-app notification-center item for the interactive session user. Scoped by the same feed rule as mark-all-read, so a browser-only kind such as a mention or a direct message is left alone. There is no undo.",
+    tags: ["Notifications"],
+    responses: {
+      200: jsonSuccessResponse(responseSchema, "Notification center cleared", {
+        data: { count: 10 },
+        meta: {
+          timestamp: "2026-06-16T15:00:00.000Z",
+          requestId: "550e8400-e29b-41d4-a716-446655440000",
+        },
+      }),
+      401: jsonErrorResponse("Unauthorized"),
+      500: jsonErrorResponse("Internal Server Error"),
+    },
+  }),
+);
+
+export default function mount(app: OpenAPIHonoWithAuth) {
+  app.openapi(route, async (c) => {
+    const userContext = requireOwnerUserContext(c.var.authContext);
+
+    const result = await prisma.notification.deleteMany({
+      where: {
+        userId: userContext.userId,
+        ...notificationFeedWhere(),
+      },
+    });
+
+    return ok(c, responseSchema.parse({ count: result.count }));
+  });
+}

--- a/apps/core/src/routes/v1/notifications/get.ts
+++ b/apps/core/src/routes/v1/notifications/get.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { type NotificationKind, type Prisma } from "@sokosumi/database";
+import { type Prisma } from "@sokosumi/database";
 
 import { badRequest } from "@/helpers/error";
 import {
@@ -10,6 +10,7 @@ import {
   mergeAccessNotificationExclusions,
   notificationFeedWhere,
 } from "@/helpers/notification-feed";
+import { mapNotificationToItem } from "@/helpers/notification-item";
 import {
   jsonErrorResponse,
   jsonPaginatedSuccessResponse,
@@ -119,39 +120,6 @@ const route = withOrganizationSlugHeaderParameter(
     },
   }),
 );
-
-function mapNotificationToItem(notification: {
-  id: string;
-  userId: string;
-  kind: NotificationKind;
-  referenceId: string;
-  eventId: string;
-  messageKey: string;
-  messageParams: string;
-  metadata: string | null;
-  isRead: boolean;
-  readAt: Date | null;
-  createdAt: Date;
-}) {
-  return {
-    id: notification.id,
-    userId: notification.userId,
-    kind: notification.kind,
-    referenceId: notification.referenceId,
-    eventId: notification.eventId,
-    messageKey: notification.messageKey,
-    messageParams: JSON.parse(notification.messageParams) as Record<
-      string,
-      unknown
-    >,
-    metadata: notification.metadata
-      ? (JSON.parse(notification.metadata) as Record<string, unknown>)
-      : null,
-    isRead: notification.isRead,
-    readAt: notification.readAt,
-    createdAt: notification.createdAt,
-  };
-}
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {

--- a/apps/core/src/routes/v1/notifications/index.ts
+++ b/apps/core/src/routes/v1/notifications/index.ts
@@ -1,5 +1,7 @@
 import { OpenAPIHonoWithAuth } from "@/lib/hono";
+import mountDeleteNotification from "./[id]/delete.js";
 import mountMarkNotificationRead from "./[id]/read/patch.js";
+import mountClearNotifications from "./delete.js";
 import mountGetNotifications from "./get.js";
 import mountMarkAllRead from "./read-all/patch.js";
 import mountGetUnreadCount from "./unread-count/get.js";
@@ -10,5 +12,7 @@ mountGetNotifications(app);
 mountGetUnreadCount(app);
 mountMarkNotificationRead(app);
 mountMarkAllRead(app);
+mountDeleteNotification(app);
+mountClearNotifications(app);
 
 export default app;

--- a/apps/core/src/routes/v1/notifications/mutations.test.ts
+++ b/apps/core/src/routes/v1/notifications/mutations.test.ts
@@ -10,7 +10,9 @@ import { notificationFeedWhere } from "@/helpers/notification-feed";
 import { OpenAPIHonoWithAuth } from "@/lib/hono";
 import type { AuthenticationContext } from "@/middleware/auth";
 
+import mountDeleteNotification from "./[id]/delete";
 import mountMarkNotificationRead from "./[id]/read/patch";
+import mountClearNotifications from "./delete";
 import mountMarkAllRead from "./read-all/patch";
 import mountGetUnreadCount from "./unread-count/get";
 
@@ -26,6 +28,8 @@ const {
   publishClearedNotificationsMock,
   waitUntilPromises,
   notificationCountMock,
+  notificationDeleteManyMock,
+  notificationFindFirstMock,
   notificationFindManyMock,
   notificationFindUniqueMock,
   notificationUpdateManyMock,
@@ -37,6 +41,8 @@ const {
   publishClearedNotificationsMock: vi.fn(),
   waitUntilPromises: [] as Promise<unknown>[],
   notificationCountMock: vi.fn(),
+  notificationDeleteManyMock: vi.fn(),
+  notificationFindFirstMock: vi.fn(),
   notificationFindManyMock: vi.fn(),
   notificationFindUniqueMock: vi.fn(),
   notificationUpdateManyMock: vi.fn(),
@@ -62,6 +68,8 @@ vi.mock("@/lib/db/prisma", () => ({
   default: {
     notification: {
       count: notificationCountMock,
+      deleteMany: notificationDeleteManyMock,
+      findFirst: notificationFindFirstMock,
       findMany: notificationFindManyMock,
       findUnique: notificationFindUniqueMock,
       update: notificationUpdateMock,
@@ -526,5 +534,101 @@ describe("GET /notifications/unread-count", () => {
         },
       },
     });
+  });
+});
+
+describe("DELETE /notifications/{id}", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notificationDeleteManyMock.mockResolvedValue({ count: 1 });
+  });
+
+  it("deletes an owned notification and returns the row it removed", async () => {
+    const existing = createNotificationRow();
+    notificationFindFirstMock.mockResolvedValue(existing);
+
+    const app = createApp(mountDeleteNotification);
+    const response = await app.request("http://localhost/notif_123", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+    expect(notificationDeleteManyMock).toHaveBeenCalledWith({
+      where: { id: "notif_123", userId: "user_123" },
+    });
+
+    const body = (await response.json()) as {
+      data: { id: string; isRead: boolean };
+    };
+    expect(body.data.id).toBe("notif_123");
+    expect(body.data.isRead).toBe(false);
+  });
+
+  it("returns 404 when the notification does not exist", async () => {
+    notificationFindFirstMock.mockResolvedValue(null);
+
+    const app = createApp(mountDeleteNotification);
+    const response = await app.request("http://localhost/notif_missing", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(404);
+    expect(notificationDeleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 and deletes nothing for another user's notification", async () => {
+    // The row is looked up by id and reader together, so another reader's
+    // row reads as missing rather than as forbidden.
+    notificationFindFirstMock.mockResolvedValue(null);
+
+    const app = createApp(mountDeleteNotification);
+    const response = await app.request("http://localhost/notif_other", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(404);
+    expect(notificationFindFirstMock).toHaveBeenCalledWith({
+      where: { id: "notif_other", userId: "user_123" },
+    });
+    expect(notificationDeleteManyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notificationDeleteManyMock.mockResolvedValue({ count: 4 });
+  });
+
+  it("deletes every notification-center row for the authenticated user", async () => {
+    const app = createApp(mountClearNotifications);
+    const response = await app.request("http://localhost/", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+    expect(notificationDeleteManyMock).toHaveBeenCalledWith({
+      where: {
+        userId: "user_123",
+        ...notificationFeedWhere(),
+      },
+    });
+
+    const body = (await response.json()) as { data: { count: number } };
+    expect(body.data.count).toBe(4);
+  });
+
+  it("reports zero when the notification center is already empty", async () => {
+    notificationDeleteManyMock.mockResolvedValue({ count: 0 });
+
+    const app = createApp(mountClearNotifications);
+    const response = await app.request("http://localhost/", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as { data: { count: number } };
+    expect(body.data.count).toBe(0);
   });
 });


### PR DESCRIPTION
## What this changes

The notification center could only be read. A reader marked one row read, or
marked them all read, and nothing removed a row.

Two routes join the existing ones:

- `DELETE /v1/notifications/{id}` removes one row and answers with the row it
  deleted, so the caller can correct its own unread count without a second read.
- `DELETE /v1/notifications` clears the center and answers with the number of
  rows it removed.

Both take the session rule the rest of the notification routes take
(`requireOwnerUserContext`): an interactive human session only. A coworker or a
Soko Bot is rejected, so `X-Context-User-Id` cannot delete a person's
notifications.

The single delete looks a row up by id and reader together, and uses that same
pair to delete it. Another reader's notification therefore reads as missing
rather than as forbidden: the answer never confirms that someone else's row
exists. Clear-all is scoped by the same feed rule mark-all-read uses, so a
browser-only kind such as a mention or a direct message is left alone.

Rows are deleted rather than flagged. Core already deletes notification rows for
resolved vendor grants and coworker access requests, and a hidden flag would add
a second condition beside `inApp` on every list, count and mark-all-read query.
There is no undo, and both route descriptions say so.

The row-to-response mapping moves into one helper, because the list, the
mark-read route and the delete route all answer with the same shape.

## User-facing impact

None on its own. This is the API the two PRs above it call.

## Verification

- `pnpm typecheck` (19/19)
- `pnpm --filter core test`: 486 files passed, 5102 tests passed
- New route tests cover the owner rule, the 404 for another reader's row (with
  nothing deleted), and the feed scoping on clear-all

Part of [SOK-983](https://linear.app/masumi/issue/SOK-983).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete an individual notification.
  * Added the ability to clear all notifications for the authenticated user.
  * Deletion responses now include the deleted notification or affected count.
* **Bug Fixes**
  * Improved notification response consistency, including metadata, read state, identifiers, and timestamps.
  * Unauthorized or missing notifications are handled with appropriate errors.
* **Tests**
  * Added coverage for individual deletion, bulk clearing, successful responses, and unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->