### PR TITLE
chore(web): redirect leftover /coupon to billing coupon tab

### DIFF
--- a/apps/web/src/app/(app)/coupon/page.tsx
+++ b/apps/web/src/app/(app)/coupon/page.tsx
@@ -1,30 +1,5 @@
-import CouponSection from "@/components/billing/coupon-section";
-import { CreditsCheckoutReturn } from "@/components/billing/credits-checkout-return";
-import { getFeaturedCoworkers } from "@/components/billing/get-featured-coworkers";
-import { userService } from "@/lib/services";
+import { redirect } from "next/navigation";
 
-interface CouponPageProps {
-  searchParams: Promise<{
-    session_id?: string;
-    cancel?: string;
-  }>;
-}
-
-export default async function CouponPage({ searchParams }: CouponPageProps) {
-  const { session_id, cancel } = await searchParams;
-  const activeOrganization = await userService.getActiveOrganization();
-  const coworkersPromise = getFeaturedCoworkers();
-
-  return (
-    <div className="min-h-full w-full">
-      <div className="mx-auto max-w-4xl space-y-12 px-4">
-        <CouponSection organization={activeOrganization} returnPath="/coupon" />
-      </div>
-      <CreditsCheckoutReturn
-        cancel={cancel}
-        coworkersPromise={coworkersPromise}
-        sessionId={session_id}
-      />
-    </div>
-  );
+export default function CouponPage() {
+  redirect("/billing?tab=coupon");
 }

--- a/apps/web/src/lib/actions/credits/action.test.ts
+++ b/apps/web/src/lib/actions/credits/action.test.ts
@@ -138,7 +138,7 @@ describe("credits actions", () => {
       organizationId: null,
       credits: 250_000,
       promotionCodeId: "promo_1",
-      returnPath: "/coupon",
+      returnPath: "/billing?tab=coupon",
     });
     expect(result).toEqual({
       ok: true,

--- a/apps/web/src/lib/actions/credits/action.ts
+++ b/apps/web/src/lib/actions/credits/action.ts
@@ -113,7 +113,7 @@ export const claimFreeCreditsWithCoupon = withSession<
       organizationId,
       credits: coupon.credits,
       promotionCodeId: promo.data.promotionCodeId,
-      returnPath: returnPath ?? "/coupon",
+      returnPath: returnPath ?? "/billing?tab=coupon",
     });
 
     invalidatePrivateSidebarChrome({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly cleanup (`web-coupon-redirect`): leftover `/coupon` URL and Stripe checkout default return now land on the billing coupon tab.

## What changed

- `/coupon` is an App Router `redirect()` to `/billing?tab=coupon` (same leftover-route pattern as `/organizations` → `/`).
- `claimFreeCreditsWithCoupon` default `returnPath` is `/billing?tab=coupon` when callers omit it. Billing UI already passed that path.

## Verification

- `pnpm --filter web test src/lib/actions/credits/action.test.ts` — 5 passed
- Unauthenticated `GET /coupon` → `307` `/signin?returnUrl=%2Fcoupon` (existing `(app)` auth gate)
- Authenticated document request to `/coupon` encodes `NEXT_REDIRECT;replace;/billing?tab=coupon;307` from `CouponPage`
- CI: Biome, Typecheck, Test Web, Build, Validate PR Title green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa6ef0f7-1621-45e4-8539-c1f5e7f1052c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa6ef0f7-1621-45e4-8539-c1f5e7f1052c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

