### PR TITLE
chore(core): drop withGlobalHeaderParameters alias

### DIFF
--- a/apps/core/src/lib/hono-openapi-headers.test.ts
+++ b/apps/core/src/lib/hono-openapi-headers.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   withCoworkerContextHeaderParameters,
-  withGlobalHeaderParameters,
   withOrganizationSlugHeaderParameter,
 } from "./hono";
 
@@ -34,12 +33,6 @@ describe("OpenAPI header parameter helpers", () => {
     expect(
       parameterRefs(withOrganizationSlugHeaderParameter(baseRoute)),
     ).toEqual(["#/components/parameters/OrganizationSlug"]);
-  });
-
-  it("withGlobalHeaderParameters matches organization-slug-only default", () => {
-    expect(parameterRefs(withGlobalHeaderParameters(baseRoute))).toEqual(
-      parameterRefs(withOrganizationSlugHeaderParameter(baseRoute)),
-    );
   });
 
   it("withCoworkerContextHeaderParameters documents coworker context headers", () => {

--- a/apps/core/src/lib/hono.ts
+++ b/apps/core/src/lib/hono.ts
@@ -123,12 +123,3 @@ export function withCoworkerContextHeaderParameters<T extends RouteConfig>(
 ): T {
   return withHeaderParameters(route, COWORKER_CONTEXT_HEADER_PARAMETERS);
 }
-
-/**
- * Default OpenAPI header params for authenticated routes: organization slug
- * only. Prefer {@link withCoworkerContextHeaderParameters} or
- * another explicit route parameter set when the route accepts contextual auth.
- */
-export function withGlobalHeaderParameters<T extends RouteConfig>(route: T): T {
-  return withOrganizationSlugHeaderParameter(route);
-}

--- a/apps/core/src/routes/v1/agents/[id]/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/get.ts
@@ -20,7 +20,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import {
   agentDetailSchema,
@@ -39,7 +39,7 @@ const params = z.object({
   }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}",

--- a/apps/core/src/routes/v1/agents/[id]/input-schema/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/input-schema/get.ts
@@ -8,7 +8,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 
 const params = z.object({
@@ -18,7 +18,7 @@ const params = z.object({
   }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/input-schema",

--- a/apps/core/src/routes/v1/agents/[id]/reviews/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/get.ts
@@ -15,7 +15,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { agentReviewsSchema } from "@/schemas/agent.schema";
 
@@ -52,7 +52,7 @@ const query = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/reviews",

--- a/apps/core/src/routes/v1/chat-room-invite-links/[token]/accept/post.ts
+++ b/apps/core/src/routes/v1/chat-room-invite-links/[token]/accept/post.ts
@@ -10,7 +10,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { acceptChatRoomGuestInviteLinkResponseSchema } from "@/schemas/chat-room-guest-invite-link.schema";
@@ -25,7 +25,7 @@ const params = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{token}/accept",

--- a/apps/core/src/routes/v1/chats/invitations/[id]/accept/post.ts
+++ b/apps/core/src/routes/v1/chats/invitations/[id]/accept/post.ts
@@ -14,7 +14,7 @@ import { publishChatRoomsChanged } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -32,7 +32,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/accept",

--- a/apps/core/src/routes/v1/chats/invitations/[id]/decline/post.ts
+++ b/apps/core/src/routes/v1/chats/invitations/[id]/decline/post.ts
@@ -11,7 +11,7 @@ import { publishChatRoomsChanged } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -29,7 +29,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/decline",

--- a/apps/core/src/routes/v1/chats/invitations/[id]/get.ts
+++ b/apps/core/src/routes/v1/chats/invitations/[id]/get.ts
@@ -10,7 +10,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -28,7 +28,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}",

--- a/apps/core/src/routes/v1/chats/invitations/get.ts
+++ b/apps/core/src/routes/v1/chats/invitations/get.ts
@@ -10,7 +10,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -27,7 +27,7 @@ const querySchema = z.object({
   }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.ts
@@ -8,7 +8,7 @@ import { publishChatRoomsChanged } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -32,7 +32,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/archive",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/delete.ts
@@ -6,7 +6,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { CHAT_ROOM_ACCESS } from "@/schemas/chat-room.schema";
@@ -27,7 +27,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/files/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/files/post.ts
@@ -16,7 +16,7 @@ import { createChatRoomFileUploadSession } from "@/lib/blob";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import {
   isCoworkerAuthContext,
@@ -44,7 +44,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/files",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/get.ts
@@ -5,7 +5,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
@@ -32,7 +32,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/invitations/[invitationId]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/invitations/[invitationId]/delete.ts
@@ -6,7 +6,7 @@ import { publishChatRoomsChanged } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 
@@ -29,7 +29,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}/invitations/{invitationId}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/invitations/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/invitations/get.ts
@@ -11,7 +11,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomInvitationSchema } from "@/schemas/chat-room-invitation.schema";
@@ -28,7 +28,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/invitations",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/invitations/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/invitations/post.ts
@@ -25,7 +25,7 @@ import prisma from "@/lib/db/prisma";
 import { captureExternalServiceError } from "@/lib/external-service-errors";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -46,7 +46,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/invitations",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/invite-links/[token]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/invite-links/[token]/delete.ts
@@ -7,7 +7,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 
@@ -34,7 +34,7 @@ const responseSchema = z
   .object({ ok: z.boolean() })
   .openapi("RevokeChatRoomGuestInviteLinkResult");
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}/invite-links/{token}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/invite-links/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/invite-links/get.ts
@@ -7,7 +7,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomGuestInviteLinkSchema } from "@/schemas/chat-room-guest-invite-link.schema";
@@ -24,7 +24,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/invite-links",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/invite-links/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/invite-links/post.ts
@@ -11,7 +11,7 @@ import { created } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -31,7 +31,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/invite-links",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/[userId]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/[userId]/delete.ts
@@ -8,7 +8,7 @@ import { publishChatMembershipRevoked } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { leftChatRoomSchema } from "@/schemas/chat-room.schema";
@@ -36,7 +36,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}/members/{userId}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.ts
@@ -16,7 +16,7 @@ import { publishChatMembershipRevoked } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { leftChatRoomSchema } from "@/schemas/chat-room.schema";
@@ -37,7 +37,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}/members/me",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/post.ts
@@ -7,7 +7,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
@@ -31,7 +31,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/members/me",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
@@ -11,7 +11,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomMessageSchema } from "@/schemas/chat-room.schema";
@@ -40,7 +40,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}/messages/{messageId}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/get.ts
@@ -6,7 +6,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomMessageSchema } from "@/schemas/chat-room.schema";
@@ -34,7 +34,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/messages/{messageId}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/mentions/[mentionId]/retry/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/mentions/[mentionId]/retry/post.ts
@@ -8,7 +8,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomMessageSchema } from "@/schemas/chat-room.schema";
@@ -45,7 +45,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/messages/{messageId}/mentions/{mentionId}/retry",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
@@ -9,7 +9,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -42,7 +42,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "patch",
     path: "/{id}/messages/{messageId}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/pin/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/pin/delete.ts
@@ -7,7 +7,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomPinnedMessageMutationSchema } from "@/schemas/chat-room.schema";
@@ -31,7 +31,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}/messages/{messageId}/pin",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/pin/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/pin/post.ts
@@ -7,7 +7,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomPinnedMessageMutationSchema } from "@/schemas/chat-room.schema";
@@ -32,7 +32,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/messages/{messageId}/pin",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/reactions/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/reactions/post.ts
@@ -7,7 +7,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -39,7 +39,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/messages/{messageId}/reactions",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/unfurls/remove/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/unfurls/remove/post.ts
@@ -18,7 +18,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -50,7 +50,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/messages/{messageId}/unfurls/remove",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
@@ -14,7 +14,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomMessageSchema } from "@/schemas/chat-room.schema";
@@ -77,7 +77,7 @@ const querySchema = cursorPaginationQuerySchema.extend({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/messages",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -14,7 +14,7 @@ import { created } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import {
   isCoworkerAuthContext,
@@ -54,7 +54,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/messages",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/mute/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/mute/delete.ts
@@ -5,7 +5,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
@@ -31,7 +31,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}/mute",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/mute/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/mute/post.ts
@@ -6,7 +6,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
@@ -32,7 +32,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/mute",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
@@ -18,7 +18,7 @@ import prisma from "@/lib/db/prisma";
 import { serializableTransaction } from "@/lib/db/transaction";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -54,7 +54,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "patch",
     path: "/{id}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/pinned-messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/pinned-messages/get.ts
@@ -13,7 +13,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomPinnedMessageListItemSchema } from "@/schemas/chat-room.schema";
@@ -35,7 +35,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/pinned-messages",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/read/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/read/post.ts
@@ -8,7 +8,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
@@ -30,7 +30,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/read",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/restore/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/restore/post.ts
@@ -8,7 +8,7 @@ import { publishChatRoomsChanged } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -34,7 +34,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/restore",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/star/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/star/delete.ts
@@ -5,7 +5,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
@@ -31,7 +31,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "delete",
     path: "/{id}/star",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/star/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/star/post.ts
@@ -6,7 +6,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
@@ -32,7 +32,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/star",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/get.ts
@@ -13,7 +13,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -33,7 +33,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/stream/messages",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
@@ -49,7 +49,7 @@ import prisma from "@/lib/db/prisma";
 import { tryUseLogger } from "@/lib/evlog";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import {
   getResumableUiStreamContext,
@@ -106,7 +106,7 @@ async function validateUiMessagesOrBadRequest(
   }
 }
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/stream",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/stream-get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/stream-get.ts
@@ -9,7 +9,7 @@ import { jsonErrorResponse } from "@/helpers/openapi";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import {
   getResumableUiStreamContext,
@@ -34,7 +34,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/stream/active",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/get.ts
@@ -6,7 +6,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomThreadSchema } from "@/schemas/chat-room.schema";
@@ -31,7 +31,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/threads/{parentMessageId}",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.ts
@@ -13,7 +13,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomMessageSchema } from "@/schemas/chat-room.schema";
@@ -59,7 +59,7 @@ const querySchema = cursorPaginationQuerySchema.extend({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/threads/{parentMessageId}/messages",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/read/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/read/post.ts
@@ -6,7 +6,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomThreadReadStateSchema } from "@/schemas/chat-room.schema";
@@ -31,7 +31,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/threads/{parentMessageId}/read",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/get.ts
@@ -10,7 +10,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomThreadSchema } from "@/schemas/chat-room.schema";
@@ -44,7 +44,7 @@ const querySchema = cursorPaginationQuerySchema.extend({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/threads",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/read/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/read/post.ts
@@ -5,7 +5,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomThreadsMarkAllSchema } from "@/schemas/chat-room.schema";
@@ -23,7 +23,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/threads/read",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/unread-count/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/unread-count/get.ts
@@ -5,7 +5,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomThreadsUnreadCountSchema } from "@/schemas/chat-room.schema";
@@ -23,7 +23,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/{id}/threads/unread-count",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/unread/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/unread/post.ts
@@ -5,7 +5,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
@@ -30,7 +30,7 @@ const paramsSchema = z.object({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/{id}/unread",

--- a/apps/core/src/routes/v1/chats/rooms/channel-slug-availability/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/channel-slug-availability/get.ts
@@ -6,7 +6,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { channelSlugAvailabilitySchema } from "@/schemas/chat-room.schema";
@@ -25,7 +25,7 @@ const querySchema = z.object({
   }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/channel-slug-availability",

--- a/apps/core/src/routes/v1/chats/rooms/discoverable/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/discoverable/get.ts
@@ -13,7 +13,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { discoverableChatRoomSchema } from "@/schemas/chat-room.schema";
@@ -40,7 +40,7 @@ const querySchema = cursorPaginationQuerySchema.extend({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/discoverable",

--- a/apps/core/src/routes/v1/chats/rooms/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.ts
@@ -14,7 +14,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import {
@@ -69,7 +69,7 @@ const querySchema = cursorPaginationQuerySchema.extend({
     }),
 });
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "get",
     path: "/",

--- a/apps/core/src/routes/v1/chats/rooms/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.ts
@@ -9,7 +9,7 @@ import { created, ok, successResponseSchema } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
-  withGlobalHeaderParameters,
+  withOrganizationSlugHeaderParameter,
 } from "@/lib/hono";
 import {
   isCoworkerAuthContext,
@@ -42,7 +42,7 @@ const chatRoomSuccessBodySchema = successResponseSchema(chatRoomSchema).openapi(
   "ChatRoomSuccessResponse",
 );
 
-const route = withGlobalHeaderParameters(
+const route = withOrganizationSlugHeaderParameter(
   createRoute({
     method: "post",
     path: "/",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`withGlobalHeaderParameters` was a one-line alias for `withOrganizationSlugHeaderParameter`. This PR deletes the alias and points its callers at the real helper.

## Changes

- Remove `withGlobalHeaderParameters` from `apps/core/src/lib/hono.ts`.
- Repoint chat/agent OpenAPI route callers (and the header helper test) to `withOrganizationSlugHeaderParameter`.
- Drop the alias-only test that compared the two names.

Rename/repoint only. No behavior change.

## Verification

Local:

- `pnpm exec biome check` on the helper files: clean
- `pnpm --filter @sokosumi/core test src/lib/hono-openapi-headers.test.ts`: 2 passed
- `pnpm --filter @sokosumi/core typecheck`: clean
- `rg withGlobalHeaderParameters`: no remaining matches

Did not touch `betaBotRelationFilter`, PRs #4316–#4319, or unrelated product/security work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e4d24f9-4d51-451a-b68c-a73e286dce4e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e4d24f9-4d51-451a-b68c-a73e286dce4e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

