### PR TITLE
fix(apple): show channel name in toolbar title

### DIFF
--- a/apps/apple/Sokosumi/ContentView.swift
+++ b/apps/apple/Sokosumi/ContentView.swift
@@ -227,12 +227,14 @@ struct ContentView: View {
         .navigationSplitViewColumnWidth(min: 220, ideal: 260)
       } detail: {
         if let selectedRoomId = workspaces.selectedRoomId,
-           workspaces.rooms.contains(where: { $0.id == selectedRoomId }) {
+           let selectedRoom = workspaces.rooms.first(where: { $0.id == selectedRoomId }) {
           TranscriptView(roomId: selectedRoomId)
+            .navigationTitle(roomDisplayName(selectedRoom, currentUserId: workspaces.currentUserId))
         } else {
           Text("Pick a room to read it.")
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(workspaces.selection?.title ?? "")
         }
       }
     }

--- a/apps/apple/Sokosumi/TranscriptView.swift
+++ b/apps/apple/Sokosumi/TranscriptView.swift
@@ -33,14 +33,6 @@ import SwiftUI
 
     var body: some View {
       VStack(spacing: 0) {
-        if let room {
-          Text(roomDisplayName(room, currentUserId: workspaces.currentUserId))
-            .font(.headline)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-          Divider()
-        }
         transcriptBody
         Divider()
         RoomComposer(


### PR DESCRIPTION
Removes the redundant "Sokosumi" title above the transcript. The detail column now sets the toolbar title to the selected channel/DM name, and the duplicate in-content header is gone, so the channel name sits at the top.

Verification: swiftformat lint clean, swiftlint strict 0 violations, xcodebuild Debug build succeeded (ad-hoc + Development signing), Development-signed build launched without crashing.