### PR TITLE
chore(soko-bot): narrow index exports (unexport internal persona/utils helpers)

### DIFF
--- a/packages/soko-bot/src/index.ts
+++ b/packages/soko-bot/src/index.ts
@@ -6,7 +6,6 @@ export {
   type SokoBotCalendarEvent,
   type SokoBotInboxMessage,
   type SokoBotInboxMessageDetail,
-  type SokoBotIntegrationKind,
   type SokoBotIntegrationProvider,
 } from "./integrations.js";
 export {
@@ -21,21 +20,14 @@ export {
   parseSokoBotMemory,
   redactSokoBotSensitiveText,
   renderSokoBotMemory,
-  SOKO_BOT_SENSITIVE_VALUE_PLACEHOLDER,
-  type SokoBotMemory,
   sanitizeSokoBotMemoryMarkdown,
 } from "./memory.js";
-export {
-  composeSokoBotIntroduction,
-  composeSokoBotPersona,
-  type SokoBotPersona,
-} from "./persona.js";
+export { composeSokoBotIntroduction } from "./persona.js";
 export {
   exceedsUnattendedHireBudget,
   isSokoBotCapability,
   SOKO_BOT_BOT_TO_BOT_CAPABILITIES,
   SOKO_BOT_CAPABILITIES,
-  SOKO_BOT_MEMORY_LIMITS,
   SOKO_BOT_ROUTE_CAPABILITIES,
   SOKO_BOT_ROUTES,
   SOKO_BOT_TEAMMATE_CAPABILITIES,
@@ -48,9 +40,6 @@ export {
   isSokoBotSilentAnswer,
   SOKO_BOT_PROACTIVE_RULES,
   SOKO_BOT_SYSTEM_SCHEDULES,
-  type SokoBotDueFollowUp,
-  type SokoBotProactiveRule,
-  type SokoBotSystemSchedule,
 } from "./proactive.js";
 export type {
   IndexedRuntimeEvent,
@@ -60,12 +49,9 @@ export type {
   RuntimeHealth,
   RuntimeInspectInput,
   RuntimeResetInput,
-  RuntimeSessionRef,
   RuntimeTurnInput,
   RuntimeTurnRef,
-  SokoBotActorContext,
   SokoBotContextPacket,
-  SokoBotRequestClaims,
   SokoBotRuntime,
   SokoBotTurnGrantClaims,
 } from "./runtime.js";
@@ -76,11 +62,9 @@ export {
   SOKO_BOT_SCENARIOS,
   type SokoBotLabTurn,
   type SokoBotScenario,
-  type SokoBotScenarioTrigger,
 } from "./scenarios.js";
 export {
   isSokoBotDecisionTarget,
-  SOKO_BOT_DECISION_TARGETS,
   SOKO_BOT_TOOL_DESCRIPTIONS,
   SOKO_BOT_TOOL_INPUT_SCHEMAS,
   type SokoBotDecisionTarget,
@@ -116,12 +100,9 @@ export {
   applyVersionCapabilities,
   composeSystemPrompt,
   DEFAULT_SOKO_BOT_VERSION_ID,
-  getSokoBotSkill,
   getSokoBotVersion,
-  isSokoBotVersionId,
   SOKO_BOT_SKILLS,
   SOKO_BOT_VERSIONS,
-  type SokoBotSkill,
   type SokoBotVersion,
 } from "./versions/index.js";
 export { sokoBotContextPacketSchema } from "./wire-contracts.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Narrow the public surface of `@sokosumi/soko-bot` by dropping index re-exports that nothing outside `packages/soko-bot` imports. Internal modules and tests still use the same helpers via relative paths.

## Unexported (zero external callers)

Verified with ripgrep across the monorepo (`*.ts`/`*.tsx`/`*.mts`/`*.js`). Matches exist only inside `packages/soko-bot`.

**Named internals from the cleanup list:**

- `composeSokoBotPersona` / `SokoBotPersona` — only `versions/index.ts` and `persona.ts`
- `SOKO_BOT_MEMORY_LIMITS` — only `policy.ts` and `memory.ts`
- `SOKO_BOT_SENSITIVE_VALUE_PLACEHOLDER` — only `memory.ts`
- `SOKO_BOT_DECISION_TARGETS` — only `tool-contracts.ts` (Core uses `isSokoBotDecisionTarget` / `SokoBotDecisionTarget` instead)
- `getSokoBotSkill` — only `versions/` (Core uses `SOKO_BOT_SKILLS` + `composeSystemPrompt`)
- `isSokoBotVersionId` — only `versions/index.ts` and `versions.test.ts` (relative import)

**Unused type-only re-exports** (same grep: no `apps/` / other-package imports):

- `SokoBotIntegrationKind`
- `SokoBotMemory` (Core uses `parseSokoBotMemory` / `renderSokoBotMemory`; web uses generated Core DTOs)
- `SokoBotDueFollowUp` / `SokoBotProactiveRule` / `SokoBotSystemSchedule`
- `RuntimeSessionRef` / `SokoBotActorContext` / `SokoBotRequestClaims`
- `SokoBotScenarioTrigger`
- `SokoBotSkill` (Core uses `SOKO_BOT_SKILLS`)

## Kept (external consumers or Core contract)

**Version files / runtime contract** — Core still imports:

- `SOKO_BOT_VERSIONS`, `DEFAULT_SOKO_BOT_VERSION_ID`, `getSokoBotVersion`, `type SokoBotVersion`
- `SOKO_BOT_SKILLS`, `composeSystemPrompt`, `applyVersionCapabilities`

**Tool schemas** — all named `sokoBot*InputSchema` exports plus `SOKO_BOT_TOOL_INPUT_SCHEMAS` / `SOKO_BOT_TOOL_DESCRIPTIONS` stay public. Core `soko-bot-runtime.service.ts` and `in-process-runtime.ts` parse them.

**Also kept because Core still imports them:** `isSokoBotDecisionTarget`, `type SokoBotDecisionTarget`, `composeSokoBotIntroduction`.

## Verification

- `pnpm --filter @sokosumi/soko-bot check` — pass
- `pnpm --filter @sokosumi/soko-bot typecheck` — pass
- `pnpm --filter @sokosumi/soko-bot test` — 5 files / 192 tests pass
- `pnpm exec turbo run typecheck --filter=@sokosumi/soko-bot --filter=@sokosumi/core` — pass
- `pnpm --filter @sokosumi/core test` on version / lab-judge / control-plane services — 3 files / 73 tests pass

No other packages or docs touched. Does not touch product PRs #4028 / #4062.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbf84a7d-f6a6-4fbd-8df1-9734eca1e777?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbf84a7d-f6a6-4fbd-8df1-9734eca1e777&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

