### PR TITLE
fix(web): add md:pt-4 to shared task aside

### DIFF
--- a/apps/web/src/app/(app)/tasks/__tests__/task-detail-layout-contract.test.ts
+++ b/apps/web/src/app/(app)/tasks/__tests__/task-detail-layout-contract.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   TASK_DETAIL_GRID_CLASS,
   TASK_DETAIL_SHELL_CLASS,
+  TASK_DETAIL_SIDEBAR_CLASS,
 } from "@/app/tasks/constants";
 
 const tasksDir = path.resolve(
@@ -75,7 +76,7 @@ describe("task detail layout contract", () => {
       'className={cn("space-y-4 md:pt-4", APP_MAIN_MOBILE_PT_CLASS)}',
     );
     const sidebarIdx = share.indexOf(
-      "<aside className={TASK_DETAIL_SIDEBAR_CLASS}>",
+      '<aside className={cn(TASK_DETAIL_SIDEBAR_CLASS, "md:pt-4")}>',
     );
     const filesIdx = share.indexOf("<TaskFiles");
 
@@ -91,5 +92,12 @@ describe("task detail layout contract", () => {
     expect(share).not.toContain("md:hidden");
     expect(share).not.toContain("sticky top-20");
     expect(share).toContain("TASK_DETAIL_SIDEBAR_CLASS");
+  });
+
+  it("share view aside applies md:pt-4 without padding the shared sidebar constant", () => {
+    const share = readFileSync(shareViewPath, "utf8");
+
+    expect(share).toContain('cn(TASK_DETAIL_SIDEBAR_CLASS, "md:pt-4")');
+    expect(TASK_DETAIL_SIDEBAR_CLASS).not.toContain("pt-");
   });
 });

--- a/apps/web/src/app/share/components/shared-task-view.test.tsx
+++ b/apps/web/src/app/share/components/shared-task-view.test.tsx
@@ -52,4 +52,12 @@ describe("SharedTaskView", () => {
     expect(screen.queryByText(/BRIEFING.md/)).not.toBeInTheDocument();
     expect(screen.queryByText(/DESIGN.md/)).not.toBeInTheDocument();
   });
+
+  it("applies md:pt-4 on the metadata aside", async () => {
+    const { container } = render(await SharedTaskView({ task }));
+    const aside = container.querySelector("aside");
+
+    expect(aside).not.toBeNull();
+    expect(aside?.className.split(/\s+/)).toContain("md:pt-4");
+  });
 });

--- a/apps/web/src/app/share/components/shared-task-view.tsx
+++ b/apps/web/src/app/share/components/shared-task-view.tsx
@@ -162,7 +162,9 @@ export async function SharedTaskView({ task }: SharedTaskViewProps) {
           </section>
         </div>
 
-        <aside className={TASK_DETAIL_SIDEBAR_CLASS}>{propertiesPanel}</aside>
+        <aside className={cn(TASK_DETAIL_SIDEBAR_CLASS, "md:pt-4")}>
+          {propertiesPanel}
+        </aside>
 
         <div className={cn(TASK_DETAIL_MAIN_CLASS, "pb-20")}>
           <TaskFiles title={tTaskDetail("files")} files={task.files ?? []} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

On the shared task view, the metadata column sat flush with the shell top while the left header used `md:pt-4`. Status and coworker therefore sat higher than `PUBLIC TASK` on `xl+`.

Auth task detail does not show this gap because `authenticated-app-frame` already pads the whole main. The fix is share-only.

## Scope

- `shared-task-view.tsx`: `cn(TASK_DETAIL_SIDEBAR_CLASS, "md:pt-4")` on the aside
- Layout contract + `SharedTaskView` DOM tests for the inset
- Out of scope: `TASK_DETAIL_SIDEBAR_CLASS` itself (would double-pad auth)

## Tradeoffs

Rejected padding the shared sidebar constant. Auth already insets both columns via the frame.

## Blast Radius

Only the public share task layout. Auth `/tasks/[taskId]` is unchanged.

## Verification

- Contract test red without the class, green with it
- DOM test: aside `classList` contains `md:pt-4`
- Live share page at 1440px: computed `padding-top: 16px`; Status and PUBLIC TASK tops within 2px

[Before: aside flush with shell](https://cursor.com/agents/bc-1e34d927-5723-40e8-88cf-2790492c6a51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshared-view-aside-before.png)
[After: aside md:pt-4 aligns with left header](https://cursor.com/agents/bc-1e34d927-5723-40e8-88cf-2790492c6a51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshared-view-aside-pt4-after.png)
[shared-view-aside-pt4-demo.mp4](https://cursor.com/agents/bc-1e34d927-5723-40e8-88cf-2790492c6a51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshared-view-aside-pt4-demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e34d927-5723-40e8-88cf-2790492c6a51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e34d927-5723-40e8-88cf-2790492c6a51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

