### PR TITLE
fix(web): style task status select as status pill

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
@@ -132,7 +132,7 @@ export function TaskMetadataStatusField({
           <SelectValue>
             <span
               className={cn(
-                "inline-flex items-center gap-1 rounded-sm px-2.5 py-1 text-xs font-medium leading-none",
+                "inline-flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs font-medium",
                 pillTone.bg,
                 pillTone.text,
               )}

--- a/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { userTaskStatusTransitionRequiresComment } from "@sokosumi/utils";
-import { Loader2 } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -16,10 +16,11 @@ import {
 } from "@/components/ui/select";
 import { setTaskStatusFromDrag } from "@/lib/actions/task/action";
 import { TaskStatus } from "@/lib/clients/generated/core";
+import { cn } from "@/lib/utils";
 import { TASK_STATUS_DISPLAY_ORDER } from "@/lib/utils/task-status-order";
 
 import { TaskReopenToReadyDialog } from "./task-reopen-to-ready-dialog";
-import { TaskStatusBadge } from "./task-status-badge";
+import { getTaskStatusPillTone } from "./task-status-badge";
 
 export interface TaskMetadataStatusFieldLabels {
   statusLabels: Record<TaskStatus, string>;
@@ -108,6 +109,8 @@ export function TaskMetadataStatusField({
 
   const displayStatus =
     isPending && pendingStatus ? pendingStatus : currentStatus;
+  const displayLabel = labels.statusLabels[displayStatus];
+  const pillTone = getTaskStatusPillTone(displayStatus);
 
   return (
     <>
@@ -117,19 +120,28 @@ export function TaskMetadataStatusField({
         disabled={isPending}
       >
         <SelectTrigger
-          aria-label={labels.statusLabels[displayStatus]}
-          className="h-auto w-auto min-w-[8rem] border-0 bg-transparent p-0 shadow-none focus:ring-0"
+          aria-label={displayLabel}
+          className={cn(
+            "h-auto w-auto gap-0 border-0 bg-transparent p-0 shadow-none",
+            "dark:bg-transparent dark:hover:bg-transparent",
+            "focus-visible:border-transparent focus-visible:ring-0",
+            "data-[size=default]:h-auto",
+            "[&>svg]:hidden",
+          )}
         >
           <SelectValue>
-            <span className="inline-flex items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-sm px-2.5 py-1 text-xs font-medium leading-none",
+                pillTone.bg,
+                pillTone.text,
+              )}
+            >
               {isPending ? (
-                <Loader2 className="size-3.5 animate-spin" aria-hidden />
+                <Loader2 className="size-3 animate-spin" aria-hidden />
               ) : null}
-              <TaskStatusBadge
-                status={displayStatus}
-                label={labels.statusLabels[displayStatus]}
-                showLabel
-              />
+              <span>{displayLabel}</span>
+              <ChevronDown className="size-3 opacity-70" aria-hidden />
             </span>
           </SelectValue>
         </SelectTrigger>

--- a/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
@@ -122,9 +122,8 @@ export function TaskMetadataStatusField({
         <SelectTrigger
           aria-label={displayLabel}
           className={cn(
-            "h-auto w-auto gap-0 border-0 bg-transparent p-0 shadow-none",
+            "h-auto w-auto gap-0 rounded-sm border-0 bg-transparent p-0 shadow-none",
             "dark:bg-transparent dark:hover:bg-transparent",
-            "focus-visible:border-transparent focus-visible:ring-0",
             "data-[size=default]:h-auto",
             "[&>svg]:hidden",
           )}

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
@@ -330,8 +330,17 @@ describe("TaskMetadata", () => {
       statusFieldLabels: { ...baseStatusFieldLabels, statusLabels },
     });
 
-    expect(
-      screen.getByRole("combobox", { name: "Running" }),
-    ).toBeInTheDocument();
+    const trigger = screen.getByRole("combobox", { name: "Running" });
+    expect(trigger).toBeInTheDocument();
+
+    const pill = trigger.querySelector("span.inline-flex");
+    expect(pill).toHaveClass(
+      "bg-emerald-500/10",
+      "rounded-sm",
+      "px-2.5",
+      "py-1",
+      "text-xs",
+    );
+    expect(pill?.textContent).toContain("Running");
   });
 });

--- a/apps/web/src/app/(app)/tasks/components/task-status-badge.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-status-badge.tsx
@@ -95,8 +95,22 @@ const STATUS_PILL_STYLES: Partial<
   },
 };
 
+export function getTaskStatusPillTone(status: TaskStatus): {
+  bg: string;
+  text: string;
+  dot: string;
+} {
+  return (
+    STATUS_PILL_STYLES[status] ?? {
+      bg: "bg-muted",
+      text: "text-muted-foreground",
+      dot: "bg-muted-foreground",
+    }
+  );
+}
+
 export function getTaskStatusDotColorClass(status: TaskStatus): string {
-  return STATUS_PILL_STYLES[status]?.dot ?? "bg-muted-foreground";
+  return getTaskStatusPillTone(status).dot;
 }
 
 export function getTaskStatusBorderColorClass(status: TaskStatus): string {
@@ -143,11 +157,7 @@ export function TaskStatusBadge({
   showDot,
   showLabel = true,
 }: TaskStatusBadgeProps) {
-  const styles = STATUS_PILL_STYLES[status] ?? {
-    bg: "bg-muted",
-    text: "text-muted-foreground",
-    dot: "bg-muted-foreground",
-  };
+  const styles = getTaskStatusPillTone(status);
   const showIcon = shouldShowWarningIcon(status);
   const showStatusDot = shouldShowStatusDot(showDot);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Styles the editable task status control as a status pill matching `TaskStatusBadge`, then restores the shared `SelectTrigger` keyboard focus ring after Codex P1.

## Changes

- Drop nested trigger chrome around the status pill
- Remove `focus-visible:ring-0` / transparent border overrides so `SelectTrigger` focus styles (`focus-visible:ring-ring/50 focus-visible:ring-[3px]`) apply again
- Keep pill radius with `rounded-sm` on the trigger

## Linear

SOK-1028

## Verification

- Local: `pnpm --filter web exec biome check src/app/(app)/tasks/components/task-metadata-status-field.tsx` (exit 0)
- Local: `pnpm --filter web test src/app/(app)/tasks/components/task-metadata.test.tsx` (11 passed)
- Asserted `focus-visible:ring-0` removed; base `SelectTrigger` still provides the ring
- CI: green on head `edddb7255`
- Bugbot: 0 High, 0 Medium
- Codex P1 thread: replied + resolved

## Test plan

- [x] Codex focus-indicator finding addressed and thread resolved
- [x] CI green
- [x] Bugbot High = 0
- [ ] Human: Tab to task metadata status select on a preview and confirm visible focus ring (local UI drive blocked: no Neon secrets / VERIFY credentials in this VM)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b940e55-9d3d-4a81-887d-73d140b1cd19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b940e55-9d3d-4a81-887d-73d140b1cd19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

