### PR TITLE
ci(apple): run app and package tests in parallel

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -68,13 +68,27 @@ jobs:
       - name: Build Sokosumi for macOS
         run: xcodebuild -project apps/apple/Sokosumi.xcodeproj -scheme Sokosumi -configuration Debug -destination 'platform=macOS,arch=arm64' -skipPackagePluginValidation DEVELOPMENT_TEAM= CODE_SIGN_IDENTITY=- build
 
-  test:
-    name: Xcode test
+  test-suite:
+    name: ${{ matrix.name }}
     # Same PR/dispatch gate as `build` above (and as build.yml/test.yml
     # for the JS apps): build and test run in parallel, neither waits.
     needs: changes
     if: (github.event_name == 'pull_request' && needs.changes.outputs.apple == 'true') || github.event_name == 'workflow_dispatch'
     runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Xcode app tests
+            package: ""
+          - name: Swift tests (SokosumiChat)
+            package: SokosumiChat
+          - name: Swift tests (SokosumiAuth)
+            package: SokosumiAuth
+          - name: Swift tests (CoreAPI)
+            package: CoreAPI
+          - name: Swift tests (SokosumiRealtime)
+            package: SokosumiRealtime
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -89,17 +103,30 @@ jobs:
         run: xcodebuild -version && swift --version
 
       - name: Test Sokosumi app target
+        if: matrix.package == ''
         # Coverage stays off: ably-cocoa's C target (AblyDeltaCodec) cannot
         # link the profile runtime, so gathering coverage fails the test
         # build (SOK-976). Nothing consumes coverage today. Restore later by
         # excluding AblyDeltaCodec, not by re-enabling coverage on this job.
         run: xcodebuild test -project apps/apple/Sokosumi.xcodeproj -scheme Sokosumi -configuration Debug -destination 'platform=macOS,arch=arm64' -skipPackagePluginValidation DEVELOPMENT_TEAM= CODE_SIGN_IDENTITY=- -only-testing:SokosumiTests -enableCodeCoverage NO
 
-      - name: Test Swift packages
-        run: |
-          for package in apps/apple/Packages/SokosumiChat apps/apple/Packages/SokosumiAuth apps/apple/Packages/CoreAPI apps/apple/Packages/SokosumiRealtime; do
-            swift test --package-path "$package"
-          done
+      - name: Test Swift package
+        if: matrix.package != ''
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: swift test --package-path "apps/apple/Packages/$PACKAGE"
+
+  # Preserve the existing check name and require every suite to pass.
+  test:
+    name: Xcode test
+    needs: test-suite
+    if: always() && needs.test-suite.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all Apple test suites
+        env:
+          RESULT: ${{ needs.test-suite.result }}
+        run: test "$RESULT" = success
 
   lint:
     name: Swift lint and format


### PR DESCRIPTION
Apple CI took 13m 23s on PR #4300 because app tests and four local package suites ran sequentially. Run those five suites in parallel matrix jobs, retaining the same test commands, toolchain, and signing settings. The existing `Xcode test` check remains an aggregate gate that succeeds only when every suite passes; failures do not cancel the remaining suites.

This improves elapsed time through concurrency, not by skipping tests or reducing compilation. The previous slowest step was about five minutes, so that is the expected test duration before runner queue/setup overhead. Actual timing must be measured in CI. More macOS runners execute concurrently.

Validation: actionlint 1.7.12 passed; all 68 existing CI tests passed; independent review found no actionable issues. No app code changes.
