### PR TITLE
feat(apple): preserve room composer drafts

### DIFF
--- a/apps/apple/Packages/SokosumiChat/Sources/SokosumiChat/SavedComposeDraft.swift
+++ b/apps/apple/Packages/SokosumiChat/Sources/SokosumiChat/SavedComposeDraft.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Local text drafts, isolated by account, workspace, and room.
+public struct SavedComposeDraft {
+  private let defaults: UserDefaults
+  private let key: String
+
+  public init(
+    userId: String,
+    organizationId: String?,
+    roomId: String,
+    defaults: UserDefaults = .standard
+  ) {
+    self.defaults = defaults
+    // Length prefixes avoid collisions even when identifiers contain separators.
+    let parts = [userId, organizationId == nil ? "personal" : "organization", organizationId ?? "", roomId]
+    key = "sokosumi.composeDraft.v1." + parts.map { "\($0.utf8.count):\($0)" }.joined()
+  }
+
+  public func load() -> String {
+    defaults.string(forKey: key) ?? ""
+  }
+
+  public func save(_ text: String) {
+    if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      defaults.removeObject(forKey: key)
+    } else {
+      defaults.set(text, forKey: key)
+    }
+  }
+}

--- a/apps/apple/Packages/SokosumiChat/Tests/SokosumiChatTests/SavedComposeDraftTests.swift
+++ b/apps/apple/Packages/SokosumiChat/Tests/SokosumiChatTests/SavedComposeDraftTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+@testable import SokosumiChat
+import Testing
+
+@Test func composeDraftRestoresExactTextAndClearsEmptyDrafts() throws {
+  let suiteName = "compose-draft-tests-\(UUID().uuidString)"
+  let defaults = try #require(UserDefaults(suiteName: suiteName))
+  defer { defaults.removePersistentDomain(forName: suiteName) }
+  let draft = SavedComposeDraft(userId: "me", organizationId: nil, roomId: "room", defaults: defaults)
+  #expect(draft.load().isEmpty)
+  draft.save("  Unsent\nmessage 👋  ")
+  let reopened = SavedComposeDraft(userId: "me", organizationId: nil, roomId: "room", defaults: defaults)
+  #expect(reopened.load() == "  Unsent\nmessage 👋  ")
+  reopened.save("")
+  #expect(draft.load().isEmpty)
+  draft.save("   \n")
+  #expect(draft.load().isEmpty)
+}
+
+@Test func composeDraftsStayIsolatedAcrossAccountsWorkspacesAndRooms() throws {
+  let suiteName = "compose-draft-tests-\(UUID().uuidString)"
+  let defaults = try #require(UserDefaults(suiteName: suiteName))
+  defer { defaults.removePersistentDomain(forName: suiteName) }
+  struct Scope {
+    let userId: String
+    let organizationId: String?
+    let roomId: String
+  }
+  let scopes: [Scope] = [
+    .init(userId: "me", organizationId: nil, roomId: "room"),
+    .init(userId: "other", organizationId: nil, roomId: "room"),
+    .init(userId: "me", organizationId: "org", roomId: "room"),
+    .init(userId: "me", organizationId: "personal", roomId: "room"),
+    .init(userId: "me", organizationId: nil, roomId: "other-room"),
+    .init(userId: "me:org", organizationId: "room", roomId: "other"),
+    .init(userId: "me", organizationId: "org:room", roomId: "other")
+  ]
+  let drafts = scopes.map {
+    SavedComposeDraft(userId: $0.userId, organizationId: $0.organizationId, roomId: $0.roomId, defaults: defaults)
+  }
+  for (index, draft) in drafts.enumerated() {
+    draft.save("Draft \(index)")
+  }
+  for (index, draft) in drafts.enumerated() {
+    #expect(draft.load() == "Draft \(index)")
+  }
+  drafts[0].save("")
+  #expect(drafts[1].load() == "Draft 1")
+}

--- a/apps/apple/Sokosumi/TranscriptView.swift
+++ b/apps/apple/Sokosumi/TranscriptView.swift
@@ -15,7 +15,6 @@ private let messageTimeFormatter: DateFormatter = {
 struct TranscriptView: View {
   @EnvironmentObject private var workspaces: WorkspaceState
   @EnvironmentObject private var auth: AuthState
-  @State private var draft = ""
   /// Eager first layout can report near-top before the bottom anchor
   /// lands. Require a trip away from the top before auto-loading.
   @State private var transcriptWasAwayFromTop = false
@@ -38,7 +37,12 @@ struct TranscriptView: View {
       }
       transcriptBody
       Divider()
-      composer
+      RoomComposer(
+        userId: workspaces.currentUserId,
+        organizationId: workspaces.selection?.workspace.organizationId,
+        roomId: roomId
+      )
+      .id([workspaces.currentUserId, workspaces.selectionId ?? "", roomId])
     }
     .onChange(of: roomId) { _, _ in
       transcriptWasAwayFromTop = false
@@ -162,6 +166,24 @@ struct TranscriptView: View {
       Button("Retry", action: retry)
     }
   }
+}
+
+/// Owns typing state so edits do not invalidate the transcript. The parent
+/// gives each account/workspace/room a distinct identity before loading its draft.
+private struct RoomComposer: View {
+  @EnvironmentObject private var workspaces: WorkspaceState
+  @EnvironmentObject private var auth: AuthState
+  @State private var draft: String
+
+  private let savedDraft: SavedComposeDraft
+  private let roomId: String
+
+  init(userId: String, organizationId: String?, roomId: String) {
+    self.roomId = roomId
+    let savedDraft = SavedComposeDraft(userId: userId, organizationId: organizationId, roomId: roomId)
+    self.savedDraft = savedDraft
+    _draft = State(initialValue: savedDraft.load())
+  }
 
   private var canSend: Bool {
     !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -170,11 +192,17 @@ struct TranscriptView: View {
       && workspaces.transcriptRoomId == roomId
   }
 
-  private var composer: some View {
+  var body: some View {
     HStack {
-      TextField("Message", text: $draft)
-        .textFieldStyle(.roundedBorder)
-        .onSubmit(sendDraft)
+      TextField("Message", text: Binding(
+        get: { draft },
+        set: { text in
+          draft = text
+          savedDraft.save(text)
+        }
+      ))
+      .textFieldStyle(.roundedBorder)
+      .onSubmit(sendDraft)
       Button("Send", action: sendDraft)
         .disabled(!canSend)
     }
@@ -185,6 +213,7 @@ struct TranscriptView: View {
     guard canSend else { return }
     let content = draft
     draft = ""
+    savedDraft.save("")
     workspaces.sendMessage(content, auth: auth)
   }
 }

--- a/apps/apple/Sokosumi/WorkspaceState.swift
+++ b/apps/apple/Sokosumi/WorkspaceState.swift
@@ -265,12 +265,13 @@ final class WorkspaceState: ObservableObject {
     }
     realtimeAuth = auth
     let instanceId = ablyClientInstanceId
+    let baseURL = CoreSettings.baseURL
     // Sendable by construction: the session actor plus values only, never
     // MainActor state. The slug rides as a parameter because switches
     // retarget it after connect.
     let provider: RealtimeTokenProvider = { slug in
       let client = Client.connecting(
-        to: CoreSettings.baseURL,
+        to: baseURL,
         middlewares: [
           BearerAuthMiddleware(session: session),
           ExplicitNullPreferredOrganizationMiddleware()


### PR DESCRIPTION
Switching rooms currently carries the same unsent text into the next conversation, and closing the app loses it. The native composer now saves text locally per account, workspace, and room and restores it when that conversation reopens. Sending clears only that draft; failed sends keep the existing retry/remove flow.

This is the first feature in the web-to-Apple chat parity work, matching web `usePersistComposeDraft` text persistence. Typing state lives in the composer so it does not invalidate the transcript. This PR covers text drafts; attachments belong to the later file-composer feature. No API or dependency changes.

### Verification

- `swift test --package-path Packages/SokosumiChat`: 80 tests passed, including draft restoration, whitespace clearing, and account/workspace/room isolation.
- `mint run swiftformat --lint .`: passed.
- `mint run swiftlint lint --strict`: passed.
- Ad-hoc macOS Debug build: passed.
- `xcodebuild test -only-testing:SokosumiTests -enableCodeCoverage NO` with the repository destination/signing flags: passed. Coverage is disabled as in existing Apple CI because Ably C dependencies cannot link the profiling runtime.
- Independent code review: no actionable findings.
- Screenshot/manual room-switch verification remains pending: native UI automation timed out. The composer layout is unchanged.
- Root Husky hook skipped for this Swift-only change; native checks above were run instead. This checkout has no Node dependencies installed.

### Sequence

One feature per PR. Wait for this PR to merge before starting the next Apple chat feature. Remaining areas from the web review include rich composition, threads, reactions, message actions, search, room management, files, and assistant flows; iOS will use the shared packages with native UI per the Apple vision.
