### PR TITLE
chore(database): demote leftover unused repository methods

### DIFF
--- a/packages/database/src/repositories/member.repository.ts
+++ b/packages/database/src/repositories/member.repository.ts
@@ -111,14 +111,6 @@ export const memberRepository = (() => {
     });
   }
 
-  /**
-   * Retrieves members matching the given filter, including user details.
-   * Supports pagination.
-   *
-   * @param where - Prisma filter for members.
-   * @param tx - Optional Prisma transaction client.
-   * @returns An array of MemberWithUser objects.
-   */
   async function getMembersWithUser(
     where: Prisma.MemberWhereInput,
     tx: Prisma.TransactionClient,
@@ -369,7 +361,6 @@ export const memberRepository = (() => {
     getMembersWithOrganizationByUserId,
     getMembersOrganizationIdsByUserId,
     getMemberByUserIdAndOrganizationId,
-    getMembersWithUser,
     getMembersWithUserAndLastSeen,
     getMembersByOrganizationId,
     listMembersForAdminOverview,

--- a/packages/database/src/repositories/subscription.repository.test.ts
+++ b/packages/database/src/repositories/subscription.repository.test.ts
@@ -33,42 +33,10 @@ describe("subscriptionRepository", () => {
     });
   });
 
-  it("getCurrentInPeriodActiveSubscriptionByReferenceId filters by period window", async () => {
-    const inPeriodRow = { id: "current-period" };
-    let findFirstCall: unknown;
-    const now = new Date("2026-04-10T00:00:00.000Z");
-    const tx = {
-      subscription: {
-        findFirst: async (args: unknown) => {
-          findFirstCall = args;
-          return inPeriodRow;
-        },
-      },
-    } as unknown as Prisma.TransactionClient;
-
-    const result =
-      await subscriptionRepository.getCurrentInPeriodActiveSubscriptionByReferenceId(
-        "reference-1",
-        tx,
-        now,
-      );
-
-    assert.equal(result, inPeriodRow);
-    const call = findFirstCall as {
-      where: {
-        periodEnd: { gt: Date };
-        periodStart: { lte: Date };
-        referenceId: string;
-      };
-    };
-    assert.equal(call.where.referenceId, "reference-1");
-    assert.equal(call.where.periodStart.lte, now);
-    assert.equal(call.where.periodEnd.gt, now);
-  });
-
-  it("resolveActiveSubscriptionByReferenceId prefers in-period over latest by periodEnd", async () => {
+  it("resolveActiveSubscriptionByReferenceId prefers the in-period row and filters by period window", async () => {
     const inPeriodRow = { id: "current-period" };
     const calls: unknown[] = [];
+    const now = new Date("2026-04-10T00:00:00.000Z");
     const tx = {
       subscription: {
         findFirst: async (args: unknown) => {
@@ -85,39 +53,21 @@ describe("subscriptionRepository", () => {
       await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
         "reference-1",
         tx,
+        now,
       );
 
     assert.equal(result, inPeriodRow);
     assert.equal(calls.length, 1);
-  });
-
-  it("getLatestStartedActiveSubscriptionByReferenceId excludes future periodStart", async () => {
-    let findFirstCall: unknown;
-    const now = new Date("2026-04-14T12:00:00.000Z");
-    const tx = {
-      subscription: {
-        findFirst: async (args: unknown) => {
-          findFirstCall = args;
-          return null;
-        },
-      },
-    } as unknown as Prisma.TransactionClient;
-
-    await subscriptionRepository.getLatestStartedActiveSubscriptionByReferenceId(
-      "reference-1",
-      tx,
-      now,
-    );
-
-    const call = findFirstCall as {
+    const call = calls[0] as {
       where: {
-        OR: Array<{ periodStart: null | { lte: Date } }>;
+        periodEnd: { gt: Date };
+        periodStart: { lte: Date };
+        referenceId: string;
       };
     };
-    assert.deepEqual(call.where.OR, [
-      { periodStart: null },
-      { periodStart: { lte: now } },
-    ]);
+    assert.equal(call.where.referenceId, "reference-1");
+    assert.equal(call.where.periodStart.lte, now);
+    assert.equal(call.where.periodEnd.gt, now);
   });
 
   it("resolveActiveSubscriptionByReferenceId falls back to latest started active when not in period", async () => {

--- a/packages/database/src/repositories/subscription.repository.ts
+++ b/packages/database/src/repositories/subscription.repository.ts
@@ -18,6 +18,54 @@ function subscriptionPeriodStartedAtOrBefore(
   };
 }
 
+/**
+ * Active subscription whose billing period contains `now`
+ * (`periodStart <= now < periodEnd`). Use when credits/UI must reflect the
+ * period the customer is in, not a pre-created successor row.
+ */
+async function getCurrentInPeriodActiveSubscriptionByReferenceId(
+  referenceId: string,
+  tx: Prisma.TransactionClient,
+  now: Date,
+): Promise<Subscription | null> {
+  return await tx.subscription.findFirst({
+    where: {
+      referenceId,
+      ...activeSubscriptionStatusWhere(),
+      periodStart: {
+        lte: now,
+      },
+      periodEnd: {
+        gt: now,
+      },
+    },
+    orderBy: [{ updatedAt: "desc" }],
+  });
+}
+
+/**
+ * Active subscription with the latest `periodEnd` among rows whose period has
+ * started (`periodStart` null or `<= now`). Excludes pre-created successors
+ * whose `periodStart` is still in the future.
+ */
+async function getLatestStartedActiveSubscriptionByReferenceId(
+  referenceId: string,
+  tx: Prisma.TransactionClient,
+  now: Date,
+): Promise<Subscription | null> {
+  return await tx.subscription.findFirst({
+    where: {
+      referenceId,
+      ...activeSubscriptionStatusWhere(),
+      ...subscriptionPeriodStartedAtOrBefore(now),
+    },
+    orderBy: [
+      { periodEnd: { sort: "desc", nulls: "last" } },
+      { updatedAt: "desc" },
+    ],
+  });
+}
+
 export const subscriptionRepository = {
   async getSubscriptionByStripeSubscriptionId(
     stripeSubscriptionId: string,
@@ -47,54 +95,6 @@ export const subscriptionRepository = {
   },
 
   /**
-   * Active subscription whose billing period contains `now`
-   * (`periodStart <= now < periodEnd`). Use when credits/UI must reflect the
-   * period the customer is in, not a pre-created successor row.
-   */
-  async getCurrentInPeriodActiveSubscriptionByReferenceId(
-    referenceId: string,
-    tx: Prisma.TransactionClient,
-    now: Date = new Date(),
-  ): Promise<Subscription | null> {
-    return await tx.subscription.findFirst({
-      where: {
-        referenceId,
-        ...activeSubscriptionStatusWhere(),
-        periodStart: {
-          lte: now,
-        },
-        periodEnd: {
-          gt: now,
-        },
-      },
-      orderBy: [{ updatedAt: "desc" }],
-    });
-  },
-
-  /**
-   * Active subscription with the latest `periodEnd` among rows whose period has
-   * started (`periodStart` null or `<= now`). Excludes pre-created successors
-   * whose `periodStart` is still in the future.
-   */
-  async getLatestStartedActiveSubscriptionByReferenceId(
-    referenceId: string,
-    tx: Prisma.TransactionClient,
-    now: Date = new Date(),
-  ): Promise<Subscription | null> {
-    return await tx.subscription.findFirst({
-      where: {
-        referenceId,
-        ...activeSubscriptionStatusWhere(),
-        ...subscriptionPeriodStartedAtOrBefore(now),
-      },
-      orderBy: [
-        { periodEnd: { sort: "desc", nulls: "last" } },
-        { updatedAt: "desc" },
-      ],
-    });
-  },
-
-  /**
    * Billing/credits resolution: current in-period row when one exists, otherwise
    * the latest started active row by `periodEnd` (ended periods, missing dates).
    */
@@ -104,12 +104,12 @@ export const subscriptionRepository = {
     now: Date = new Date(),
   ): Promise<Subscription | null> {
     return (
-      (await subscriptionRepository.getCurrentInPeriodActiveSubscriptionByReferenceId(
+      (await getCurrentInPeriodActiveSubscriptionByReferenceId(
         referenceId,
         tx,
         now,
       )) ??
-      (await subscriptionRepository.getLatestStartedActiveSubscriptionByReferenceId(
+      (await getLatestStartedActiveSubscriptionByReferenceId(
         referenceId,
         tx,
         now,

--- a/packages/database/src/repositories/workspace.repository.ts
+++ b/packages/database/src/repositories/workspace.repository.ts
@@ -24,6 +24,18 @@ async function ensureServiceplanGrantForWorkspace(
   });
 }
 
+async function findOrganizationWorkspace({
+  organizationId,
+  tx,
+}: {
+  organizationId: string;
+  tx: Prisma.TransactionClient;
+}): Promise<Workspace | null> {
+  return await tx.workspace.findUnique({
+    where: { organizationId },
+  });
+}
+
 export const workspaceRepository = {
   async findPersonalWorkspace({
     userId,
@@ -37,18 +49,6 @@ export const workspaceRepository = {
     });
   },
 
-  async findOrganizationWorkspace({
-    organizationId,
-    tx,
-  }: {
-    organizationId: string;
-    tx: Prisma.TransactionClient;
-  }): Promise<Workspace | null> {
-    return await tx.workspace.findUnique({
-      where: { organizationId },
-    });
-  },
-
   async upsertOrganizationWorkspace({
     organizationId,
     tx,
@@ -56,7 +56,7 @@ export const workspaceRepository = {
     organizationId: string;
     tx: Prisma.TransactionClient;
   }): Promise<Workspace> {
-    const existingWorkspace = await this.findOrganizationWorkspace({
+    const existingWorkspace = await findOrganizationWorkspace({
       organizationId,
       tx,
     });
@@ -75,7 +75,7 @@ export const workspaceRepository = {
       return workspace;
     } catch (error) {
       if (isPrismaUniqueConstraintError(error)) {
-        const racedWorkspace = await this.findOrganizationWorkspace({
+        const racedWorkspace = await findOrganizationWorkspace({
           organizationId,
           tx,
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Demotes leftover unused methods on live `@sokosumi/database` repository classes so they are no longer part of the public export surface. This is not a dead-repo sweep.

## Changes

- `memberRepository.getMembersWithUser` is no longer exported. It stays as an internal helper for `getMembersWithUserAndLastSeen`. Removed the false "Supports pagination" JSDoc.
- `getCurrentInPeriodActiveSubscriptionByReferenceId` and `getLatestStartedActiveSubscriptionByReferenceId` are module-private. Billing/credits still resolve through `resolveActiveSubscriptionByReferenceId`.
- `findOrganizationWorkspace` is module-private. Org workspace create/find still goes through `upsertOrganizationWorkspace`.

No migrations. No other packages.

## Verification

- `pnpm --filter @sokosumi/database test src/repositories/subscription.repository.test.ts src/repositories/workspace.repository.test.ts`
- `pnpm --filter @sokosumi/database typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97d10f70-fcb7-4edf-baf8-5ee195e6a507?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97d10f70-fcb7-4edf-baf8-5ee195e6a507&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

