### PR TITLE
docs(adr): mark 0006 partially superseded by 0024

### DIFF
--- a/docs/adr/0006-stop-agent-browse-and-app-hire.md
+++ b/docs/adr/0006-stop-agent-browse-and-app-hire.md
@@ -1,13 +1,15 @@
 # Stop marketplace Agent browse and app Hire; Jobs live at `/jobs/{jobId}`
 
-The marketplace no longer offers **browse or Hire in the app**. Users must not discover Agents on `/agents` or start a new Job from gallery or Agent detail. **Core Hire APIs stay.** **Hermes** still Hires via orchestrator `POST /v1/agents/{id}/jobs`. **Coworker** still Hires via `POST /v1/tasks/{id}/jobs`. Task UI assigns a Coworker; it does not Hire an Agent. Existing Jobs stay. Canonical Job URL is `/jobs/{jobId}` so Agent detail can be deleted later without moving Jobs again.
+- Status: Partially superseded by [ADR-0024](./0024-restore-agent-catalog-browse-without-app-hire.md). The app Hire ban remains in force; only the “stop agent browse” decision is superseded.
+
+The marketplace no longer offers **browse or Hire in the app**. Users must not discover Agents on `/agents` or start a new Job from gallery or Agent detail. **Core Hire APIs stay.** **Soko Bot (then Hermes)** still Hires via orchestrator `POST /v1/agents/{id}/jobs`. **Coworker** still Hires via `POST /v1/tasks/{id}/jobs`. Task UI assigns a Coworker; it does not Hire an Agent. Existing Jobs stay. Canonical Job URL is `/jobs/{jobId}` so Agent detail can be deleted later without moving Jobs again.
 
 **Why not delete Agent detail now:** Jobs and “your Jobs for this Agent” still hang off `/agents/{id}`. Unlisted detail + list stay this cut; removal is a later decision.
 
 **Why not a flag:** App marketplace Hire is gone, not paused.
 
-**Why Core Hire stays:** External / API clients still Hire. Hermes and Coworker are API clients, not marketplace browse. Only the app marketplace loop ends.
+**Why Core Hire stays:** External / API clients still Hire. Soko Bot (then Hermes) and Coworker are API clients, not marketplace browse. Only the app marketplace loop ends.
 
 **Why `GET /v1/agents` stays public:** Web catalog is removed; the list API is not. Admin Agent tools stay.
 
-**Rejected:** Killing `/agents` (Coworker gallery lives there). 404 on Agent detail this cut. Dual-rendered Job pages. New `/jobs` index. Rejecting Core Hire POSTs. Stopping Hermes or Coworker Hire.
+**Rejected:** Killing `/agents` (Coworker gallery lives there). 404 on Agent detail this cut. Dual-rendered Job pages. New `/jobs` index. Rejecting Core Hire POSTs. Stopping Soko Bot (then Hermes) or Coworker Hire.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Marks ADR 0006 as **partially superseded** by ADR 0024. The app Hire ban from 0006 stays in force; only the “stop agent browse” decision is superseded. Still-true hire sentences now say **Soko Bot (then Hermes)** instead of Hermes.

## Changes

- Status line on `docs/adr/0006-stop-agent-browse-and-app-hire.md` (same `- Status:` pattern as other ADRs).
- Hermes renamed to Soko Bot in hire-related sentences. No hire policy change.

## Verification

Docs-only. Confirmed the Status pattern against existing ADRs (`- Status: Accepted` / `- Status: Superseded by [ADR-0013](...)`). `pnpm check` and `pnpm typecheck` passed on commit.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb91f4dc-e5be-484d-8ed0-f9ccca2b0e40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb91f4dc-e5be-484d-8ed0-f9ccca2b0e40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

