### PR TITLE
chore(core): drop unused constants, helpers, and catalog wrapper

### DIFF
--- a/apps/core/.cursor/agents/backend.md
+++ b/apps/core/.cursor/agents/backend.md
@@ -63,15 +63,11 @@ throw conflict("Already exists");
 
 ### Authentication
 
-Use type-safe Hono classes that automatically apply auth middleware:
+Use type-safe Hono class that automatically applies auth middleware:
 
 ```typescript
-import { HonoWithAuth, OpenAPIHonoWithAuth } from "@/lib/hono";
+import { OpenAPIHonoWithAuth } from "@/lib/hono";
 
-// For standard routes
-const router = new HonoWithAuth();
-
-// For OpenAPI-documented routes
 const app = new OpenAPIHonoWithAuth();
 ```
 
@@ -220,5 +216,5 @@ const cents = convertCreditsToCents(1.0); // BigInt(1000000000000)
 ❌ `return c.json({ error: "..." }, 403)` - Use error helpers
 ❌ `return c.json({ data: user })` - Use `ok(c, { user })`
 ❌ New repository wrappers in routes - Prefer direct Prisma in new route handlers
-❌ Manual auth middleware - Use HonoWithAuth/OpenAPIHonoWithAuth
+❌ Manual auth middleware - Use OpenAPIHonoWithAuth
 ❌ Hardcoded response formats - Use standardized helpers

--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -91,19 +91,15 @@ const unreadCounts = await getChatRoomUnreadCounts([room.id], userId, prisma);
 
 ### Authentication Classes
 
-Use type-safe Hono classes that automatically apply authentication:
+Use type-safe Hono class that automatically applies authentication:
 
 ```typescript
-import { HonoWithAuth, OpenAPIHonoWithAuth } from "@/lib/hono";
+import { OpenAPIHonoWithAuth } from "@/lib/hono";
 
-// For standard routes
-const router = new HonoWithAuth();
-
-// For OpenAPI-documented routes
 const app = new OpenAPIHonoWithAuth();
 ```
 
-**Important**: These classes automatically apply `requireAuth` middleware - do not add it manually.
+**Important**: This class automatically applies `requireAuth` middleware - do not add it manually.
 
 ### Response Handling
 
@@ -198,7 +194,7 @@ Cross-origin calls from the web app require the web deployment to use a hostname
 
 ### Authentication Context
 
-Routes using `HonoWithAuth` or `OpenAPIHonoWithAuth` have access to `AuthContext`:
+Routes using `OpenAPIHonoWithAuth` have access to `AuthContext`:
 
 ```typescript
 const auth = c.get("auth");
@@ -626,7 +622,7 @@ Environment variables required by Vitest (or by code under test) must be set in 
 
 ### Authentication
 
-- `HonoWithAuth` and `OpenAPIHonoWithAuth` automatically apply auth middleware
+- `OpenAPIHonoWithAuth` automatically applies auth middleware
 - Don't manually call `app.use("*", requireAuth)` when using these classes
 - Internal tokens have full access; user tokens and session-authenticated requests are scoped to the authenticated user
 - Session cookies must be forwarded with requests (`credentials: "include"`) and rely on the Better Auth handler configuration documented above

--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -623,7 +623,7 @@ Environment variables required by Vitest (or by code under test) must be set in 
 ### Authentication
 
 - `OpenAPIHonoWithAuth` automatically applies auth middleware
-- Don't manually call `app.use("*", requireAuth)` when using these classes
+- Don't manually call `app.use("*", requireAuth)` when using this class
 - Internal tokens have full access; user tokens and session-authenticated requests are scoped to the authenticated user
 - Session cookies must be forwarded with requests (`credentials: "include"`) and rely on the Better Auth handler configuration documented above
 - Use `c.var.user` for direct user access, or `c.get("auth")` for full auth context

--- a/apps/core/README.md
+++ b/apps/core/README.md
@@ -194,7 +194,7 @@ src/
 
 ### Key Patterns
 
-- **Authentication**: Use `HonoWithAuth` or `OpenAPIHonoWithAuth` for protected routes
+- **Authentication**: Use `OpenAPIHonoWithAuth` for protected routes
 - **Database Access**: Use Prisma directly via `@sokosumi/database/client` (repositories are not used)
 - **Error Handling**: Always use error helpers from `helpers/error.ts`
 - **Response Format**: Use response helpers from `helpers/response.ts`

--- a/apps/core/src/config/constants.ts
+++ b/apps/core/src/config/constants.ts
@@ -4,11 +4,6 @@ import {
 } from "@sokosumi/utils";
 
 /**
- * Application constants for the Core API
- * Centralized configuration values for better maintainability
- */
-
-/**
  * Time durations in seconds
  */
 export const TIME = {
@@ -124,7 +119,4 @@ export const CRYPTO = {
 export const STORAGE = {
   /** Default directory for image uploads */
   IMAGES_UPLOAD_DIR: "images",
-
-  /** Root directory for user file uploads */
-  USER_UPLOADS_DIR: "users",
 } as const;

--- a/apps/core/src/helpers/active-ui-stream-metadata.ts
+++ b/apps/core/src/helpers/active-ui-stream-metadata.ts
@@ -1,1 +1,0 @@
-export const ACTIVE_UI_STREAM_ID_METADATA_KEY = "active_ui_stream_id" as const;

--- a/apps/core/src/helpers/active-ui-stream-room-metadata.ts
+++ b/apps/core/src/helpers/active-ui-stream-room-metadata.ts
@@ -1,7 +1,7 @@
 import prisma from "@/lib/db/prisma";
 import { getRedisClient } from "@/lib/redis";
 
-import { ACTIVE_UI_STREAM_ID_METADATA_KEY } from "./active-ui-stream-metadata";
+const ACTIVE_UI_STREAM_ID_METADATA_KEY = "active_ui_stream_id" as const;
 
 function roomActiveStreamRedisKey(roomId: string): string {
   return `sokosumi:room:${roomId}:${ACTIVE_UI_STREAM_ID_METADATA_KEY}`;

--- a/apps/core/src/routes/v1/products/subscription/get.ts
+++ b/apps/core/src/routes/v1/products/subscription/get.ts
@@ -5,7 +5,7 @@ import { ok } from "@/helpers/response";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { requireUserAuthContext } from "@/middleware/auth";
 import { subscriptionCatalogSchema } from "@/schemas/subscription-catalog.schema";
-import { stripeBillingService } from "@/services/stripe-billing.service";
+import { getSubscriptionCatalog } from "@/services/subscription-catalog.service";
 
 const route = createRoute({
   method: "get",
@@ -72,7 +72,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     requireUserAuthContext(c.var.authContext);
 
-    const catalog = await stripeBillingService.getSubscriptionCatalog();
+    const catalog = await getSubscriptionCatalog();
 
     return ok(c, subscriptionCatalogSchema.parse(catalog));
   });

--- a/apps/core/src/services/invoice-admin.service.ts
+++ b/apps/core/src/services/invoice-admin.service.ts
@@ -15,12 +15,7 @@ import prisma from "@/lib/db/prisma";
 import { stripeCustomerBillingService } from "@/services/stripe-customer-billing.service";
 import { handleInvoicePaidEvent } from "@/services/stripe-invoice-credit.service";
 
-/**
- * Port of the web app's `invoiceAdminService`
- * (`apps/web/src/lib/services/invoice-admin.service.ts`): admin one-time
- * credit invoices issued through Stripe, granted through the shared
- * invoice-paid automation.
- */
+/** Core owns admin one-time credit invoice issuance. */
 
 const ADMIN_INVOICE_SOURCE = "admin_one_time_credit";
 

--- a/apps/core/src/services/stripe-billing.service.ts
+++ b/apps/core/src/services/stripe-billing.service.ts
@@ -15,8 +15,6 @@ import {
   provisionOrganizationStripeCustomer,
   provisionUserStripeCustomer,
 } from "@/services/stripe-customer-provision.service";
-import type { SubscriptionCatalog } from "@/services/subscription-catalog.service";
-import { getSubscriptionCatalog } from "@/services/subscription-catalog.service";
 
 export class CouponNotFoundError extends Error {
   constructor(couponId: string) {
@@ -282,10 +280,6 @@ async function isAccountOnFreePlan(
 }
 
 export const stripeBillingService = {
-  async getSubscriptionCatalog(): Promise<SubscriptionCatalog> {
-    return await getSubscriptionCatalog();
-  },
-
   async getCreditTopUpPricing(userId: string): Promise<CreditTopUpPricing> {
     const zeroMarginLookupKey = await resolveZeroMarginLookupKeyForUser(userId);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly Core dead-surface cleanup. Subtraction only. No console.* round, no credit `$transaction` rewrite, no adjacent hardening.

## Kill list

- `STORAGE.USER_UPLOADS_DIR` (unused; `IMAGES_UPLOAD_DIR` kept)
- Filler constants file header comment
- `helpers/active-ui-stream-metadata.ts` — inlined `ACTIVE_UI_STREAM_ID_METADATA_KEY` into `active-ui-stream-room-metadata.ts`
- `stripeBillingService.getSubscriptionCatalog` wrapper — `GET /v1/products/subscription` now calls `getSubscriptionCatalog()` from `subscription-catalog.service` directly
- Stale “port of web” comment on `invoice-admin.service.ts` (Core owns admin invoice issuance)

## Docs (tiny, same PR)

- `HonoWithAuth` → `OpenAPIHonoWithAuth` in `apps/core/AGENTS.md`, `README.md`, and `.cursor/agents/backend.md` (the class does not exist)

## Verification

- `pnpm check` and `pnpm typecheck` (husky precommit)
- Targeted Core tests for subscription catalog, stripe billing, and room stream metadata callers

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3550ba79-3e3d-4c52-b005-778a4c906771?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3550ba79-3e3d-4c52-b005-778a4c906771&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

