### PR TITLE
feat(core): allow organization members to share and revoke job shares

### DIFF
--- a/apps/core/src/helpers/access-control.job-share.test.ts
+++ b/apps/core/src/helpers/access-control.job-share.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { EnvVariables } from "@/lib/hono";
 import type {
+  CoworkerAuthenticationContext,
   SokoBotAuthenticationContext,
   UserAuthenticationContext,
 } from "@/middleware/auth";
@@ -65,7 +66,8 @@ function varsFor(
   workspaceContext: WorkspaceContext | null,
   authContext:
     | UserAuthenticationContext
-    | SokoBotAuthenticationContext = memberAuthContext,
+    | SokoBotAuthenticationContext
+    | CoworkerAuthenticationContext = memberAuthContext,
 ): EnvVariables["Variables"] {
   return {
     isAuthenticated: true,
@@ -200,6 +202,36 @@ describe("requireJobShareCollaboration", () => {
     // SOK-1030 widens human access only. Agent policy is unchanged.
     expect(requireJobCollaborationMock).toHaveBeenCalledWith(
       sokoBotAuthContext,
+      "job_123",
+      tx,
+    );
+    expect(tx.job.findFirst).not.toHaveBeenCalled();
+  });
+  it("leaves coworker access to the existing collaboration rules", async () => {
+    const tx = createTransactionClient();
+    const coworkerAuthContext: CoworkerAuthenticationContext = {
+      actor: "coworker",
+      coworkerId: "cow_123",
+      vendorId: "01960001-0001-7001-8001-000000000001",
+      context: {
+        userId: "member_456",
+        organizationId: "org_123",
+      },
+    };
+
+    requireJobCollaborationMock.mockResolvedValueOnce({ id: "job_123" });
+
+    await expect(
+      requireJobShareCollaboration(
+        varsFor(organizationWorkspaceContext, coworkerAuthContext),
+        "job_123",
+        tx,
+      ),
+    ).resolves.toMatchObject({ id: "job_123" });
+
+    // A coworker still needs the tasks capability and a task assigned to it.
+    expect(requireJobCollaborationMock).toHaveBeenCalledWith(
+      coworkerAuthContext,
       "job_123",
       tx,
     );

--- a/apps/core/src/helpers/access-control.job-share.test.ts
+++ b/apps/core/src/helpers/access-control.job-share.test.ts
@@ -77,7 +77,7 @@ function varsFor(
 }
 
 describe("requireJobShareCollaboration", () => {
-  it("scopes a member to the active workspace without an ownership filter", async () => {
+  it("admits the owner or any member of the active workspace", async () => {
     const tx = createTransactionClient();
     vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
       id: "job_123",

--- a/apps/core/src/helpers/access-control.job-share.test.ts
+++ b/apps/core/src/helpers/access-control.job-share.test.ts
@@ -15,8 +15,8 @@ const { requireJobCollaborationMock } = vi.hoisted(() => ({
   requireJobCollaborationMock: vi.fn(),
 }));
 
-// Only the agent branch is mocked. The human branch below runs the real
-// `requireJobRead`, so its where clause is the assertion, not a stub.
+// Only the agent branch is mocked. The human branch below runs the helper's own
+// query, so the asserted `where` clause is the real policy, not a stub.
 vi.mock("./access-control", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./access-control")>();
 

--- a/apps/core/src/helpers/access-control.job-share.test.ts
+++ b/apps/core/src/helpers/access-control.job-share.test.ts
@@ -93,9 +93,15 @@ describe("requireJobShareCollaboration", () => {
       ),
     ).resolves.toMatchObject({ id: "job_123" });
 
-    // The whole policy is in this where clause: workspace, never ownerId.
+    // The whole policy is in this where clause: owner OR workspace member.
     expect(tx.job.findFirst).toHaveBeenCalledWith({
-      where: { id: "job_123", workspaceId: organizationWorkspaceId },
+      where: {
+        id: "job_123",
+        OR: [
+          { ownerId: "member_456" },
+          { workspaceId: organizationWorkspaceId },
+        ],
+      },
     });
   });
 
@@ -126,18 +132,57 @@ describe("requireJobShareCollaboration", () => {
     ).rejects.toThrow("Job not found");
 
     expect(tx.job.findFirst).toHaveBeenCalledWith({
-      where: { id: "job_of_another_user", workspaceId: personalWorkspaceId },
+      where: {
+        id: "job_of_another_user",
+        OR: [{ ownerId: "member_456" }, { workspaceId: personalWorkspaceId }],
+      },
     });
   });
 
-  it("denies a member with no workspace context", async () => {
+  // API key and OAuth callers carry `organizationId: null`, so they can reach
+  // this helper with no organization workspace. They must keep sharing the jobs
+  // they own.
+  it("falls back to ownership when there is no workspace context", async () => {
     const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      ownerId: "member_456",
+      taskId: null,
+    } as never);
 
     await expect(
       requireJobShareCollaboration(varsFor(null), "job_123", tx),
-    ).rejects.toThrow("Workspace is missing");
+    ).resolves.toMatchObject({ id: "job_123" });
 
-    expect(tx.job.findFirst).not.toHaveBeenCalled();
+    expect(tx.job.findFirst).toHaveBeenCalledWith({
+      where: { id: "job_123", OR: [{ ownerId: "member_456" }] },
+    });
+  });
+
+  it("denies a non-owner with no workspace context", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce(null);
+
+    await expect(
+      requireJobShareCollaboration(varsFor(null), "job_of_another_user", tx),
+    ).rejects.toThrow("Job not found");
+  });
+
+  it("lets an owner share a job outside their active workspace", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      ownerId: "member_456",
+      taskId: null,
+    } as never);
+
+    await expect(
+      requireJobShareCollaboration(
+        varsFor(personalWorkspaceContext),
+        "job_123",
+        tx,
+      ),
+    ).resolves.toMatchObject({ id: "job_123" });
   });
 
   it("denies a job whose parent task is parked", async () => {

--- a/apps/core/src/helpers/access-control.job-share.test.ts
+++ b/apps/core/src/helpers/access-control.job-share.test.ts
@@ -1,0 +1,208 @@
+import { type Prisma, TaskStatus } from "@sokosumi/database";
+import { describe, expect, it, vi } from "vitest";
+
+import type { EnvVariables } from "@/lib/hono";
+import type {
+  SokoBotAuthenticationContext,
+  UserAuthenticationContext,
+} from "@/middleware/auth";
+import type { WorkspaceContext } from "@/middleware/workspace";
+
+import { requireJobShareCollaboration } from "./access-control.job-share";
+
+const { requireJobCollaborationMock } = vi.hoisted(() => ({
+  requireJobCollaborationMock: vi.fn(),
+}));
+
+// Only the agent branch is mocked. The human branch below runs the real
+// `requireJobRead`, so its where clause is the assertion, not a stub.
+vi.mock("./access-control", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./access-control")>();
+
+  return {
+    ...actual,
+    requireJobCollaboration: requireJobCollaborationMock,
+  };
+});
+
+const organizationWorkspaceId = "11111111-1111-7111-8111-111111111111";
+const personalWorkspaceId = "22222222-2222-7222-8222-222222222222";
+
+function createTransactionClient() {
+  return {
+    job: {
+      findFirst: vi.fn(),
+    },
+    task: {
+      findFirst: vi.fn(),
+    },
+    sokoBot: {
+      findFirst: vi.fn(),
+    },
+  } as unknown as Prisma.TransactionClient;
+}
+
+const memberAuthContext: UserAuthenticationContext = {
+  actor: "user",
+  userId: "member_456",
+  organizationId: "org_123",
+  role: "user",
+};
+
+const organizationWorkspaceContext: WorkspaceContext = {
+  workspaceId: organizationWorkspaceId,
+  userId: null,
+  organizationId: "org_123",
+};
+
+const personalWorkspaceContext: WorkspaceContext = {
+  workspaceId: personalWorkspaceId,
+  userId: "member_456",
+  organizationId: null,
+};
+
+function varsFor(
+  workspaceContext: WorkspaceContext | null,
+  authContext:
+    | UserAuthenticationContext
+    | SokoBotAuthenticationContext = memberAuthContext,
+): EnvVariables["Variables"] {
+  return {
+    isAuthenticated: true,
+    authContext,
+    workspaceContext,
+  };
+}
+
+describe("requireJobShareCollaboration", () => {
+  it("scopes a member to the active workspace without an ownership filter", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      ownerId: "other_member_789",
+      taskId: null,
+    } as never);
+
+    await expect(
+      requireJobShareCollaboration(
+        varsFor(organizationWorkspaceContext),
+        "job_123",
+        tx,
+      ),
+    ).resolves.toMatchObject({ id: "job_123" });
+
+    // The whole policy is in this where clause: workspace, never ownerId.
+    expect(tx.job.findFirst).toHaveBeenCalledWith({
+      where: { id: "job_123", workspaceId: organizationWorkspaceId },
+    });
+  });
+
+  it("denies a job outside the active workspace", async () => {
+    const tx = createTransactionClient();
+    // A job in another organization's workspace does not match the filter.
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce(null);
+
+    await expect(
+      requireJobShareCollaboration(
+        varsFor(organizationWorkspaceContext),
+        "job_other_org",
+        tx,
+      ),
+    ).rejects.toThrow("Job not found");
+  });
+
+  it("scopes a personal workspace to that workspace only", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce(null);
+
+    await expect(
+      requireJobShareCollaboration(
+        varsFor(personalWorkspaceContext),
+        "job_of_another_user",
+        tx,
+      ),
+    ).rejects.toThrow("Job not found");
+
+    expect(tx.job.findFirst).toHaveBeenCalledWith({
+      where: { id: "job_of_another_user", workspaceId: personalWorkspaceId },
+    });
+  });
+
+  it("denies a member with no workspace context", async () => {
+    const tx = createTransactionClient();
+
+    await expect(
+      requireJobShareCollaboration(varsFor(null), "job_123", tx),
+    ).rejects.toThrow("Workspace is missing");
+
+    expect(tx.job.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("denies a job whose parent task is parked", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      ownerId: "other_member_789",
+      taskId: "tsk_123",
+    } as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      status: TaskStatus.GRANT_PENDING,
+    } as never);
+
+    await expect(
+      requireJobShareCollaboration(
+        varsFor(organizationWorkspaceContext),
+        "job_123",
+        tx,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("allows a job whose parent task is not parked", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      ownerId: "other_member_789",
+      taskId: "tsk_123",
+    } as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      status: TaskStatus.COMPLETED,
+    } as never);
+
+    await expect(
+      requireJobShareCollaboration(
+        varsFor(organizationWorkspaceContext),
+        "job_123",
+        tx,
+      ),
+    ).resolves.toMatchObject({ id: "job_123" });
+  });
+  it("leaves Soko Bot access to the existing collaboration rules", async () => {
+    const tx = createTransactionClient();
+    const sokoBotAuthContext = {
+      actor: "sokoBot",
+      sokoBotId: "bot_123",
+      userId: "member_456",
+      organizationId: "org_123",
+      workspaceId: organizationWorkspaceId,
+    } as unknown as SokoBotAuthenticationContext;
+
+    requireJobCollaborationMock.mockResolvedValueOnce({ id: "job_123" });
+
+    await expect(
+      requireJobShareCollaboration(
+        varsFor(organizationWorkspaceContext, sokoBotAuthContext),
+        "job_123",
+        tx,
+      ),
+    ).resolves.toMatchObject({ id: "job_123" });
+
+    // SOK-1030 widens human access only. Agent policy is unchanged.
+    expect(requireJobCollaborationMock).toHaveBeenCalledWith(
+      sokoBotAuthContext,
+      "job_123",
+      tx,
+    );
+    expect(tx.job.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/helpers/access-control.job-share.ts
+++ b/apps/core/src/helpers/access-control.job-share.ts
@@ -2,23 +2,28 @@ import type { Job, Prisma } from "@sokosumi/database";
 
 import prisma from "@/lib/db/prisma";
 import type { EnvVariables } from "@/lib/hono";
-import { isUserAuthContext } from "@/middleware/auth";
-import { requireWorkspaceContext } from "@/middleware/workspace";
+import { isUserAuthContext, requireUserContext } from "@/middleware/auth";
 
 import {
   requireJobCollaboration,
-  requireJobRead,
   requireParentTaskNotParked,
 } from "./access-control";
+import { notFound } from "./error";
 
 /**
  * Public-share write access for a job: create, update, or revoke the share.
  *
- * Any human member of the job's workspace may share, not only the job owner
- * (SOK-1030). The workspace is the permission boundary: `workspaceContext` is
- * resolved server-side from the session's active organization, never from a
- * client header, so an organization workspace admits every member of that
- * organization while a personal workspace admits only its owner.
+ * A human caller qualifies as the job owner, or as a member of the job's
+ * workspace (SOK-1030). The workspace half is what widens sharing beyond the
+ * owner: `workspaceContext` is resolved server-side from the session's active
+ * organization, never from a client header, so an organization workspace admits
+ * every member of that organization while a personal workspace admits only its
+ * owner.
+ *
+ * Ownership stays in the predicate because API key and OAuth callers carry no
+ * active organization (`organizationId: null` in their auth context), so their
+ * workspace resolves to the personal one. Dropping ownership would stop them
+ * sharing their own organization jobs.
  *
  * Deliberately separate from {@link requireJobCollaboration}, which also guards
  * refund, workspace move, metadata patch, and input submission. Widening that
@@ -27,7 +32,7 @@ import {
  * Soko Bot and coworker contexts keep their existing collaboration rules
  * unchanged; this only widens human access.
  *
- * @throws {notFound} If the job is not in the caller's active workspace
+ * @throws {notFound} If the caller neither owns the job nor shares its workspace
  * @throws {forbidden} If the parent task is parked, or the agent context is not
  *   permitted to act on the job
  */
@@ -42,11 +47,24 @@ export async function requireJobShareCollaboration(
     return await requireJobCollaboration(authContext, jobId, tx);
   }
 
-  const job = await requireJobRead(
-    requireWorkspaceContext(workspaceContext),
-    jobId,
-    tx,
-  );
+  const userContext = requireUserContext(authContext);
+
+  const job = await tx.job.findFirst({
+    where: {
+      id: jobId,
+      OR: [
+        { ownerId: userContext.userId },
+        ...(workspaceContext
+          ? [{ workspaceId: workspaceContext.workspaceId }]
+          : []),
+      ],
+    },
+  });
+
+  if (!job) {
+    throw notFound("Job not found");
+  }
+
   await requireParentTaskNotParked(job, tx);
 
   return job;

--- a/apps/core/src/helpers/access-control.job-share.ts
+++ b/apps/core/src/helpers/access-control.job-share.ts
@@ -15,10 +15,14 @@ import { notFound } from "./error";
  *
  * A human caller qualifies as the job owner, or as a member of the job's
  * workspace (SOK-1030). The workspace half is what widens sharing beyond the
- * owner: `workspaceContext` is resolved server-side from the session's active
- * organization, never from a client header, so an organization workspace admits
- * every member of that organization while a personal workspace admits only its
- * owner.
+ * owner, so an organization workspace admits every member of that organization
+ * while a personal workspace admits only its owner.
+ *
+ * `workspaceContext` is not client-controlled. It comes from the session's
+ * active organization, or, when the session carries none, from an
+ * `X-Organization-Slug` header that `organizationHeaderMiddleware` resolves
+ * only after `resolveOrganizationFromSlug` confirms the caller's `Member` row.
+ * A caller therefore cannot name an organization they do not belong to.
  *
  * Ownership stays in the predicate because API key and OAuth callers carry no
  * active organization (`organizationId: null` in their auth context), so their

--- a/apps/core/src/helpers/access-control.job-share.ts
+++ b/apps/core/src/helpers/access-control.job-share.ts
@@ -36,7 +36,8 @@ import { notFound } from "./error";
  * Soko Bot and coworker contexts keep their existing collaboration rules
  * unchanged; this only widens human access.
  *
- * @throws {notFound} If the caller neither owns the job nor shares its workspace
+ * @throws {notFound} If the caller neither owns the job nor shares its
+ *   workspace, or if the job's parent task is missing or archived
  * @throws {forbidden} If the parent task is parked, or the agent context is not
  *   permitted to act on the job
  */

--- a/apps/core/src/helpers/access-control.job-share.ts
+++ b/apps/core/src/helpers/access-control.job-share.ts
@@ -2,7 +2,7 @@ import type { Job, Prisma } from "@sokosumi/database";
 
 import prisma from "@/lib/db/prisma";
 import type { EnvVariables } from "@/lib/hono";
-import { isUserAuthContext, requireUserContext } from "@/middleware/auth";
+import { isUserAuthContext } from "@/middleware/auth";
 import { requireWorkspaceContext } from "@/middleware/workspace";
 
 import {
@@ -41,8 +41,6 @@ export async function requireJobShareCollaboration(
   if (!isUserAuthContext(authContext)) {
     return await requireJobCollaboration(authContext, jobId, tx);
   }
-
-  requireUserContext(authContext);
 
   const job = await requireJobRead(
     requireWorkspaceContext(workspaceContext),

--- a/apps/core/src/helpers/access-control.job-share.ts
+++ b/apps/core/src/helpers/access-control.job-share.ts
@@ -1,0 +1,55 @@
+import type { Job, Prisma } from "@sokosumi/database";
+
+import prisma from "@/lib/db/prisma";
+import type { EnvVariables } from "@/lib/hono";
+import { isUserAuthContext, requireUserContext } from "@/middleware/auth";
+import { requireWorkspaceContext } from "@/middleware/workspace";
+
+import {
+  requireJobCollaboration,
+  requireJobRead,
+  requireParentTaskNotParked,
+} from "./access-control";
+
+/**
+ * Public-share write access for a job: create, update, or revoke the share.
+ *
+ * Any human member of the job's workspace may share, not only the job owner
+ * (SOK-1030). The workspace is the permission boundary: `workspaceContext` is
+ * resolved server-side from the session's active organization, never from a
+ * client header, so an organization workspace admits every member of that
+ * organization while a personal workspace admits only its owner.
+ *
+ * Deliberately separate from {@link requireJobCollaboration}, which also guards
+ * refund, workspace move, metadata patch, and input submission. Widening that
+ * helper would widen those routes too.
+ *
+ * Soko Bot and coworker contexts keep their existing collaboration rules
+ * unchanged; this only widens human access.
+ *
+ * @throws {notFound} If the job is not in the caller's active workspace
+ * @throws {forbidden} If the parent task is parked, or the agent context is not
+ *   permitted to act on the job
+ */
+export async function requireJobShareCollaboration(
+  vars: EnvVariables["Variables"],
+  jobId: string,
+  tx: Prisma.TransactionClient = prisma,
+): Promise<Job> {
+  const { authContext, workspaceContext } = vars;
+
+  if (!isUserAuthContext(authContext)) {
+    return await requireJobCollaboration(authContext, jobId, tx);
+  }
+
+  requireUserContext(authContext);
+
+  const job = await requireJobRead(
+    requireWorkspaceContext(workspaceContext),
+    jobId,
+    tx,
+  );
+  await requireParentTaskNotParked(job, tx);
+
+  return job;
+}

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -2270,6 +2270,26 @@ describe("requireJobCollaboration", () => {
     ).rejects.toThrow("You can only access your own jobs");
   });
 
+  // SOK-1030 widened job *sharing* to any workspace member via
+  // `requireJobShareCollaboration`. This helper still guards refund, workspace
+  // move, metadata patch, and input submission, so it must stay owner-only.
+  it("stays owner-only for a member of the same organization", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce(null);
+
+    await expect(
+      requireJobCollaboration(
+        { ...userAuthContext, userId: "member_456" },
+        "job_of_another_member",
+        tx,
+      ),
+    ).rejects.toThrow("You can only access your own jobs");
+
+    expect(tx.job.findFirst).toHaveBeenCalledWith({
+      where: { id: "job_of_another_member", ownerId: "member_456" },
+    });
+  });
+
   it("allows a delegated coworker to act on a job assigned to it", async () => {
     const tx = createTransactionClient();
 

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -1052,7 +1052,7 @@ export async function requireJobReadForRouteVars(
   return job;
 }
 
-async function requireParentTaskNotParked(
+export async function requireParentTaskNotParked(
   job: Pick<Job, "taskId">,
   tx: Prisma.TransactionClient,
 ): Promise<void> {

--- a/apps/core/src/routes/v1/jobs/[id]/share/delete.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/delete.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { forbidden } from "@/helpers/error";
+import { forbidden, notFound } from "@/helpers/error";
 import { OpenAPIHonoWithAuth } from "@/lib/hono";
 
 import mountDeleteJobShareById from "./delete";
@@ -193,9 +193,9 @@ describe("DELETE /jobs/{id}/share", () => {
     expect(deleteByJobIdMock).not.toHaveBeenCalled();
   });
 
-  it("returns 403 when the job does not exist (no existence leak)", async () => {
+  it("returns 404 when the job is not reachable (no existence leak)", async () => {
     requireJobShareCollaborationMock.mockRejectedValueOnce(
-      forbidden("Job not found"),
+      notFound("Job not found"),
     );
     const app = createApp();
 
@@ -203,7 +203,7 @@ describe("DELETE /jobs/{id}/share", () => {
       method: "DELETE",
     });
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(deleteByJobIdMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/jobs/[id]/share/delete.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/delete.test.ts
@@ -9,7 +9,7 @@ const {
   authContextState,
   prismaTransactionMock,
   deleteByJobIdMock,
-  requireJobCollaborationMock,
+  requireJobShareCollaborationMock,
 } = vi.hoisted(() => ({
   authContextState: {
     current: {
@@ -26,11 +26,11 @@ const {
   },
   prismaTransactionMock: vi.fn(),
   deleteByJobIdMock: vi.fn(),
-  requireJobCollaborationMock: vi.fn(),
+  requireJobShareCollaborationMock: vi.fn(),
 }));
 
-vi.mock("@/helpers/access-control.js", () => ({
-  requireJobCollaboration: requireJobCollaborationMock,
+vi.mock("@/helpers/access-control.job-share.js", () => ({
+  requireJobShareCollaboration: requireJobShareCollaborationMock,
 }));
 
 vi.mock("@/middleware/auth", () => ({
@@ -124,7 +124,7 @@ describe("DELETE /jobs/{id}/share", () => {
     prismaTransactionMock.mockImplementation(
       async (callback: (tx: unknown) => Promise<unknown>) => await callback({}),
     );
-    requireJobCollaborationMock.mockResolvedValue({
+    requireJobShareCollaborationMock.mockResolvedValue({
       id: "job_123",
       userId: "user_123",
       taskId: null,
@@ -160,9 +160,28 @@ describe("DELETE /jobs/{id}/share", () => {
     expect(deleteByJobIdMock).not.toHaveBeenCalled();
   });
 
-  it("returns 403 when the job is owned by another user", async () => {
-    requireJobCollaborationMock.mockRejectedValueOnce(
-      forbidden("You can only access your own jobs"),
+  it("revokes the share on another member's job in the same workspace", async () => {
+    requireJobShareCollaborationMock.mockResolvedValue({
+      id: "job_123",
+      userId: "other_member_456",
+      taskId: null,
+    });
+    const app = createApp();
+
+    const response = await app.request("http://localhost/job_123/share", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+    expect(deleteByJobIdMock).toHaveBeenCalledWith(
+      "job_123",
+      expect.any(Object),
+    );
+  });
+
+  it("propagates a 403 from the access check", async () => {
+    requireJobShareCollaborationMock.mockRejectedValueOnce(
+      forbidden("Task is parked"),
     );
     const app = createApp();
 
@@ -175,8 +194,8 @@ describe("DELETE /jobs/{id}/share", () => {
   });
 
   it("returns 403 when the job does not exist (no existence leak)", async () => {
-    requireJobCollaborationMock.mockRejectedValueOnce(
-      forbidden("You can only access your own jobs"),
+    requireJobShareCollaborationMock.mockRejectedValueOnce(
+      forbidden("Job not found"),
     );
     const app = createApp();
 

--- a/apps/core/src/routes/v1/jobs/[id]/share/delete.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/delete.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { publicShareRepository } from "@sokosumi/database/repositories";
 
-import { requireJobCollaboration } from "@/helpers/access-control.js";
+import { requireJobShareCollaboration } from "@/helpers/access-control.job-share.js";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -45,7 +45,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id } = c.req.valid("param");
 
     await prisma.$transaction(async (tx) => {
-      await requireJobCollaboration(c.var.authContext, id, tx);
+      await requireJobShareCollaboration(c.var, id, tx);
 
       await publicShareRepository.deleteByJobId(id, tx);
     });

--- a/apps/core/src/routes/v1/jobs/[id]/share/put.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/put.test.ts
@@ -9,7 +9,7 @@ const {
   authContextState,
   prismaTransactionMock,
   upsertForJobMock,
-  requireJobCollaborationMock,
+  requireJobShareCollaborationMock,
 } = vi.hoisted(() => ({
   authContextState: {
     current: {
@@ -26,11 +26,11 @@ const {
   },
   prismaTransactionMock: vi.fn(),
   upsertForJobMock: vi.fn(),
-  requireJobCollaborationMock: vi.fn(),
+  requireJobShareCollaborationMock: vi.fn(),
 }));
 
-vi.mock("@/helpers/access-control.js", () => ({
-  requireJobCollaboration: requireJobCollaborationMock,
+vi.mock("@/helpers/access-control.job-share.js", () => ({
+  requireJobShareCollaboration: requireJobShareCollaborationMock,
 }));
 
 vi.mock("@/middleware/auth", () => ({
@@ -124,7 +124,7 @@ describe("PUT /jobs/{id}/share", () => {
     prismaTransactionMock.mockImplementation(
       async (callback: (tx: unknown) => Promise<unknown>) => await callback({}),
     );
-    requireJobCollaborationMock.mockResolvedValue({
+    requireJobShareCollaborationMock.mockResolvedValue({
       id: "job_123",
       userId: "user_123",
       taskId: null,
@@ -185,9 +185,35 @@ describe("PUT /jobs/{id}/share", () => {
     expect(upsertForJobMock).not.toHaveBeenCalled();
   });
 
-  it("returns 403 when the job is owned by another user", async () => {
-    requireJobCollaborationMock.mockRejectedValueOnce(
-      forbidden("You can only access your own jobs"),
+  it("creates a share for another member's job in the same workspace", async () => {
+    requireJobShareCollaborationMock.mockResolvedValue({
+      id: "job_123",
+      userId: "other_member_456",
+      taskId: null,
+    });
+    const app = createApp();
+
+    const response = await app.request("http://localhost/job_123/share", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        allowSearchIndexing: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(upsertForJobMock).toHaveBeenCalledWith(
+      "job_123",
+      true,
+      expect.any(Object),
+    );
+  });
+
+  it("propagates a 403 from the access check", async () => {
+    requireJobShareCollaborationMock.mockRejectedValueOnce(
+      forbidden("Task is parked"),
     );
     const app = createApp();
 
@@ -206,8 +232,8 @@ describe("PUT /jobs/{id}/share", () => {
   });
 
   it("returns 403 when the job does not exist (no existence leak)", async () => {
-    requireJobCollaborationMock.mockRejectedValueOnce(
-      forbidden("You can only access your own jobs"),
+    requireJobShareCollaborationMock.mockRejectedValueOnce(
+      forbidden("Job not found"),
     );
     const app = createApp();
 

--- a/apps/core/src/routes/v1/jobs/[id]/share/put.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/put.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { forbidden } from "@/helpers/error";
+import { forbidden, notFound } from "@/helpers/error";
 import { OpenAPIHonoWithAuth } from "@/lib/hono";
 
 import mountPutJobShareById from "./put";
@@ -231,9 +231,9 @@ describe("PUT /jobs/{id}/share", () => {
     expect(upsertForJobMock).not.toHaveBeenCalled();
   });
 
-  it("returns 403 when the job does not exist (no existence leak)", async () => {
+  it("returns 404 when the job is not reachable (no existence leak)", async () => {
     requireJobShareCollaborationMock.mockRejectedValueOnce(
-      forbidden("Job not found"),
+      notFound("Job not found"),
     );
     const app = createApp();
 
@@ -247,7 +247,7 @@ describe("PUT /jobs/{id}/share", () => {
       }),
     });
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(upsertForJobMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/jobs/[id]/share/put.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/put.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { publicShareRepository } from "@sokosumi/database/repositories";
 
-import { requireJobCollaboration } from "@/helpers/access-control.js";
+import { requireJobShareCollaboration } from "@/helpers/access-control.job-share.js";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -50,7 +50,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { allowSearchIndexing } = c.req.valid("json");
 
     const share = await prisma.$transaction(async (tx) => {
-      await requireJobCollaboration(c.var.authContext, id, tx);
+      await requireJobShareCollaboration(c.var, id, tx);
 
       return await publicShareRepository.upsertForJob(
         id,

--- a/apps/web/src/components/jobs/job-details/job-details-view.test.tsx
+++ b/apps/web/src/components/jobs/job-details/job-details-view.test.tsx
@@ -259,6 +259,57 @@ describe("JobDetailsView", () => {
     expect(screen.queryByLabelText("moveToWorkspace")).not.toBeInTheDocument();
   });
 
+  // The public /share/[token] page renders this view. No mutation control may
+  // reach an anonymous viewer, whichever render path is taken.
+  it("renders no action controls under the public job layout", () => {
+    useJobsHeaderMock.mockReturnValue({
+      agent: {
+        id: "agent-1",
+        credits: 100,
+      },
+      ratingStats: { averageRating: 0, ratingCount: 0 },
+      canRate: false,
+      existingRating: null,
+      disabled: false,
+    });
+
+    render(
+      <JobDetailsView
+        job={createJob()}
+        readOnly
+        publicJobLayout
+        showAgentHeader
+      />,
+    );
+
+    expect(screen.queryByLabelText("share")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("edit")).not.toBeInTheDocument();
+  });
+
+  it("renders no action controls under the public job layout inline path", () => {
+    render(
+      <JobDetailsView
+        job={createJob()}
+        readOnly
+        publicJobLayout
+        showAgentHeader={false}
+      />,
+    );
+
+    expect(screen.queryByLabelText("share")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("edit")).not.toBeInTheDocument();
+  });
+
+  // The inline path is the one used by the job details modal.
+  it("renders share on the inline path for a job owned by another member", () => {
+    render(
+      <JobDetailsView job={createJob()} readOnly showAgentHeader={false} />,
+    );
+
+    expect(screen.getByLabelText("share")).toBeInTheDocument();
+    expect(screen.queryByLabelText("edit")).not.toBeInTheDocument();
+  });
+
   it("renders a move action for standalone jobs when another workspace is available", () => {
     useJobsHeaderMock.mockReturnValue({
       agent: {

--- a/apps/web/src/components/jobs/job-details/job-details-view.test.tsx
+++ b/apps/web/src/components/jobs/job-details/job-details-view.test.tsx
@@ -239,6 +239,26 @@ describe("JobDetailsView", () => {
     expect(screen.getByLabelText("share")).toBeInTheDocument();
   });
 
+  // SOK-1030: a workspace member who does not own the job may still share it.
+  it("renders share but not edit for a job owned by another member", () => {
+    useJobsHeaderMock.mockReturnValue({
+      agent: {
+        id: "agent-1",
+        credits: 100,
+      },
+      ratingStats: { averageRating: 0, ratingCount: 0 },
+      canRate: false,
+      existingRating: null,
+      disabled: false,
+    });
+
+    render(<JobDetailsView job={createJob()} readOnly showAgentHeader />);
+
+    expect(screen.getByLabelText("share")).toBeInTheDocument();
+    expect(screen.queryByLabelText("edit")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("moveToWorkspace")).not.toBeInTheDocument();
+  });
+
   it("renders a move action for standalone jobs when another workspace is available", () => {
     useJobsHeaderMock.mockReturnValue({
       agent: {

--- a/apps/web/src/components/jobs/job-details/job-details-view.tsx
+++ b/apps/web/src/components/jobs/job-details/job-details-view.tsx
@@ -54,7 +54,12 @@ export interface JobDetailsViewProps {
   personalWorkspaceLabel?: string;
   projectName?: string | null;
   showAgentHeader?: boolean;
-  /** Share route only: eyebrow, status badge, agent title, mobile top offset. */
+  /**
+   * Share route only: eyebrow, status badge, agent title, mobile top offset.
+   * Also suppresses every job action control on both render paths, so an
+   * anonymous viewer of `/share/[token]` gets no share, rename, or move
+   * button.
+   */
   publicJobLayout?: boolean;
 }
 

--- a/apps/web/src/components/jobs/job-details/job-details-view.tsx
+++ b/apps/web/src/components/jobs/job-details/job-details-view.tsx
@@ -113,15 +113,17 @@ export default function JobDetailsView({
               <Header
                 {...jobsHeader}
                 detailActions={
-                  <JobDetailsTopBarActions
-                    job={job}
-                    editing={nameController.editing}
-                    onEdit={nameController.startEditing}
-                    organizations={organizations}
-                    hasPersonalWorkspace={hasPersonalWorkspace}
-                    personalWorkspaceLabel={personalWorkspaceLabel}
-                    readOnly={readOnly}
-                  />
+                  publicJobLayout ? undefined : (
+                    <JobDetailsTopBarActions
+                      job={job}
+                      editing={nameController.editing}
+                      onEdit={nameController.startEditing}
+                      organizations={organizations}
+                      hasPersonalWorkspace={hasPersonalWorkspace}
+                      personalWorkspaceLabel={personalWorkspaceLabel}
+                      readOnly={readOnly}
+                    />
+                  )
                 }
               />
             ) : null}
@@ -132,6 +134,7 @@ export default function JobDetailsView({
                 hasPersonalWorkspace={hasPersonalWorkspace}
                 personalWorkspaceLabel={personalWorkspaceLabel}
                 readOnly={readOnly}
+                publicJobLayout={publicJobLayout}
                 showInlineActions={!showAgentHeader}
                 controller={nameController}
               />
@@ -193,6 +196,7 @@ function JobDetailsHeader({
   hasPersonalWorkspace = false,
   personalWorkspaceLabel,
   readOnly,
+  publicJobLayout,
   showInlineActions,
   controller,
 }: {
@@ -201,12 +205,13 @@ function JobDetailsHeader({
   hasPersonalWorkspace?: boolean;
   personalWorkspaceLabel?: string;
   readOnly: boolean;
+  publicJobLayout: boolean;
   showInlineActions: boolean;
   controller: ReturnType<typeof useJobDetailsNameController>;
 }) {
   return (
     <div className="flex flex-col gap-2" key={`${job.id}-details-header`}>
-      {showInlineActions ? (
+      {showInlineActions && !publicJobLayout ? (
         <div className="flex justify-end">
           <JobDetailsTopBarActions
             job={job}

--- a/apps/web/src/components/jobs/job-details/job-details-view.tsx
+++ b/apps/web/src/components/jobs/job-details/job-details-view.tsx
@@ -113,16 +113,15 @@ export default function JobDetailsView({
               <Header
                 {...jobsHeader}
                 detailActions={
-                  !readOnly ? (
-                    <JobDetailsTopBarActions
-                      job={job}
-                      editing={nameController.editing}
-                      onEdit={nameController.startEditing}
-                      organizations={organizations}
-                      hasPersonalWorkspace={hasPersonalWorkspace}
-                      personalWorkspaceLabel={personalWorkspaceLabel}
-                    />
-                  ) : undefined
+                  <JobDetailsTopBarActions
+                    job={job}
+                    editing={nameController.editing}
+                    onEdit={nameController.startEditing}
+                    organizations={organizations}
+                    hasPersonalWorkspace={hasPersonalWorkspace}
+                    personalWorkspaceLabel={personalWorkspaceLabel}
+                    readOnly={readOnly}
+                  />
                 }
               />
             ) : null}
@@ -207,7 +206,7 @@ function JobDetailsHeader({
 }) {
   return (
     <div className="flex flex-col gap-2" key={`${job.id}-details-header`}>
-      {!readOnly && showInlineActions ? (
+      {showInlineActions ? (
         <div className="flex justify-end">
           <JobDetailsTopBarActions
             job={job}
@@ -216,6 +215,7 @@ function JobDetailsHeader({
             organizations={organizations}
             hasPersonalWorkspace={hasPersonalWorkspace}
             personalWorkspaceLabel={personalWorkspaceLabel}
+            readOnly={readOnly}
           />
         </div>
       ) : null}
@@ -237,6 +237,7 @@ function JobDetailsTopBarActions({
   hasPersonalWorkspace = false,
   onEdit,
   personalWorkspaceLabel,
+  readOnly,
 }: {
   job: Job;
   editing: boolean;
@@ -244,6 +245,7 @@ function JobDetailsTopBarActions({
   hasPersonalWorkspace?: boolean;
   onEdit: () => void;
   personalWorkspaceLabel?: string;
+  readOnly: boolean;
 }) {
   const tName = useTranslations("Components.Jobs.JobDetails.Header.JobName");
   const tActions = useTranslations("Components.Jobs.JobDetails.Header.Actions");
@@ -254,9 +256,11 @@ function JobDetailsTopBarActions({
     organizations,
     hasPersonalWorkspace,
   );
+  // Any member of the job's workspace may share it (SOK-1030). Renaming and
+  // moving stay with the owner, so `readOnly` still hides those.
   const canMoveStandaloneJob =
-    !job.taskId && moveTargetCount > 0 && !!personalWorkspaceLabel;
-  const isTaskControlledJob = !!job.taskId;
+    !readOnly && !job.taskId && moveTargetCount > 0 && !!personalWorkspaceLabel;
+  const isTaskControlledJob = !readOnly && !!job.taskId;
 
   return (
     <>
@@ -296,18 +300,20 @@ function JobDetailsTopBarActions({
             </TooltipContent>
           </Tooltip>
         ) : null}
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-8 md:size-7"
-          onClick={onEdit}
-          title={tName("edit")}
-          aria-label={tName("edit")}
-          disabled={editing}
-        >
-          <Pencil className="size-4" />
-        </Button>
+        {!readOnly ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 md:size-7"
+            onClick={onEdit}
+            title={tName("edit")}
+            aria-label={tName("edit")}
+            disabled={editing}
+          >
+            <Pencil className="size-4" />
+          </Button>
+        ) : null}
         <JobShareButton
           job={job}
           variant="ghost"


### PR DESCRIPTION
Closes SOK-1030.

## What changed

Public job sharing required the job owner. Any human member of a job's workspace can now create, update, and revoke that job's public share.

The workspace is the permission boundary. An organization workspace admits every member of that organization; a personal workspace admits only its owner. Membership in one organization grants nothing in another.

## Why the check is a new helper

At this branch's base commit, `requireJobCollaboration` guarded six route files, not just the two share routes:

| Route | What it does |
| --- | --- |
| `share/put.ts` | in scope |
| `share/delete.ts` | in scope |
| `[id]/patch.ts` | rename and metadata |
| `[id]/workspace/put.ts` | move between workspaces |
| `[id]/inputs/post.ts` | submit inputs |
| `[id]/refund/post.ts` | issue a refund |

Widening it would have let any member refund or move a colleague's job. This branch moves the two share routes onto their own helper, so `requireJobCollaboration` now guards the remaining four. So sharing got `requireJobShareCollaboration` in `apps/core/src/helpers/access-control.job-share.ts`, and a regression test pins `requireJobCollaboration` as owner-only.

The predicate is the job owner **or** a member of the caller's active workspace. Ownership stays in it because API key and OAuth contexts carry `organizationId: null` (`middleware/auth.ts:429` and `:632`), so their workspace resolves to the personal one. Workspace-only scoping would have stopped them sharing their own organization jobs. The predicate is strictly additive: everything that worked before still works.

Soko Bot and coworker contexts delegate to the existing rules, unchanged. Agent publication policy is out of scope.

## User-facing impact

A member opening a colleague's job now sees the share control and it works. Rename, workspace move, refund, and input submission remain owner-only, so the same page shows fewer controls for a non-owner than for the owner.

`readOnly` previously hid the whole job action bar. It moved inward, and the public `/share/[token]` page is now gated explicitly on `publicJobLayout` rather than relying on `useJobsHeader()` returning null off the app subtree.

## One API change

An unreachable job returns **404** on the share routes where it previously returned 403. Both routes already declared 404, so the OpenAPI contract is unchanged, but a client matching on 403 would notice.

## Verification

- `pnpm --filter core test` — `5199 passed | 11 skipped`
- `pnpm typecheck` — 19 tasks successful
- `pnpm check` — clean
- CI on this PR is green, `Test Web` included
- Three mutations (drop the workspace arm, drop the owner arm, drop the public gate) each fail 2 to 3 tests with a non-zero collected count, so the tests pin behaviour rather than merely passing

Correction to the first version of this description: it reported 28 web test failures in `time-ago.test.tsx` and `task-activity.test.tsx` as a pre-existing defect from the React 19.3 bump. That was wrong. The cause was a stale local install: `react-dom` 19.2.8 was present against the `19.3.0` pin in `apps/web/package.json`, so `browser` was undefined at `time-ago.tsx:76`. Comparing against the base commit could not reveal it, because both revisions ran against the same stale `node_modules`. CI installs from the lockfile and `Test Web` passes.

No schema change, no migration, no Core client regeneration: the route shapes are unchanged.

## Follow-up

SOK-1005 carries a comment: a stale session's `activeOrganizationId` window now also reaches public sharing. This PR inherits that gap deliberately and does not add a membership re-check.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace members can share jobs they do not own when they have appropriate access.
  * Job sharing remains available in read-only views, while editing and moving remain restricted.
  * Public job layouts now hide sharing, editing, and moving controls.

* **Bug Fixes**
  * Improved authorization for creating and removing job shares.
  * Unauthorized or inaccessible jobs now return consistent errors without revealing whether a job exists.
  * Parked parent tasks cannot be shared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->