### PR TITLE
chore(packages): narrow net, email, and chat public exports

### DIFF
--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./models/index.js";
+export { getModelIdentifier } from "./models/index.js";

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,13 +1,2 @@
 export * from "./renderers/index.js";
-export type {
-  ChatRoomInvitationEmailProps,
-  JobFailureNotificationEmailProps,
-  JobFinalStatusEmailProps,
-  JobInputRequiredEmailProps,
-  LocalizedEmailProps,
-  MagicLinkEmailProps,
-  OrganizationInvitationEmailProps,
-  RenderedEmail,
-  ResetPasswordEmailProps,
-  VerificationEmailProps,
-} from "./types.js";
+export type { JobFailureNotificationEmailProps } from "./types.js";

--- a/packages/net/src/index.ts
+++ b/packages/net/src/index.ts
@@ -1,7 +1,1 @@
-export {
-  assertPublicHttpUrl,
-  MAX_SSRF_FETCH_REDIRECTS,
-  SsrfError,
-  type SsrfSafeFetchInit,
-  ssrfSafeFetch,
-} from "./ssrf-fetch.js";
+export { ssrfSafeFetch } from "./ssrf-fetch.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly cleanup: `packages-narrow-net-email-chat`.

Trim the public export surface of three package indexes. No new APIs. Implementation modules stay in place.

## Changes

- `@sokosumi/net`: keep `ssrfSafeFetch`. Stop re-exporting `assertPublicHttpUrl`, `MAX_SSRF_FETCH_REDIRECTS`, `SsrfError`, and `SsrfSafeFetchInit`. Tests still import `./ssrf-fetch.js` directly.
- `@sokosumi/email`: keep renderers and `JobFailureNotificationEmailProps`. Drop unused `*EmailProps`, `RenderedEmail`, and `LocalizedEmailProps` from the public index. Those types remain in `types.ts` for in-package use.
- `@sokosumi/chat`: export only `getModelIdentifier`. Leave `chat-models.ts` and the catalog barrel as-is (no catalog collapse).

## Consumers

Grep found no remaining imports of the removed re-exports. The only external type still needed from email is `JobFailureNotificationEmailProps` in Core job sync.

## Verification

- `pnpm --filter @sokosumi/net test` — 15 passed
- `pnpm --filter @sokosumi/email test` — 16 passed
- `pnpm --filter @sokosumi/chat test` — 7 passed
- Husky `pnpm check` + `pnpm typecheck` on commit — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e63e0edf-6ecc-470d-b1e5-9bebe33ca44b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e63e0edf-6ecc-470d-b1e5-9bebe33ca44b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

