### PR TITLE
chore(deps): drop unused @sokosumi/chat and @sokosumi/email from apps

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -53,7 +53,6 @@
     "@sentry/node": "10.74.0",
     "@sentry/profiling-node": "10.74.0",
     "@sokosumi/ai-provider": "workspace:*",
-    "@sokosumi/chat": "workspace:*",
     "@sokosumi/database": "workspace:*",
     "@sokosumi/email": "workspace:*",
     "@sokosumi/masumi": "workspace:*",

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -95,7 +95,7 @@ pnpm test
 
 ### Deployment (Vercel)
 
-[`vercel.json`](./vercel.json) sets `installCommand` to `pnpm install --frozen-lockfile --filter web...` so only the web app and its workspace deps (`@sokosumi/chat`, `@sokosumi/email`, `@sokosumi/masumi`, `@sokosumi/net`, `@sokosumi/utils`) are installed. `@sokosumi/database` is not a dependency and is not built on web deploys — no Neon/`DATABASE_URL*` vars are required.
+[`vercel.json`](./vercel.json) sets `installCommand` to `pnpm install --frozen-lockfile --filter web...` so only the web app and its workspace deps (`@sokosumi/masumi`, `@sokosumi/net`, `@sokosumi/soko-bot`, `@sokosumi/utils`) are installed. `@sokosumi/database` is not a dependency and is not built on web deploys — no Neon/`DATABASE_URL*` vars are required.
 
 `buildCommand` runs [`scripts/vercel-build.mjs`](./scripts/vercel-build.mjs), which invokes `turbo run build --filter=web` (Vercel's global `turbo`; the filtered install does not include root `turbo`). Vercel Remote Cache is enabled automatically. Production (`VERCEL_ENV=production`) always uses `--force`. Preview may restore when inputs match. Unique deploy env (`VERCEL_URL`, related-project URLs) and Next Skew Protection often produce a miss; use the deployment Run Summary to confirm. Do not put `turbo` in the web `build` script (recursive turbo).
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,8 +46,6 @@
     "@next/third-parties": "16.3.4",
     "@radix-ui/react-slot": "1.3.3",
     "@sentry/nextjs": "10.74.0",
-    "@sokosumi/chat": "workspace:*",
-    "@sokosumi/email": "workspace:*",
     "@sokosumi/masumi": "workspace:*",
     "@sokosumi/net": "workspace:*",
     "@sokosumi/soko-bot": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,9 +188,6 @@ importers:
       '@sokosumi/ai-provider':
         specifier: workspace:*
         version: link:../../packages/ai-provider
-      '@sokosumi/chat':
-        specifier: workspace:*
-        version: link:../../packages/chat
       '@sokosumi/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -351,12 +348,6 @@ importers:
       '@sentry/nextjs':
         specifier: 10.74.0
         version: 10.74.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.4)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0(react@19.3.0))(react@19.3.0))(react@19.3.0)(supports-color@8.1.1)(webpack@5.107.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28))
-      '@sokosumi/chat':
-        specifier: workspace:*
-        version: link:../../packages/chat
-      '@sokosumi/email':
-        specifier: workspace:*
-        version: link:../../packages/email
       '@sokosumi/masumi':
         specifier: workspace:*
         version: link:../../packages/masumi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove unused workspace package dependencies from app `package.json` files so Vercel filtered installs and the lockfile match what web and Core actually import.

## Changes

- **web:** drop `@sokosumi/chat` and `@sokosumi/email` (no source, config, or test imports)
- **core:** drop `@sokosumi/chat` (unused). Keep `@sokosumi/email` (auth, job-sync, chat-room invitation mail)
- **kept:** `@sokosumi/chat` on `packages/ai-provider`
- **docs:** `apps/web/README.md` Vercel filter list now lists remaining web workspace deps (`masumi`, `net`, `soko-bot`, `utils`)
- **lockfile:** `pnpm install` refreshed importer links only

## Verification

- Confirmed no `from "@sokosumi/chat"` / `from "@sokosumi/email"` in `apps/web`
- Confirmed no `from "@sokosumi/chat"` in `apps/core`
- `pnpm install` succeeded; lockfile drops only the three unused importer entries
- Husky precommit: `pnpm check` + `pnpm typecheck` green (web and core typecheck without the removed deps)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62d426e0-1073-415a-bdd8-08ca9599347f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62d426e0-1073-415a-bdd8-08ca9599347f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

