### PR TITLE
fix(chat): read sidebar invalidations while the tab is hidden

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
@@ -24,7 +24,9 @@ describe("RoomsClient Ably island", () => {
       /LazyAblyProvider>\s*<RoomMessageRealtimeBridge[\s\S]*<\/LazyAblyProvider>/,
     );
     expect(source).not.toContain("ChannelProvider");
-    expect(source).toContain("roomIds={rooms.map((room) => room.id)}");
+    expect(source).toContain(
+      "roomIds={channelCatalogRooms.map((room) => room.id)}",
+    );
     // Open room chrome lives in RoomShellLayout (Instant + progressive share it).
     expect(source).toContain("listScrollerRef={scrollerRef}");
     expect(source).toContain("<RoomShellLayout");

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-read-visibility.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-read-visibility.test.tsx
@@ -15,6 +15,11 @@ import {
 import type { RoomComposerHandle } from "@/app/chat/components/room-composer";
 import { RoomsClient } from "@/app/chat/components/rooms-client";
 import type { RoomMessagesPage } from "@/components/chat/fetch-room-messages";
+import {
+  clearMembershipVisibleRoomsSnapshot,
+  publishMembershipVisibleRooms,
+} from "@/components/chat/membership-visible-rooms-store";
+import { ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT } from "@/components/chat/organization-chat-events";
 import { markOrganizationChatRoomReadAction } from "@/components/chat/organization-chat-list.actions";
 import {
   clearRoomReadOverlays,
@@ -384,6 +389,7 @@ const baseProps = {
 describe("RoomsClient read visibility", () => {
   beforeEach(() => {
     clearRoomReadOverlays();
+    clearMembershipVisibleRoomsSnapshot();
     vi.clearAllMocks();
     vi.mocked(listRoomMessagesAction)
       .mockReset()
@@ -410,6 +416,7 @@ describe("RoomsClient read visibility", () => {
   });
 
   afterEach(() => {
+    clearMembershipVisibleRoomsSnapshot();
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
@@ -835,5 +842,39 @@ describe("RoomsClient read visibility", () => {
     await deliverMessageInVisibility("hidden");
     expect(markOrganizationChatRoomReadAction).not.toHaveBeenCalled();
     expect(rememberRoomRead).not.toHaveBeenCalled();
+  });
+
+  it("attaches catalog rooms and invalidates the sidebar on a create in a room that is not selected", async () => {
+    const otherRoom = { ...channelRoom(), id: "room-other", name: "other" };
+    publishMembershipVisibleRooms([otherRoom], "org-1", "user-1");
+    const seen = vi.fn();
+    window.addEventListener(ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT, seen);
+    try {
+      render(<RoomsClient {...baseProps} messages={[sampleMessage()]} />);
+      await act(async () => {});
+
+      const options = vi.mocked(useChatRoomRealtime).mock.calls.at(-1)?.[0];
+      expect(options?.roomIds).toEqual(["room-other", "room-channel"]);
+      expect(options?.onMessage).toBeTypeOf("function");
+
+      const incoming = {
+        ...sampleMessage("foreign room create"),
+        id: "foreign-msg",
+        roomId: "room-other",
+      };
+      const event = chatRoomMessageEventDataSchema.parse(
+        JSON.parse(JSON.stringify({ eventType: "create", message: incoming })),
+      );
+      await act(async () => {
+        options?.onMessage?.(event);
+      });
+
+      expect(seen).toHaveBeenCalledTimes(1);
+      expect(seen.mock.calls[0]?.[0]).toMatchObject({
+        detail: { collections: ["active"] },
+      });
+    } finally {
+      window.removeEventListener(ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT, seen);
+    }
   });
 });

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2517,7 +2517,7 @@ export function RoomsClient({
             currentUserId ? (
               <LazyAblyProvider>
                 <RoomMessageRealtimeBridge
-                  roomIds={rooms.map((room) => room.id)}
+                  roomIds={channelCatalogRooms.map((room) => room.id)}
                   currentUserId={currentUserId}
                   selectedRoomId={selectedRoomId}
                   onMessage={handleChatRoomRealtimeMessage}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -214,7 +214,8 @@ const ROOM_MESSAGE_FALLBACK_MS = 3_000;
 /**
  * A message landed in a membership room that is not open here: its sidebar
  * row (order, unread) changed. Ask for the active collection only; the
- * scheduler coalesces a burst into one read and defers it while hidden.
+ * scheduler coalesces a burst into one read. It runs even while the tab is
+ * hidden, because the row's unread is what the tab title shows the reader.
  */
 function notifySidebarOfForeignRoomMessage() {
   notifyOrganizationChatRoomsChanged({ collections: ["active"] });

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
@@ -52,8 +52,9 @@ import { useChatTabUnreadPresence } from "./use-chat-tab-unread-presence";
 let hasFocus: ReturnType<typeof vi.spyOn>;
 
 /**
- * Leave the foreground, learn the rooms went stale while away, and come
- * back: the one focus gesture that turns into a read.
+ * Leave the foreground, learn the rooms changed while away, and come back.
+ * The invalidation reads at once (the unread dot needs it); the return then
+ * has nothing stale left, so the round is exactly one read.
  */
 function returnToForeground() {
   hasFocus.mockReturnValue(false);

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
@@ -56,7 +56,7 @@ let hasFocus: ReturnType<typeof vi.spyOn>;
  * The invalidation reads at once (the unread dot needs it); the return then
  * has nothing stale left, so the round is exactly one read.
  */
-function returnToForeground() {
+function invalidateWhileAwayAndReturn() {
   hasFocus.mockReturnValue(false);
   window.dispatchEvent(new Event("blur"));
   window.dispatchEvent(new Event("organization-chat-rooms-changed"));
@@ -185,7 +185,7 @@ describe("useChatTabUnreadPresence", () => {
       );
     });
 
-    await act(async () => returnToForeground());
+    await act(async () => invalidateWhileAwayAndReturn());
 
     await waitFor(() => {
       expect(listRoomsMock).toHaveBeenCalledTimes(2);

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.test.tsx
@@ -342,6 +342,43 @@ describe("authoritative tab attention", () => {
     expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "yes");
   });
 
+  it("reads an invalidation while hidden so the unread dot can change while away", async () => {
+    const visibility = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("visible");
+    listRoomsMock.mockResolvedValue({
+      ok: true,
+      value: { rooms: [room({ id: "a" })], nextCursor: null },
+    });
+    render(<Harness />);
+    await waitFor(() => {
+      expect(listRoomsMock).toHaveBeenCalled();
+    });
+    listRoomsMock.mockClear();
+    listRoomsMock.mockResolvedValue({
+      ok: true,
+      value: { rooms: [room({ id: "a", unreadCount: 2 })], nextCursor: null },
+    });
+
+    await act(async () => {
+      visibility.mockReturnValue("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(
+        new CustomEvent("organization-chat-rooms-changed", {
+          detail: { collections: ["active"] },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("presence")).toHaveAttribute(
+        "data-show",
+        "yes",
+      );
+    });
+    expect(listRoomsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores invalidations that do not name the active collection", async () => {
     render(<Harness />);
     await act(async () => undefined);

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
@@ -78,8 +78,9 @@ export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
   }, [scope, currentUserId, organizationId]);
 
   // Same GET read and scheduling rules as the sidebar's active collection
-  // (SOK-986): paused while hidden or unfocused, one read on return, and a
-  // slow recovery cadence while Ably is connected.
+  // (SOK-986): timer reads pause while hidden or unfocused with one read on
+  // return, invalidations read at once, and a slow recovery cadence while
+  // Ably is connected.
   const refreshRooms = useCallback(async (isCurrent: () => boolean) => {
     const requestRevision = beginRoomAttentionRefresh();
     const page = await fetchSidebarRoomCollection("active");

--- a/apps/web/src/components/chat/use-chat-refresh-scheduler.test.ts
+++ b/apps/web/src/components/chat/use-chat-refresh-scheduler.test.ts
@@ -104,18 +104,29 @@ describe("useChatRefreshScheduler", () => {
     expect(refresh).toHaveBeenCalledTimes(3);
   });
 
-  it("starts no read while hidden and reads once on return", async () => {
+  it("starts no timer read while hidden and reads once on return", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    mount(refresh, { healthy: false });
+
+    await act(async () => goBackground("hidden"));
+    await tick(FALLBACK_MS * 4);
+    expect(refresh).not.toHaveBeenCalled();
+
+    await act(async () => goForeground());
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs an explicit request while hidden, so the tab title can change while away", async () => {
     const refresh = vi.fn().mockResolvedValue(undefined);
     const { result } = mount(refresh, { healthy: false });
 
     await act(async () => goBackground("hidden"));
-    await tick(FALLBACK_MS * 4);
     await act(async () => {
       result.current();
-      result.current();
     });
-    expect(refresh).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(1);
 
+    // The read already happened; the return has nothing stale to catch up.
     await act(async () => goForeground());
     expect(refresh).toHaveBeenCalledTimes(1);
   });
@@ -144,17 +155,20 @@ describe("useChatRefreshScheduler", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 
-  it("reads once on return when a request arrived while away", async () => {
+  it("reads once on return when a timer elapsed after an explicit read while away", async () => {
     const refresh = vi.fn().mockResolvedValue(undefined);
     const { result } = mount(refresh);
 
     await act(async () => goBackground("hidden"));
     await act(async () => {
       result.current();
-      result.current();
     });
-    await act(async () => goForeground());
     expect(refresh).toHaveBeenCalledTimes(1);
+    await tick(CHAT_HEALTHY_REFRESH_MS);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => goForeground());
+    expect(refresh).toHaveBeenCalledTimes(2);
   });
 
   it("does not treat the first healthy flip as a recovery", async () => {

--- a/apps/web/src/components/chat/use-chat-refresh-scheduler.test.ts
+++ b/apps/web/src/components/chat/use-chat-refresh-scheduler.test.ts
@@ -116,9 +116,36 @@ describe("useChatRefreshScheduler", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 
-  it("runs an explicit request while hidden, so the tab title can change while away", async () => {
-    const refresh = vi.fn().mockResolvedValue(undefined);
-    const { result } = mount(refresh, { healthy: false });
+  it.each(["hidden", "blur"] as const)(
+    "runs an explicit request while %s, so the tab title can change while away",
+    async (kind) => {
+      const refresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = mount(refresh, { healthy: false });
+
+      await act(async () => goBackground(kind));
+      await act(async () => {
+        result.current();
+      });
+      expect(refresh).toHaveBeenCalledTimes(1);
+
+      // The read already happened; the return has nothing stale to catch up.
+      await act(async () => goForeground());
+      expect(refresh).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("runs a queued explicit request as soon as the in-flight read finishes, even while hidden", async () => {
+    const pending = Promise.withResolvers<void>();
+    const refresh = vi
+      .fn()
+      .mockReturnValueOnce(pending.promise)
+      .mockResolvedValue(undefined);
+    const { result } = mount(refresh);
+
+    await act(async () => {
+      result.current();
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
 
     await act(async () => goBackground("hidden"));
     await act(async () => {
@@ -126,9 +153,11 @@ describe("useChatRefreshScheduler", () => {
     });
     expect(refresh).toHaveBeenCalledTimes(1);
 
-    // The read already happened; the return has nothing stale to catch up.
+    await act(async () => pending.resolve());
+    expect(refresh).toHaveBeenCalledTimes(2);
+
     await act(async () => goForeground());
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
   });
 
   it("treats a visible but unfocused window as background", async () => {

--- a/apps/web/src/components/chat/use-chat-refresh-scheduler.ts
+++ b/apps/web/src/components/chat/use-chat-refresh-scheduler.ts
@@ -36,11 +36,15 @@ interface UseChatRefreshSchedulerOptions {
  * collection, or the mobile unread indicator. Ably events apply to local
  * state elsewhere; this only decides when a read may start.
  *
- * - Background (hidden or unfocused): no read starts. A request or an
- *   elapsed timer is recorded as a need, and one read runs on return to the
- *   foreground; a return with nothing stale keeps the running timer.
+ * - Background (hidden or unfocused): no timer read starts. An elapsed timer
+ *   is recorded as a need, and one read runs on return to the foreground; a
+ *   return with nothing stale keeps the running timer.
+ * - Explicit requests read at once, background or not. They carry a change
+ *   the reader must be shown while away, such as a foreign-room message that
+ *   becomes the tab title's unread count; deferring them to the return would
+ *   show the count only when it is no longer needed.
  * - In flight: any need that arrives queues exactly one follow-up read,
- *   never a parallel one.
+ *   never a parallel one. A queued explicit request stays explicit.
  * - Timer: re-armed after completion, so a slow response never stacks; the
  *   interval is 60 seconds while healthy, `fallbackIntervalMs` otherwise.
  *
@@ -69,6 +73,7 @@ export function useChatRefreshScheduler({
     let cancelled = false;
     let inFlight = false;
     let queued = false;
+    let queuedExplicit = false;
     let needed = false;
     let wasForeground = isChatForeground();
     let timer: number | undefined;
@@ -86,18 +91,20 @@ export function useChatRefreshScheduler({
       void run();
     }
 
-    async function run() {
+    async function run(explicit = false) {
       if (cancelled) return;
-      if (!isChatForeground()) {
+      if (!explicit && !isChatForeground()) {
         needed = true;
         return;
       }
       if (inFlight) {
         queued = true;
+        queuedExplicit ||= explicit;
         return;
       }
       window.clearTimeout(timer);
       inFlight = true;
+      needed = false;
       try {
         await refreshRef.current(() => !cancelled);
       } catch {
@@ -106,8 +113,10 @@ export function useChatRefreshScheduler({
         inFlight = false;
         if (!cancelled) {
           if (queued) {
+            const followUpExplicit = queuedExplicit;
             queued = false;
-            void run();
+            queuedExplicit = false;
+            void run(followUpExplicit);
           } else {
             schedule();
           }
@@ -132,7 +141,7 @@ export function useChatRefreshScheduler({
 
     const onOnline = () => void run();
 
-    requestRef.current = () => void run();
+    requestRef.current = () => void run(true);
     rescheduleRef.current = () => {
       if (!inFlight) schedule();
     };
@@ -151,6 +160,7 @@ export function useChatRefreshScheduler({
     return () => {
       cancelled = true;
       queued = false;
+      queuedExplicit = false;
       window.clearTimeout(timer);
       window.removeEventListener("focus", onForegroundChange);
       window.removeEventListener("blur", onForegroundChange);

--- a/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
@@ -30,8 +30,9 @@ const NO_INVITATIONS: ChatRoomInvitation[] = [];
 let hasFocus: ReturnType<typeof vi.spyOn>;
 
 /**
- * Leave the foreground, learn the active collection went stale while away,
- * and come back: the one focus gesture that turns into a read.
+ * Leave the foreground, learn the active collection changed while away, and
+ * come back. The invalidation reads at once (the tab title needs it); the
+ * return then has nothing stale left, so the round is exactly one read.
  */
 function returnToForeground() {
   hasFocus.mockReturnValue(false);
@@ -458,13 +459,19 @@ describe("authoritative sidebar refresh", () => {
     expect(listRoomsMock).not.toHaveBeenCalled();
   });
 
-  it("defers an invalidation while hidden and reads once on return", async () => {
+  it("reads an active invalidation while hidden, so the tab title can show the unread room", async () => {
+    // A message in another room reaches the sidebar as an active-collection
+    // invalidation. The reader is not looking at the tab; the title counter
+    // is the only thing that can tell them. The read must not wait for focus.
     const visibility = vi
       .spyOn(document, "visibilityState", "get")
       .mockReturnValue("visible");
-    mount();
+    const { result } = mount({ rooms: [channel("other-1")] });
     await act(async () => undefined);
     listRoomsMock.mockClear();
+    listRoomsMock.mockResolvedValue(
+      emptyListResult([channel("other-1", { unreadCount: 1 })]),
+    );
 
     await act(async () => {
       visibility.mockReturnValue("hidden");
@@ -474,19 +481,10 @@ describe("authoritative sidebar refresh", () => {
           detail: { collections: ["active"] },
         }),
       );
-      window.dispatchEvent(
-        new CustomEvent(ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT, {
-          detail: { collections: ["active"] },
-        }),
-      );
     });
-    expect(listRoomsMock).not.toHaveBeenCalled();
 
-    await act(async () => {
-      visibility.mockReturnValue("visible");
-      document.dispatchEvent(new Event("visibilitychange"));
-    });
     expect(listRoomsMock).toHaveBeenCalledTimes(1);
+    expect(result.current.roomRows[0]?.unreadCount).toBe(1);
   });
 
   it("does not restore a removed room from an older poll", async () => {

--- a/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.test.ts
@@ -34,7 +34,7 @@ let hasFocus: ReturnType<typeof vi.spyOn>;
  * come back. The invalidation reads at once (the tab title needs it); the
  * return then has nothing stale left, so the round is exactly one read.
  */
-function returnToForeground() {
+function invalidateWhileAwayAndReturn() {
   hasFocus.mockReturnValue(false);
   window.dispatchEvent(new Event("blur"));
   window.dispatchEvent(
@@ -341,7 +341,7 @@ describe("authoritative sidebar refresh", () => {
     listRoomsMock.mockResolvedValue(
       emptyListResult([{ ...original, unreadCount: 2 }]),
     );
-    await act(async () => returnToForeground());
+    await act(async () => invalidateWhileAwayAndReturn());
     expect(result.current.roomRows[0]?.unreadCount).toBe(2);
   });
 
@@ -532,7 +532,7 @@ describe("authoritative sidebar refresh", () => {
       await act(async () => undefined);
       await act(async () => {
         if (trigger === "focus") {
-          returnToForeground();
+          invalidateWhileAwayAndReturn();
         } else {
           window.dispatchEvent(new Event(trigger));
         }
@@ -587,7 +587,7 @@ describe("authoritative sidebar refresh", () => {
 
       const refreshed = { ...updated, name: "Later room name" };
       listRoomsMock.mockResolvedValue(emptyListResult([refreshed]));
-      await act(async () => returnToForeground());
+      await act(async () => invalidateWhileAwayAndReturn());
       expect(result.current.roomRows).toEqual([refreshed]);
     },
   );
@@ -619,7 +619,7 @@ describe("authoritative sidebar refresh", () => {
     listRoomsMock.mockResolvedValue(
       emptyListResult([{ ...original, unreadCount: 1 }]),
     );
-    await act(async () => returnToForeground());
+    await act(async () => invalidateWhileAwayAndReturn());
     expect(result.current.roomRows[0]?.unreadCount).toBe(1);
   });
 });

--- a/apps/web/src/components/chat/use-organization-chat-rooms.ts
+++ b/apps/web/src/components/chat/use-organization-chat-rooms.ts
@@ -40,9 +40,11 @@ interface UseOrganizationChatRoomsOptions {
  * and every path that can change the rows behind the reader's back (the
  * scheduled recovery read, foreground return, room-read, and the rooms-changed
  * control event). Each collection is its own scheduled read (SOK-986): an
- * invalidation naming only `archived` never re-reads the other two, reads
- * pause while the tab is hidden or unfocused, and a healthy Ably connection
- * slows recovery to once a minute.
+ * invalidation naming only `archived` never re-reads the other two, timer
+ * reads pause while the tab is hidden or unfocused, and a healthy Ably
+ * connection slows recovery to once a minute. An invalidation still reads
+ * while away: the live rows feed the tab title's unread count, which is
+ * the one signal a reader who is not looking at the tab gets.
  *
  * Rendering and room actions live in the components. Room actions still write
  * the archived and pending collections through the setters this returns; the


### PR DESCRIPTION
Regression from #4310 (SOK-986).

## User-facing impact

- On an open room, the browser tab title shows `(N)` when a message arrives in another membership-visible room while the Sokosumi tab is hidden or the window is unfocused. The open-room Ably island attaches the sidebar catalog, not only the selected room, so that create can invalidate the active collection immediately.
- Timer reads still pause in the background. One coalesced read per real change, no polling.

## Root cause

Two gates stacked:

1. The refresh scheduler from #4310 deferred every read, including Ably-triggered requests, until the tab was visible and focused.
2. The open-room page only attached the selected room, so a foreign-room `chat_room_message` never reached the client to request that refresh.

## Fix

- Explicit requests (`requestRefresh`) read at once regardless of foreground. Timer reads still pause in the background and catch up with one read on return.
- An explicit request during an in-flight read stays explicit for the queued follow-up.
- A read that runs clears the pending "needed" flag, so a return does not read a second time.
- `RoomMessageRealtimeBridge` attaches `channelCatalogRooms` (sidebar snapshot merged with the LCP selected room). Desktop sidebar publishes that snapshot on every app page. Token capability still intersects the attach set.

## Still open

Off a room page (including the `/chat` list) no room message channels are attached (ADR 0003: room message subs stay chat-scoped). The mobile Chats unread dot on the list, and the title off a room page, still only move via the 60s timer (paused in the background) or control-channel archive/invite events. Covering those needs the per-user `notification_created` signal and a product decision about silenced notifications; not part of this PR.

## Verification

- `rooms-client-read-visibility.test.tsx`: catalog attach + a create in a room that is not selected dispatches `{ collections: ["active"] }`.
- `use-organization-chat-rooms.test.ts`: hides the tab, delivers an active-collection invalidation, asserts the row gains its unread count immediately.
- `use-chat-tab-unread-presence.test.tsx`: same invalidation-while-hidden contract for the list unread-dot hook, when that island is mounted and an invalidation fires.
- `use-chat-refresh-scheduler.test.ts`: timer reads paused while hidden; explicit requests run while hidden or unfocused; a queued explicit follow-up runs while still hidden with no duplicate read on return.