### PR TITLE
ci(apple): seed Mint cache on main

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -5,6 +5,15 @@ permissions:
 on:
   workflow_dispatch:
   pull_request:
+  # Lint on main after Apple merges so the Mint cache is saved on the default
+  # branch. PR caches are scoped to refs/pull/N/merge and cannot be restored
+  # by sibling PRs.
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/apple/**"
+      - ".github/workflows/apple.yml"
 
 jobs:
   changes:
@@ -38,7 +47,9 @@ jobs:
   build:
     name: Xcode build
     needs: changes
-    if: needs.changes.outputs.apple == 'true' || github.event_name == 'workflow_dispatch'
+    # PR (Apple paths) or dispatch only. Skip `push` — main push exists to seed
+    # the Mint cache via `lint` (PR caches are ref-scoped).
+    if: (github.event_name == 'pull_request' && needs.changes.outputs.apple == 'true') || github.event_name == 'workflow_dispatch'
     # Packages declare `swift-tools-version: 6.2`, which needs Xcode 26 (macOS 26).
     runs-on: macos-26
     steps:
@@ -59,10 +70,10 @@ jobs:
 
   test:
     name: Xcode test
-    # Same path/dispatch gate as `build` above (and as build.yml/test.yml
+    # Same PR/dispatch gate as `build` above (and as build.yml/test.yml
     # for the JS apps): build and test run in parallel, neither waits.
     needs: changes
-    if: needs.changes.outputs.apple == 'true' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'pull_request' && needs.changes.outputs.apple == 'true') || github.event_name == 'workflow_dispatch'
     runs-on: macos-26
     steps:
       - name: Checkout repository
@@ -93,8 +104,9 @@ jobs:
   lint:
     name: Swift lint and format
     needs: changes
-    # Same path/dispatch gate as `build`/`test` above.
-    if: needs.changes.outputs.apple == 'true' || github.event_name == 'workflow_dispatch'
+    # Same PR/dispatch gate as `build`/`test`, plus path-filtered `push` to
+    # main so `actions/cache` saves ~/.mint on the default branch.
+    if: needs.changes.outputs.apple == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     runs-on: macos-26
     steps:
       - name: Checkout repository

--- a/apps/apple/AGENTS.md
+++ b/apps/apple/AGENTS.md
@@ -43,7 +43,7 @@ No ad-hoc signing assets live in CI: every `xcodebuild` invocation overrides wit
 
 - Swift package tests run via `swift test --package-path Packages/<name>`; app-target tests via `xcodebuild test -only-testing:SokosumiTests`.
 - Fake Core HTTP at the OpenAPI `ClientTransport` boundary. Do not test SwiftUI layout, Keychain, or `ASWebAuthenticationSession` as the required suite.
-- Apple CI (`.github/workflows/apple.yml`) runs build + tests in parallel on `macos-26` for PRs touching `apps/apple/**` (or manual dispatch), including drafts. Lint/format is a separate job with the same gate.
+- Apple CI (`.github/workflows/apple.yml`) runs build + tests in parallel on `macos-26` for PRs touching `apps/apple/**` (or manual dispatch), including drafts. Lint/format is a separate job with that same PR/dispatch gate, plus path-filtered pushes to `main` so the Mint binary cache is saved on the default branch.
 
 ## App-Specific Gotchas
 


### PR DESCRIPTION
Apple lint currently caches `~/.mint` under a Mintfile-hash key, but `apple.yml` never runs on `main`. GitHub scopes cache entries by ref, so each PR saves a copy on `refs/pull/N/merge` that sibling PRs cannot restore. Cold lint then compiles SwiftLint/SwiftFormat from source (~17 min vs ~24 s on a hit).

## Changes
- Path-filtered `push` to `main` (`apps/apple/**`, `apple.yml`) so lint can save the Mint cache on the default branch
- `build` / `test` stay PR-or-dispatch only (no extra Xcode jobs on main)
- `apps/apple/AGENTS.md` lint-gate sentence updated to match

Cache key, path, and `actions/cache` step are unchanged. No `restore-keys`, no restore/save split.

## Verification
- Parsed `.github/workflows/apple.yml` as YAML
- After merge, the `apple.yml` change itself triggers lint on `main` and writes `macOS-mint-<Mintfile hash>` on `refs/heads/main`; later Apple PRs restore that entry
- First main lint run is still a cold compile (no default-branch entry yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apple CI workflows to run linting for relevant changes pushed to the main branch.
  * Limited Apple build and test jobs to applicable pull requests and manual runs.
  * Enabled Mint cache seeding to improve workflow efficiency.

* **Documentation**
  * Updated Apple CI documentation to reflect the revised workflow triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->