### PR TITLE
fix(apple): isolate avatar decoding from UI task priority

### DIFF
--- a/apps/apple/Packages/SokosumiChat/Sources/SokosumiChat/AvatarImage.swift
+++ b/apps/apple/Packages/SokosumiChat/Sources/SokosumiChat/AvatarImage.swift
@@ -22,10 +22,25 @@ public func loadAvatarCGImage(
   if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
     return nil
   }
-  return avatarThumbnail(data: data, maxPixel: max(pointSize * scale, 1))
+  return await decodeAvatarThumbnail(data: data, maxPixel: max(pointSize * scale, 1))
+}
+
+/// ImageIO can synchronously wait on its own decoder threads. Keep that work
+/// off the caller's cooperative executor and do not inherit a view task's QoS.
+private let avatarDecodeQueue = DispatchQueue(label: "com.sokosumi.avatar-decode", qos: .utility)
+
+func decodeAvatarThumbnail(data: Data, maxPixel: CGFloat) async -> CGImage? {
+  guard !Task.isCancelled else { return nil }
+  let image: CGImage? = await withCheckedContinuation { continuation in
+    avatarDecodeQueue.async(qos: .utility, flags: .enforceQoS) {
+      continuation.resume(returning: avatarThumbnail(data: data, maxPixel: maxPixel))
+    }
+  }
+  return Task.isCancelled ? nil : image
 }
 
 private func avatarThumbnail(data: Data, maxPixel: CGFloat) -> CGImage? {
+  dispatchPrecondition(condition: .onQueue(avatarDecodeQueue))
   let sourceOptions: [CFString: Any] = [kCGImageSourceShouldCache: false]
   guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else {
     return nil

--- a/apps/apple/Packages/SokosumiChat/Tests/SokosumiChatTests/AvatarImageTests.swift
+++ b/apps/apple/Packages/SokosumiChat/Tests/SokosumiChatTests/AvatarImageTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import ImageIO
+@testable import SokosumiChat
+import Testing
+
+@MainActor
+struct AvatarImageTests {
+  private func imageData() throws -> Data {
+    let context = try #require(CGContext(
+      data: nil, width: 80, height: 40, bitsPerComponent: 8, bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    let image = try #require(context.makeImage())
+    let data = NSMutableData()
+    let destination = try #require(CGImageDestinationCreateWithData(data, "public.png" as CFString, 1, nil))
+    CGImageDestinationAddImage(destination, image, nil)
+    #expect(CGImageDestinationFinalize(destination))
+    return data as Data
+  }
+
+  @Test func thumbnailFromMainActorPreservesAspectRatioAndPixelLimit() async throws {
+    let image = try #require(await decodeAvatarThumbnail(data: imageData(), maxPixel: 20))
+    #expect(image.width == 20)
+    #expect(image.height == 10)
+  }
+
+  @Test func invalidImageReturnsNil() async {
+    #expect(await decodeAvatarThumbnail(data: Data("invalid".utf8), maxPixel: 20) == nil)
+  }
+
+  @Test func cancelledDecodeReturnsNil() async throws {
+    let data = try imageData()
+    let task = Task {
+      withUnsafeCurrentTask { $0?.cancel() }
+      return await decodeAvatarThumbnail(data: data, maxPixel: 20)
+    }
+    #expect(await task.value == nil)
+  }
+}


### PR DESCRIPTION
Avatar thumbnail decoding currently runs synchronously at the caller's task priority. Xcode reported a user-initiated thread waiting inside ImageIO on an internal thread without a QoS class.

Move the existing ImageIO downsampling operation to a serial utility queue with enforced QoS. The caller suspends through a continuation; image decoding no longer blocks its cooperative executor or inherits its high priority. Cancellation before scheduling and after completion returns no image. Image sizing and rendering stay unchanged.

Validation: 104 chat-package tests pass, including new tests for a main-actor caller, thumbnail dimensions/aspect ratio, invalid image data, and cancellation. Apple Development signed macOS build, shared-package iOS 17 build, SwiftFormat, and strict SwiftLint pass. Independent review found no actionable issues.

The exact Thread Performance Checker warning still needs runtime confirmation. The native verification tool failed with a ScreenCaptureKit capture error. Run the app from Xcode with Thread Performance Checker enabled and open rooms with avatars; verify avatars load and the reported ImageIO priority inversion no longer appears.

This is a separate bugfix based on main. PR #4322 remains focused on read/unread attention. No dependencies, Core contracts, web files, or SwiftUI layout changes.
