### PR TITLE
chore(utils): remove unused user-name helpers

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -401,9 +401,7 @@ export {
   type UserMetadata,
 } from "./user-metadata.js";
 export {
-  getFallbackUserName,
   getFirstName,
-  getStoredUserName,
   resolveAccountDisplayName,
 } from "./user-name.js";
 export {

--- a/packages/utils/src/user-name.test.ts
+++ b/packages/utils/src/user-name.test.ts
@@ -2,23 +2,7 @@ import assert from "node:assert/strict";
 
 import { test } from "vitest";
 
-import {
-  getFallbackUserName,
-  getFirstName,
-  getStoredUserName,
-  resolveAccountDisplayName,
-} from "./user-name.js";
-
-test("getStoredUserName preserves a trimmed name", () => {
-  assert.equal(
-    getStoredUserName("  Andreas  ", "andreas@example.com"),
-    "Andreas",
-  );
-});
-
-test("getStoredUserName falls back to the email prefix for blank names", () => {
-  assert.equal(getStoredUserName("   ", "magic@example.com"), "magic");
-});
+import { getFirstName, resolveAccountDisplayName } from "./user-name.js";
 
 test("resolveAccountDisplayName prefers a non-empty trimmed name", () => {
   assert.equal(resolveAccountDisplayName("  Ada  ", "ada@example.com"), "Ada");
@@ -29,19 +13,6 @@ test("resolveAccountDisplayName falls back to the full email when the name is bl
     resolveAccountDisplayName("   ", "ada@example.com"),
     "ada@example.com",
   );
-});
-
-test("getFallbackUserName falls back to the full email when the local part is empty", () => {
-  assert.equal(getFallbackUserName("@example.com"), "@example.com");
-});
-
-test("getFallbackUserName falls back to User when the email is blank", () => {
-  assert.equal(getFallbackUserName("   "), "User");
-});
-
-test("user name helpers trim surrounding whitespace consistently", () => {
-  assert.equal(getFallbackUserName("  spaced@example.com  "), "spaced");
-  assert.equal(getStoredUserName(null, "  @example.com  "), "@example.com");
 });
 
 test("getFirstName returns the given name from a full name", () => {

--- a/packages/utils/src/user-name.ts
+++ b/packages/utils/src/user-name.ts
@@ -1,22 +1,5 @@
 import { Namefully } from "namefully";
 
-export function getFallbackUserName(email: string): string {
-  const normalizedEmail = email.trim();
-  const [prefix] = normalizedEmail.split("@");
-  const normalizedPrefix = prefix?.trim();
-
-  return normalizedPrefix || normalizedEmail || "User";
-}
-
-export function getStoredUserName(
-  name: null | string | undefined,
-  email: string,
-): string {
-  const normalizedName = name?.trim();
-
-  return normalizedName || getFallbackUserName(email);
-}
-
 /** Prefer trimmed name; otherwise the full email (account chrome labels). */
 export function resolveAccountDisplayName(name: string, email: string): string {
   return name.trim() || email;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delete unused `@sokosumi/utils` user-name helpers. Repo-wide search found no product callers for `getFallbackUserName` or `getStoredUserName` — only their definitions, unit tests, and the package barrel.

Account chrome already uses `resolveAccountDisplayName`. That helper, `getFirstName`, and their call sites are unchanged.

## Changes

- Remove `getFallbackUserName` and `getStoredUserName` from `packages/utils/src/user-name.ts`
- Drop both from `packages/utils/src/index.ts` barrel exports
- Remove tests that only covered those two helpers

No migrations. No call-site rewrites.

## Verification

- Repo grep: zero remaining references to the deleted symbols
- `pnpm --filter @sokosumi/utils test src/user-name.test.ts` — 5 passed (remaining `resolveAccountDisplayName` + `getFirstName` tests)
- Husky precommit: `pnpm check` and `pnpm typecheck` (includes `web`) passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fdaddad-583c-4abc-b0db-c461bb6ff3ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fdaddad-583c-4abc-b0db-c461bb6ff3ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

