### PR TITLE
chore(env): decouple APP_SIGNING_SECRET from BETTER_AUTH_SECRET

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,7 +413,7 @@ When Neon secrets are absent, provision skips and local Postgres remains the fal
 
 ### `.env` files (gitignored, snapshot-persisted)
 
-`apps/core/.env` and `apps/web/.env` were created from `.env.example` with local fixes so the apps boot past their Zod env validation. Non-obvious edits: DB host `sokosumi`→`localhost` (overwritten by agent DB provision when Neon secrets are present); `RESEND_FROM_EMAIL` defaults to `noreply@sokosumi.com`; invalid `AGENT_HIRED_WEBHOOK` placeholder removed; `BETTER_AUTH_COOKIE_DOMAIN` disabled so session cookies work on `localhost`; web `APP_SIGNING_SECRET` set equal to Core `BETTER_AUTH_SECRET` (required to match).
+`apps/core/.env` and `apps/web/.env` were created from `.env.example` with local fixes so the apps boot past their Zod env validation. Non-obvious edits: DB host `sokosumi`→`localhost` (overwritten by agent DB provision when Neon secrets are present); `RESEND_FROM_EMAIL` defaults to `noreply@sokosumi.com`; invalid `AGENT_HIRED_WEBHOOK` placeholder removed; `BETTER_AUTH_COOKIE_DOMAIN` disabled so session cookies work on `localhost`. Web `APP_SIGNING_SECRET` is independent of Core `BETTER_AUTH_SECRET`.
 
 ### Running & known local gotchas
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pnpm install
 pnpm env:bootstrap
 ```
 
-Copies `apps/web/.env.example` and `apps/core/.env.example` to `.env` when missing, replaces Zod-breaking placeholders, comments production `BETTER_AUTH_COOKIE_DOMAIN` in `.env` (portless injects `sokosumi.localhost` at runtime), and sets web `APP_SIGNING_SECRET` equal to Core `BETTER_AUTH_SECRET`. Grok copies (`.git/grok-worktree-source`) and linked git worktrees reuse the primary checkout `.env` so `BETTER_AUTH_SECRET` / `DATABASE_URL` match — unless the worktree already has a unique secret.
+Copies `apps/web/.env.example` and `apps/core/.env.example` to `.env` when missing, replaces Zod-breaking placeholders, and comments production `BETTER_AUTH_COOKIE_DOMAIN` in `.env` (portless injects `sokosumi.localhost` at runtime). Grok copies (`.git/grok-worktree-source`) and linked git worktrees reuse the primary checkout `.env` so `BETTER_AUTH_SECRET` / `DATABASE_URL` match — unless the worktree already has a unique secret.
 
 One-time on a machine, start the portless HTTPS proxy (port 443, may prompt for sudo) and trust the local CA if `portless doctor` says it is untrusted:
 

--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -155,7 +155,7 @@ Environment variables are accessed via `process.env`, validated at startup with 
 
 - `PORT` — HTTP port (default `8787`; portless injects an ephemeral `4000–4999` port)
 - `WEB_APP_BASE_URL` — Browser origin. Default `http://localhost:3000`; `pnpm portless:dev` / `pnpm portless:core` set this to `pnpm portless:url web`
-- `BETTER_AUTH_SECRET` — Shared with the web Better Auth instance
+- `BETTER_AUTH_SECRET` — Better Auth server secret (sessions, cookies, OAuth state). Independent of web `APP_SIGNING_SECRET`.
 - `BETTER_AUTH_URL` — Public base URL of this Core service; used as Better Auth `baseURL` except on Vercel Preview
 - `VERCEL_ENV`, `VERCEL_URL`, `VERCEL_BRANCH_URL`, `VERCEL_PROJECT_PRODUCTION_URL` — Optional; on Preview, `getBetterAuthPublicBaseUrl()` prefers `VERCEL_BRANCH_URL` over `VERCEL_URL`, and prefers a `*.sokosumi.com` candidate when only one of those is on the preview suffix (see `@sokosumi/utils` `resolveBetterAuthPublicBaseUrl`)
 

--- a/apps/core/README.md
+++ b/apps/core/README.md
@@ -48,7 +48,7 @@ Configuration is validated at startup with Zod (`src/config/env.ts`). Copy `apps
 | -------- | ------- |
 | `DATABASE_URL` | Postgres connection string (Neon pooled URL at runtime on Vercel) |
 | `DATABASE_URL_UNPOOLED` | Injected by the Vercel Neon integration. Non-pooler URL used by `prisma migrate deploy` during the Core build. Not required for local Postgres |
-| `BETTER_AUTH_SECRET` | Shared secret with the web app’s Better Auth config |
+| `BETTER_AUTH_SECRET` | Better Auth server secret (sessions, cookies, OAuth state). Independent of web `APP_SIGNING_SECRET` |
 | `BETTER_AUTH_URL` | Public base URL of **this** Core deployment (e.g. `http://localhost:8787`). Used as Better Auth `baseURL` when not on Vercel Preview |
 | `BETTER_AUTH_COOKIE_DOMAIN` | Optional shared cookie domain for Better Auth cross-subdomain cookies. Leave unset on localhost; set it explicitly in deployed environments that need shared auth cookies |
 | `RESEND_API_KEY` | Resend API key for transactional email |
@@ -251,7 +251,7 @@ All other endpoints require authentication.
 
 ### Authentication Issues
 
-1. Verify `BETTER_AUTH_SECRET` matches the web app and `BETTER_AUTH_URL` reflects the **Core** public URL (on Vercel Preview, confirm `VERCEL_BRANCH_URL` is the sokosumi preview host — via Preview Deployment Suffix — so magic-link cookies work)
+1. Verify `BETTER_AUTH_SECRET` is set and `BETTER_AUTH_URL` reflects the **Core** public URL (on Vercel Preview, confirm `VERCEL_BRANCH_URL` is the sokosumi preview host — via Preview Deployment Suffix — so magic-link cookies work)
 2. Verify the web app’s `CORE_APP_BASE_URL` points at this Core deployment
 3. For browser calls from the web app, confirm the page origin is allowlisted for CORS and Better Auth `trustedOrigins` (see **CORS Configuration** above)
 4. Verify coworker callers use dedicated `coworker_*` API keys where applicable

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,7 +21,7 @@ CORE_APP_BASE_URL="http://localhost:8787"
 # fail / stay on the old binary.
 # CHROMIUM_EXECUTABLE_URL="https://github.com/Sparticuz/chromium/releases/download/v152.0.0/chromium-v152.0.0-pack.x64.tar"
 
-# APP_SIGNING_SECRET: HMAC secret for design-md job tokens; must match Core BETTER_AUTH_SECRET.
+# APP_SIGNING_SECRET: HMAC secret for DESIGN.md job tokens (web-only).
 APP_SIGNING_SECRET=<app-signing-secret>
 # Optional — defaults to 100 when unset.
 # ORG_INVITATION_LIMIT=100

--- a/apps/web/src/config/env.secrets.ts
+++ b/apps/web/src/config/env.secrets.ts
@@ -49,7 +49,7 @@ const envSecretsSchema = z.object({
     .url()
     .default("https://www.masumi.network/api/v1"),
 
-  // Shared signing secret (must match Core BETTER_AUTH_SECRET).
+  // HMAC secret for DESIGN.md job tokens (web-only).
   APP_SIGNING_SECRET: z.string().min(1),
 
   // Max pending invitations per organization (optional; default 100).

--- a/scripts/local-env/bootstrap.mjs
+++ b/scripts/local-env/bootstrap.mjs
@@ -2,9 +2,9 @@
 /**
  * Copy apps/{web,core}/.env.example → .env when missing, then make the
  * files bootable for local / worktree agents (Zod-safe dummies, cookie-domain
- * trap, matching signing secret). Grok/git worktrees reuse the primary
- * checkout .env (BETTER_AUTH_SECRET, DATABASE_URL, …) unless the worktree
- * already has a unique secret. Does not overwrite that unique secret.
+ * trap). Grok/git worktrees reuse the primary checkout .env
+ * (BETTER_AUTH_SECRET, DATABASE_URL, …) unless the worktree already has a
+ * unique secret. Does not overwrite that unique secret.
  *
  * Usage: node scripts/local-env/bootstrap.mjs
  */
@@ -30,7 +30,7 @@ const OPTIONAL_URL_KEYS = new Set([
 ]);
 
 const STRING_DUMMIES = {
-  APP_SIGNING_SECRET: DEFAULT_BETTER_AUTH_SECRET,
+  APP_SIGNING_SECRET: "dummy-app-signing-secret",
   GOOGLE_CLIENT_ID: "dummy-google-client-id",
   GOOGLE_CLIENT_SECRET: "dummy-google-client-secret",
   MICROSOFT_CLIENT_ID: "dummy-microsoft-client-id",
@@ -171,26 +171,6 @@ export function readEnvValue(contents, key) {
 }
 
 /**
- * @param {string} webContents
- * @param {string} coreContents
- */
-export function syncSigningSecret(webContents, coreContents) {
-  const secret =
-    readEnvValue(coreContents, "BETTER_AUTH_SECRET") ||
-    DEFAULT_BETTER_AUTH_SECRET;
-  if (readEnvValue(webContents, "APP_SIGNING_SECRET") === secret) {
-    return webContents;
-  }
-  if (/^APP_SIGNING_SECRET=/m.test(webContents)) {
-    return webContents.replace(
-      /^APP_SIGNING_SECRET=.*$/m,
-      `APP_SIGNING_SECRET="${secret}"`,
-    );
-  }
-  return `${webContents.trimEnd()}\nAPP_SIGNING_SECRET="${secret}"\n`;
-}
-
-/**
  * @param {string | null} contents
  */
 async function tryRead(file) {
@@ -313,8 +293,6 @@ export async function bootstrapLocalEnv(repoRoot) {
 
     written[app] = sanitizeEnvContents(source);
   }
-
-  written.web = syncSigningSecret(written.web, written.core);
 
   await writeFile(
     path.join(repoRoot, "apps", "core", ".env"),

--- a/scripts/local-env/bootstrap.test.mjs
+++ b/scripts/local-env/bootstrap.test.mjs
@@ -12,7 +12,6 @@ import {
   resolvePrimaryEnvRoot,
   sanitizeEnvContents,
   shouldReusePrimaryEnv,
-  syncSigningSecret,
 } from "./bootstrap.mjs";
 
 describe("isPlaceholderValue", () => {
@@ -92,16 +91,6 @@ describe("sanitizeEnvContents", () => {
   });
 });
 
-describe("syncSigningSecret", () => {
-  it("copies Core BETTER_AUTH_SECRET onto web APP_SIGNING_SECRET", () => {
-    const web = syncSigningSecret(
-      'APP_SIGNING_SECRET="<app-signing-secret>"\n',
-      'BETTER_AUTH_SECRET="shared-secret"\n',
-    );
-    assert.match(web, /^APP_SIGNING_SECRET="shared-secret"$/m);
-  });
-});
-
 describe("bootstrapLocalEnv", () => {
   it("creates .env from examples and sanitizes both apps", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "sokosumi-env-"));
@@ -137,7 +126,7 @@ describe("bootstrapLocalEnv", () => {
     assert.match(core, /^# BETTER_AUTH_COOKIE_DOMAIN=/m);
     assert.match(core, /^# COMPOSIO_API_KEY=/m);
     assert.match(core, /@localhost:5432/);
-    assert.match(web, /^APP_SIGNING_SECRET="core-secret"$/m);
+    assert.match(web, /^APP_SIGNING_SECRET="dummy-app-signing-secret"$/m);
     assert.match(web, /^# NEXT_PUBLIC_SENTRY_DSN=/m);
     assert.match(web, /^CORE_APP_BASE_URL="http:\/\/localhost:8787"$/m);
     assert.equal(paths.reusedFrom, null);
@@ -282,7 +271,7 @@ describe("bootstrapLocalEnv primary reuse", () => {
     assert.match(core, /^BETTER_AUTH_SECRET="primary-secret"$/m);
     assert.match(core, /neondb_owner@db.example/);
     assert.match(core, /^# BETTER_AUTH_COOKIE_DOMAIN=/m);
-    assert.match(web, /^APP_SIGNING_SECRET="primary-secret"$/m);
+    assert.match(web, /^APP_SIGNING_SECRET="stale-web-secret"$/m);
   });
 
   it("replaces a worktree .env that still has the example secret", async () => {


### PR DESCRIPTION
## Summary

Stop treating web `APP_SIGNING_SECRET` and Core `BETTER_AUTH_SECRET` as the same secret.

- `pnpm env:bootstrap` no longer copies Core `BETTER_AUTH_SECRET` onto web `APP_SIGNING_SECRET`.
- Docs and env comments no longer say they must match.
- Web job-token HMAC stays independent so rotating Better Auth does not clobber in-flight DESIGN.md tokens.

No product behavior change. Auth still lives only on Core.

## Verification

- `pnpm local-env:test`
- husky precommit: `pnpm check && pnpm typecheck`