### PR TITLE
chore(masumi): unexport internal hash and utils helpers

### DIFF
--- a/packages/masumi/AGENTS.md
+++ b/packages/masumi/AGENTS.md
@@ -29,10 +29,15 @@ import { createAgentClient, hashInput, hashResult } from "@sokosumi/masumi";
 ### Hash Export (`@sokosumi/masumi/hash`)
 
 - **Purpose**: Hash utilities for job verification
-- **Includes**: `hashInput`, `hashResult`, verification functions
+- **Includes**: `hashInput`, `hashResult`, `isInputHashVerified`, `isResultHashVerified`
 
 ```typescript
-import { hashInput, hashResult, verifyInputHash } from "@sokosumi/masumi/hash";
+import {
+  hashInput,
+  hashResult,
+  isInputHashVerified,
+  isResultHashVerified,
+} from "@sokosumi/masumi/hash";
 
 const inputHash = hashInput(JSON.stringify(inputData), purchaserId);
 const resultHash = hashResult(resultString, purchaserId);
@@ -60,6 +65,7 @@ const agentClient = createAgentClient({
 import {
   jobStatusResponseSchema,
   inputSchemaResponseSchema,
+  type InputSchemaType,
 } from "@sokosumi/masumi/schemas";
 ```
 
@@ -69,7 +75,7 @@ import {
 - **Includes**: Agent types, input types
 
 ```typescript
-import type { Agent, InputSchemaType } from "@sokosumi/masumi/types";
+import type { Agent } from "@sokosumi/masumi/types";
 ```
 
 ### Tools Export (`@sokosumi/masumi/tools`)
@@ -153,7 +159,6 @@ const resultHash = hashResult(resultString, purchaserId);
 
 ### URL Handling
 
-- Use `safeAddPathComponent` for URL construction
 - Validate agent API base URLs (no query strings, no hashes)
 - Support HTTP and HTTPS protocols
 

--- a/packages/masumi/src/hash/index.ts
+++ b/packages/masumi/src/hash/index.ts
@@ -1,4 +1,4 @@
-export { hashInput, hashInputSchema, hashResult } from "./hash.js";
+export { hashInput, hashResult } from "./hash.js";
 export {
   type InputVerificationOptions,
   isInputHashVerified,

--- a/packages/masumi/src/utils/index.ts
+++ b/packages/masumi/src/utils/index.ts
@@ -1,5 +1,13 @@
 export * from "./agent-version.js";
-export * from "./caip19.js";
+export {
+  buildCaip19AssetKey,
+  CAIP2_EVM_NETWORK_PATTERN,
+  EVM_ADDRESS_PATTERN,
+  isEvmNamespacedUnit,
+} from "./caip19.js";
 export * from "./hex.js";
-export * from "./payment-amounts.js";
-export * from "./url.js";
+export {
+  doMasumiPaymentAmountsMatch,
+  normalizeMasumiPaymentUnit,
+  toMasumiPaymentNodeAmounts,
+} from "./payment-amounts.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly cleanup for `@sokosumi/masumi`: shrink the public surface so docs match real exports.

## Changes

- Drop `hashInputSchema` from the public hash barrel. In-package callers still import it from `hash.ts`.
- Stop re-exporting `aggregateMasumiPaymentAmounts`, `safeAddPathComponent`, `parseCaip19AssetKey`, `isCaip19AssetKey`, and `Caip19AssetKeyParts` from the utils barrel. They stay available via relative in-package imports.
- Update `packages/masumi/AGENTS.md`:
  - `verifyInputHash` → `isInputHashVerified` / `isResultHashVerified`
  - `InputSchemaType` imported from `./schemas`, not `./types`
  - no consumer guidance for internal `safeAddPathComponent`

No consumer outside the package imported the unexported names. Web and Core typecheck still pass.

## Verification

- `pnpm check` + `pnpm typecheck` (husky / turbo)
- `pnpm masumi:test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-383a0cde-f1da-40b9-82c6-8f647997a26b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-383a0cde-f1da-40b9-82c6-8f647997a26b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

