### PR TITLE
fix(apple): scroll transcript to true bottom on open

### DIFF
--- a/apps/apple/Sokosumi/TranscriptView.swift
+++ b/apps/apple/Sokosumi/TranscriptView.swift
@@ -124,11 +124,14 @@ import SwiftUI
               }
               .id(message.id)
             }
-            Color.clear.frame(height: 1).id("timeline-bottom")
+            // Bottom anchor doubles as the trailing breathing room (1pt anchor
+            // plus the 8pt the stack used to pad outside). Padding below the
+            // anchor would park every scrollTo 8pt short of the true bottom.
+            Color.clear.frame(height: 9).id("timeline-bottom")
           }
           .scrollTargetLayout()
           .padding(.horizontal, 12)
-          .padding(.vertical, 8)
+          .padding(.top, 8)
         }
         .defaultScrollAnchor(.bottom)
         .scrollPosition(id: $visibleMessageId, anchor: .top)


### PR DESCRIPTION
Chat opened parked 8pt above the true bottom: every follow-latest `scrollTo("timeline-bottom")` aligned the 1pt spacer with the viewport bottom while the stack's 8pt bottom padding sat below the anchor. The anchor now doubles as the trailing breathing room (9pt) with top-only outer padding, so all scroll-to-bottom paths land at distance 0. Row spacing is pixel-identical.

Root-cause evidence: a throwaway probe replicating the scroll construction settled at distBottom=8.0 before the fix and 0.0 after; adding only an onAppear scrollTo still settled at 8.0.

Verification (apps/apple): swiftformat lint clean, swiftlint strict clean, xcodebuild build + 58 app tests passed, package suites passed (CoreAPI 1, Auth 34, Chat 128, Realtime 27).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript scrolling so the view reaches the intended bottom position while preserving appropriate trailing space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->