### PR TITLE
chore(web): delete unused Duration.Short and JobInput Schema locale keys

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6223,41 +6223,6 @@
       }
     },
     "JobInput": {
-      "Schema": {
-        "Id": {
-          "required": "Input-ID ist erforderlich"
-        },
-        "Type": {
-          "enum": "Muss einer der folgenden Werte sein: {options}"
-        },
-        "Name": {
-          "required": "Input-Name ist erforderlich"
-        },
-        "Data": {
-          "Values": {
-            "value": {
-              "required": "Option ist erforderlich"
-            },
-            "min": "Mindestens 1 Option erforderlich",
-            "unique": "Optionswerte müssen eindeutig sein"
-          }
-        },
-        "Validations": {
-          "Validation": {
-            "enum": "Muss einer der folgenden Werte sein: {options}"
-          },
-          "Value": {
-            "invalid": "Wert ist ungültig für Validierung {validation}",
-            "required": "Wert ist erforderlich für Validierung {validation}",
-            "integer": "Wert muss eine ganze Zahl sein für Validierung {validation}",
-            "enum": "Wert muss einer der folgenden sein: {options}, für Validierung {validation}"
-          },
-          "fileInvalid": "Schema der Datei ist ungültig. Erforderliche Validierungen fehlen"
-        },
-        "invalidValidations": "Validierungen sind nicht gültig für Typ {type}",
-        "optionValuesRequired": "Werte sind für den Optionstyp erforderlich",
-        "noDataValues": "Werte müssen für Nicht-Optionstypen undefiniert sein"
-      },
       "Form": {
         "clear": "Zurücksetzen",
         "back": "Zurück",
@@ -6306,9 +6271,6 @@
           "show": "Passwort anzeigen",
           "hide": "Passwort verbergen"
         }
-      },
-      "Error": {
-        "failedToFetchJobInputSchema": "Job-Input-Schema konnte nicht abgerufen werden"
       }
     },
     "Duration": {
@@ -6317,12 +6279,6 @@
         "hours": "{value, plural, =1 {Stunde} other {Stunden}}",
         "minutes": "{value, plural, =1 {Minute} other {Minuten}}",
         "seconds": "{value, plural, =1 {Sekunde} other {Sekunden}}"
-      },
-      "Short": {
-        "days": "{value, plural, =1 {Tag} other {Tage}}",
-        "hours": "{value, plural, =1 {Std.} other {Std.}}",
-        "minutes": "{value, plural, =1 {Min.} other {Min.}}",
-        "seconds": "{value, plural, =1 {Sek.} other {Sek.}}"
       }
     },
     "Notifications": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6223,41 +6223,6 @@
       }
     },
     "JobInput": {
-      "Schema": {
-        "Id": {
-          "required": "Input Id is required"
-        },
-        "Type": {
-          "enum": "Must be one of {options}"
-        },
-        "Name": {
-          "required": "Input name is required"
-        },
-        "Data": {
-          "Values": {
-            "value": {
-              "required": "Option is required"
-            },
-            "min": "Must have at least 1 option",
-            "unique": "Option values must be unique"
-          }
-        },
-        "Validations": {
-          "Validation": {
-            "enum": "Must be one of {options}"
-          },
-          "Value": {
-            "invalid": "Value is invalid for validation {validation}",
-            "required": "Value is required for validation {validation}",
-            "integer": "Value must be integer for validation {validation}",
-            "enum": "Value must be one of {options}, for validation {validation}"
-          },
-          "fileInvalid": "File's schema is invalid. Missing required validations"
-        },
-        "invalidValidations": "Validations are not valid for type {type}",
-        "optionValuesRequired": "Values are required for option type",
-        "noDataValues": "Values must be undefined for non-option type"
-      },
       "Form": {
         "clear": "Clear",
         "back": "Back",
@@ -6306,9 +6271,6 @@
           "show": "Show password",
           "hide": "Hide password"
         }
-      },
-      "Error": {
-        "failedToFetchJobInputSchema": "Failed to fetch Job Input Schema"
       }
     },
     "Duration": {
@@ -6317,12 +6279,6 @@
         "hours": "{value, plural, =1 {hour} other {hours}}",
         "minutes": "{value, plural, =1 {minute} other {minutes}}",
         "seconds": "{value, plural, =1 {second} other {seconds}}"
-      },
-      "Short": {
-        "days": "{value, plural, =1 {day} other {days}}",
-        "hours": "{value, plural, =1 {hr} other {hr}}",
-        "minutes": "{value, plural, =1 {min} other {min}}",
-        "seconds": "{value, plural, =1 {sec} other {sec}}"
       }
     },
     "Notifications": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6223,41 +6223,6 @@
       }
     },
     "JobInput": {
-      "Schema": {
-        "Id": {
-          "required": "El ID de Input es obligatorio"
-        },
-        "Type": {
-          "enum": "Debe ser uno de los siguientes valores: {options}"
-        },
-        "Name": {
-          "required": "El nombre de Input es obligatorio"
-        },
-        "Data": {
-          "Values": {
-            "value": {
-              "required": "La opción es obligatoria"
-            },
-            "min": "Se requiere al menos 1 opción",
-            "unique": "Los valores de las opciones deben ser únicos"
-          }
-        },
-        "Validations": {
-          "Validation": {
-            "enum": "Debe ser uno de los siguientes valores: {options}"
-          },
-          "Value": {
-            "invalid": "El valor no es válido para la validación {validation}",
-            "required": "El valor es obligatorio para la validación {validation}",
-            "integer": "El valor debe ser un número entero para la validación {validation}",
-            "enum": "El valor debe ser uno de los siguientes: {options}, para la validación {validation}"
-          },
-          "fileInvalid": "El esquema del archivo no es válido. Faltan validaciones obligatorias"
-        },
-        "invalidValidations": "Las validaciones no son válidas para el tipo {type}",
-        "optionValuesRequired": "Los valores son obligatorios para el tipo de opción",
-        "noDataValues": "Los valores deben ser indefinidos para tipos que no son de opción"
-      },
       "Form": {
         "clear": "Restablecer",
         "back": "Atrás",
@@ -6306,9 +6271,6 @@
           "show": "Mostrar contraseña",
           "hide": "Ocultar contraseña"
         }
-      },
-      "Error": {
-        "failedToFetchJobInputSchema": "No se pudo obtener el esquema de Input del job"
       }
     },
     "Duration": {
@@ -6317,12 +6279,6 @@
         "hours": "{value, plural, =1 {hora} other {horas}}",
         "minutes": "{value, plural, =1 {minuto} other {minutos}}",
         "seconds": "{value, plural, =1 {segundo} other {segundos}}"
-      },
-      "Short": {
-        "days": "{value, plural, =1 {día} other {días}}",
-        "hours": "{value, plural, =1 {h} other {h}}",
-        "minutes": "{value, plural, =1 {min} other {min}}",
-        "seconds": "{value, plural, =1 {seg} other {seg}}"
       }
     },
     "Notifications": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly **web-locale-dead-keys** cleanup. Subtractive locale-key deletions only.

## What
Remove unused keys from `apps/web/messages/{en,de,es}.json`:

- `Library.Duration.Short` (`days` / `hours` / `minutes` / `seconds`) — unused. **Kept** `Library.Duration.Long` (used by agent detail stats).
- `Library.JobInput.Schema` (~15 keys) — unused after #4334 removed `JobInputSchemaIntlPath`. **Kept** `Library.JobInput.Form`.
- `Library.JobInput.Error.failedToFetchJobInputSchema` — unused; empty `Error` parent removed.

## Out of scope
- lowercase `notifications.*` (Core keys)
- `App.Chat.Landing` and `Library.Notifications.Job`
- other JobInput keys still in use
- no extra locale cleanup, docs, or machinery

## Verification
- Searched `useTranslations` / `getTranslations` namespaces, `t("...")` usage, and raw key strings before deleting
- `pnpm --filter web messages:parity`
- `pnpm --filter web format`
- `pnpm check` and `pnpm typecheck` on commit

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-950e174c-0968-43de-a3ef-038158c35c8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-950e174c-0968-43de-a3ef-038158c35c8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

