### PR TITLE
fix(web): move getHistoryItemHref off the client

### DIFF
--- a/apps/web/src/app/(app)/components/history-search-dialog.tsx
+++ b/apps/web/src/app/(app)/components/history-search-dialog.tsx
@@ -3,12 +3,12 @@
 import { useRouter } from "next/navigation";
 import { HistorySearchItemStatus } from "@/app/components/history-search-item-status";
 import { useHistorySearchCorpus } from "@/app/components/use-history-search-corpus";
-import { getHistoryItemHref } from "@/app/history/components/history-list-item";
 import {
   HistoryMetaTime,
   HistoryOwnerAvatar,
 } from "@/app/history/components/history-meta";
 import { HistoryTypeIcon } from "@/app/history/components/history-type-icon";
+import { getHistoryItemHref } from "@/app/history/utils/history-item-href";
 import {
   CommandDialog,
   CommandEmpty,

--- a/apps/web/src/app/(app)/history/components/history-list-item.test.tsx
+++ b/apps/web/src/app/(app)/history/components/history-list-item.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  getHistoryItemHref,
   HistoryListItem,
   type HistoryListItemLabels,
 } from "@/app/history/components/history-list-item";
+import { getHistoryItemHref } from "@/app/history/utils/history-item-href";
 import { getHistoryRowSubtitle } from "@/app/history/utils/history-row-subtitle";
 import { TaskStatus } from "@/lib/clients/generated/core";
 import type { HistoryItem } from "@/lib/services/history.service";

--- a/apps/web/src/app/(app)/history/components/history-list-item.tsx
+++ b/apps/web/src/app/(app)/history/components/history-list-item.tsx
@@ -6,16 +6,16 @@ import {
   HistoryOwnerAvatar,
 } from "@/app/history/components/history-meta";
 import { HistoryTypeIcon } from "@/app/history/components/history-type-icon";
+import { getHistoryItemHref } from "@/app/history/utils/history-item-href";
 import { getHistoryRowSubtitle } from "@/app/history/utils/history-row-subtitle";
 import { TaskStatusBadge } from "@/app/tasks/components/task-status-badge";
 import { JobStatusBadge } from "@/components/jobs/job-status-badge";
-import { NotificationKind, TaskStatus } from "@/lib/clients/generated/core";
+import { TaskStatus } from "@/lib/clients/generated/core";
 import type { HistoryItem } from "@/lib/services/history.service";
 import type { SokosumiJobStatus } from "@/lib/types/core-dto";
 import { cn } from "@/lib/utils";
 import { formatCreditsForDisplay } from "@/lib/utils/credits";
 import { useLocalizedDateTime } from "@/lib/utils/datetime.client";
-import { getNotificationHref } from "@/lib/utils/notification-href";
 
 export interface HistoryListItemLabels {
   credit: string;
@@ -148,14 +148,6 @@ function HistoryListItemContent({
 
 export function isArchivedHistoryItem(item: HistoryItem): boolean {
   return item.archivedAt != null;
-}
-
-export function getHistoryItemHref(item: HistoryItem): string {
-  return getNotificationHref({
-    kind: item.kind.toUpperCase() as NotificationKind,
-    referenceId: item.id,
-    metadata: item.kind === "job" ? { agentId: item.agentId } : null,
-  });
 }
 
 export function HistoryTypeColumn({

--- a/apps/web/src/app/(app)/history/utils/history-item-href.ts
+++ b/apps/web/src/app/(app)/history/utils/history-item-href.ts
@@ -1,0 +1,13 @@
+import {
+  type HistoryItem,
+  type NotificationKind,
+} from "@/lib/clients/generated/core";
+import { getNotificationHref } from "@/lib/utils/notification-href";
+
+export function getHistoryItemHref(item: HistoryItem): string {
+  return getNotificationHref({
+    kind: item.kind.toUpperCase() as NotificationKind,
+    referenceId: item.id,
+    metadata: item.kind === "job" ? { agentId: item.agentId } : null,
+  });
+}

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.test.tsx
@@ -1,3 +1,6 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -161,4 +164,51 @@ describe("ProjectNeedsAttentionSection", () => {
     expect(listBox).toHaveClass(...PROJECTS_BROWSE_LAYOUT_CLASS.split(/\s+/));
     expect(listBox).toHaveClass("-mx-4", "md:mx-0");
   });
+
+  it("does not call getHistoryItemHref from a client module", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(
+      join(here, "project-needs-attention-section.tsx"),
+      "utf8",
+    );
+    const specifier = importedModuleSpecifier(source, "getHistoryItemHref");
+    const resolved = resolveAppAlias(specifier, here);
+    const importedSource = readFileSync(resolved, "utf8").trimStart();
+
+    expect(importedSource.startsWith('"use client"')).toBe(false);
+    expect(importedSource.startsWith("'use client'")).toBe(false);
+  });
 });
+
+function importedModuleSpecifier(source: string, exportName: string): string {
+  for (const match of source.matchAll(
+    /import\s+\{([^}]+)\}\s+from\s+["']([^"']+)["']/g,
+  )) {
+    const names = match[1].split(",").map((part) => {
+      const [imported] = part.trim().split(/\s+as\s+/);
+      return imported?.trim();
+    });
+    if (names.includes(exportName)) {
+      return match[2];
+    }
+  }
+
+  throw new Error(`import for ${exportName} not found`);
+}
+
+function resolveAppAlias(specifier: string, fromDir: string): string {
+  if (!specifier.startsWith("@/app/")) {
+    throw new Error(`expected @/app/ import, got ${specifier}`);
+  }
+
+  const appRoot = join(fromDir, "../..");
+  const base = join(appRoot, specifier.slice("@/app/".length));
+  for (const ext of [".ts", ".tsx"]) {
+    const candidate = `${base}${ext}`;
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`could not resolve ${specifier}`);
+}

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.tsx
@@ -102,7 +102,7 @@ function ProjectNeedsAttentionRow({
   item: HistoryItem;
   labels: ProjectNeedsAttentionLabels;
 }) {
-  const href = getHistoryItemHref(item) ?? "/tasks";
+  const href = getHistoryItemHref(item);
 
   return (
     <li>

--- a/apps/web/src/app/(app)/projects/components/project-needs-attention-section.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-needs-attention-section.tsx
@@ -1,9 +1,7 @@
 import Link from "next/link";
 
-import {
-  getHistoryItemHref,
-  HistoryTypeColumn,
-} from "@/app/history/components/history-list-item";
+import { HistoryTypeColumn } from "@/app/history/components/history-list-item";
+import { getHistoryItemHref } from "@/app/history/utils/history-item-href";
 import { ProjectResourceCountPills } from "@/app/projects/components/project-resource-count-pills";
 import {
   PROJECTS_BROWSE_DIVIDE_CLASS,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOKOSUMI-RW.

## What was broken
Project detail RSC render (`POST /projects/[projectId]`) crashed when Needs attention rows rendered. Production error:

`Attempted to call getHistoryItemHref() from the server but getHistoryItemHref is on the client.`

Sentry: https://masumi.sentry.io/issues/SOKOSUMI-RW
Introduced by #4195.

## Root cause
`getHistoryItemHref` is a pure wrapper around server-safe `getNotificationHref`, but it was exported from `history-list-item.tsx` (`"use client"`). Next turns that export into a client reference (`registerClientReference` proxy).

`ProjectNeedsAttentionSection` is a Server Component and **invoked** the helper during render (`const href = getHistoryItemHref(item)`). Rendering a client *component* (`HistoryTypeColumn`) from the server is valid; calling a client-bound *function* is not.

Vitest does not emulate the Next client proxy, so existing section tests stayed green while production RSC threw.

## Fix
Move `getHistoryItemHref` to `apps/web/src/app/(app)/history/utils/history-item-href.ts` (no `"use client"`). Client UI stays in the client file. Callers (`history-list-item`, `history-search-dialog`, `project-needs-attention-section`) import the shared helper. No re-export from the client module.

## Verification
Fail → pass on the same surface:

1. Added a source-boundary test that resolves the `getHistoryItemHref` import from `project-needs-attention-section.tsx` and asserts the target module is not `"use client"`.
2. That test failed while the helper still lived in `history-list-item.tsx` (`expected true to be false` on `startsWith('"use client"')`). Existing render tests still passed (2/3) — they never hit Next’s proxy.
3. After the move: `project-needs-attention-section.test.tsx` and `history-list-item.test.tsx` — 11 passed. `pnpm --filter web typecheck` passed.
4. PR CI green on this head: Test Web, Typecheck, Biome, Build, Validate PR Title.

## Remaining risk
`HistoryTypeColumn` remains a client component rendered from the server (allowed). Other pure helpers still exported from `"use client"` files will fail the same way if a Server Component starts calling them. This test only guards `getHistoryItemHref` at this call site.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d93a34ad-66be-4fb4-b869-5e0aea6156d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d93a34ad-66be-4fb4-b869-5e0aea6156d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

