### PR TITLE
fix(web): report a Core session outage as 503, not 401

### DIFF
--- a/apps/web/src/app/api/chat/[roomId]/messages/route.test.ts
+++ b/apps/web/src/app/api/chat/[roomId]/messages/route.test.ts
@@ -1,16 +1,18 @@
+import { err, ok } from "neverthrow";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CoreApiRequestError } from "@/lib/clients/core.request";
 
-const { getSessionMock, listMessagesMock, listThreadMessagesMock } = vi.hoisted(
-  () => ({
-    getSessionMock: vi.fn(),
+const { getSessionResultMock, listMessagesMock, listThreadMessagesMock } =
+  vi.hoisted(() => ({
+    getSessionResultMock: vi.fn(),
     listMessagesMock: vi.fn(),
     listThreadMessagesMock: vi.fn(),
-  }),
-);
-vi.mock("@/lib/auth/auth.server", () => ({ getSession: getSessionMock }));
+  }));
+vi.mock("@/lib/auth/auth.server", () => ({
+  getSessionResult: getSessionResultMock,
+}));
 vi.mock("@/lib/services/chat-room.service", () => ({
   chatRoomService: {
     listMessages: listMessagesMock,
@@ -32,7 +34,7 @@ function get(query = "") {
 describe("GET /api/chat/[roomId]/messages", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    getSessionResultMock.mockResolvedValue(ok({ user: { id: "user-1" } }));
     listMessagesMock.mockResolvedValue({
       messages: [{ id: "msg-1" }],
       nextCursor: "cursor-2",
@@ -70,11 +72,24 @@ describe("GET /api/chat/[roomId]/messages", () => {
   });
 
   it("returns JSON 401 without a sign-in redirect", async () => {
-    getSessionMock.mockResolvedValue(null);
+    getSessionResultMock.mockResolvedValue(ok(null));
     const result = await get();
     expect(result.status).toBe(401);
     expect(result.headers.get("location")).toBeNull();
     expect(await result.json()).toEqual({ error: "Unauthorized" });
+    expect(listMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503, not 401, when the Core session read times out", async () => {
+    getSessionResultMock.mockResolvedValue(
+      err({ path: "/auth/get-session", reason: "timeout" }),
+    );
+    const result = await get();
+    expect(result.status).toBe(503);
+    expect(await result.json()).toEqual({
+      error: "Chat messages unavailable",
+      reason: "timeout",
+    });
     expect(listMessagesMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/api/chat/background-read.ts
+++ b/apps/web/src/app/api/chat/background-read.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getSession } from "@/lib/auth/auth.server";
+import { getSessionResult } from "@/lib/auth/auth.server";
 import { CoreApiRequestError } from "@/lib/clients/core.request";
 
 interface BackgroundChatReadPage {
@@ -15,13 +15,25 @@ interface BackgroundChatReadPage {
  * JSON page with the Core response envelope, and Core failure status passed
  * through without its details. Background reads bypass the server action
  * queue used by chat mutations.
+ *
+ * A session read that could not reach Core answers 503, never 401. Only an
+ * answered read carrying no session is a 401.
  */
 export async function respondToBackgroundChatRead(
   unavailableMessage: string,
   read: () => Promise<BackgroundChatReadPage>,
 ): Promise<NextResponse> {
   try {
-    if (!(await getSession())) {
+    const sessionResult = await getSessionResult();
+    // A Core timeout is not a logout. Answering 401 for one told the browser
+    // the session was gone and cost it its realtime client; 503 says retry.
+    if (sessionResult.isErr()) {
+      return NextResponse.json(
+        { error: unavailableMessage, reason: sessionResult.error.reason },
+        { status: 503, headers: { "Retry-After": "1" } },
+      );
+    }
+    if (!sessionResult.value) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     const page = await read();

--- a/apps/web/src/app/api/chat/rooms/route.test.ts
+++ b/apps/web/src/app/api/chat/rooms/route.test.ts
@@ -1,16 +1,23 @@
+import { err, ok } from "neverthrow";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CoreApiRequestError } from "@/lib/clients/core.request";
 
-const { getSessionMock, listRoomsMock, listArchivedMock, listPendingMock } =
-  vi.hoisted(() => ({
-    getSessionMock: vi.fn(),
-    listRoomsMock: vi.fn(),
-    listArchivedMock: vi.fn(),
-    listPendingMock: vi.fn(),
-  }));
-vi.mock("@/lib/auth/auth.server", () => ({ getSession: getSessionMock }));
+const {
+  getSessionResultMock,
+  listRoomsMock,
+  listArchivedMock,
+  listPendingMock,
+} = vi.hoisted(() => ({
+  getSessionResultMock: vi.fn(),
+  listRoomsMock: vi.fn(),
+  listArchivedMock: vi.fn(),
+  listPendingMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/auth.server", () => ({
+  getSessionResult: getSessionResultMock,
+}));
 vi.mock("@/lib/services/chat-room.service", () => ({
   chatRoomService: {
     listRooms: listRoomsMock,
@@ -30,7 +37,7 @@ function request(collection: string) {
 describe("GET /api/chat/rooms", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    getSessionResultMock.mockResolvedValue(ok({ user: { id: "user-1" } }));
     listRoomsMock.mockResolvedValue({
       rooms: [{ id: "room-1" }],
       nextCursor: null,
@@ -71,11 +78,26 @@ describe("GET /api/chat/rooms", () => {
   });
 
   it("returns JSON 401 without a sign-in redirect", async () => {
-    getSessionMock.mockResolvedValue(null);
+    getSessionResultMock.mockResolvedValue(ok(null));
     const result = await GET(request("active"));
     expect(result.status).toBe(401);
     expect(result.headers.get("location")).toBeNull();
     expect(await result.json()).toEqual({ error: "Unauthorized" });
+    expect(listRoomsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503, not 401, when the Core session read times out", async () => {
+    getSessionResultMock.mockResolvedValue(
+      err({ path: "/auth/get-session", reason: "timeout" }),
+    );
+    const result = await GET(request("active"));
+    // 401 told the browser its session was gone and cost it the realtime
+    // client; the session was fine and Core was only slow.
+    expect(result.status).toBe(503);
+    expect(await result.json()).toEqual({
+      error: "Chat rooms unavailable",
+      reason: "timeout",
+    });
     expect(listRoomsMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/chat/fetch-background-json.test.ts
+++ b/apps/web/src/components/chat/fetch-background-json.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchBackgroundJson } from "./fetch-background-json";
+
+const TIMEOUT_MS = 20_000;
+
+function response(status: number, body: unknown = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("fetchBackgroundJson", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the payload on the first success", async () => {
+    fetchMock.mockResolvedValue(response(200, { data: ["room-1"] }));
+
+    await expect(
+      fetchBackgroundJson("/api/chat/rooms", TIMEOUT_MS),
+    ).resolves.toEqual({ data: ["room-1"] });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("retries a 503 after 1s and returns the retried payload", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(503))
+      .mockResolvedValueOnce(response(200, { data: ["room-1"] }));
+
+    const result = fetchBackgroundJson("/api/chat/rooms", TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(result).resolves.toEqual({ data: ["room-1"] });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after two spaced retries of a 503", async () => {
+    fetchMock.mockResolvedValue(response(503));
+
+    const result = fetchBackgroundJson("/api/chat/rooms", TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await expect(result).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([401, 400, 502])(
+    "does not retry a %i, which is an answer rather than a stall",
+    async (status) => {
+      fetchMock.mockResolvedValue(response(status));
+
+      await expect(
+        fetchBackgroundJson("/api/chat/rooms", TIMEOUT_MS),
+      ).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps every retry inside the caller's deadline", async () => {
+    fetchMock.mockResolvedValue(response(503));
+
+    // Deadline shorter than the first retry delay: the wait is aborted rather
+    // than outliving the budget the caller asked for.
+    const result = fetchBackgroundJson("/api/chat/rooms", 500);
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(result).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/chat/fetch-background-json.ts
+++ b/apps/web/src/components/chat/fetch-background-json.ts
@@ -3,6 +3,33 @@
  * the server action queue; bounded; null on any failure, redirect, or
  * non-2xx so a late or failed read never replaces newer local data.
  */
+
+/**
+ * Spaced retries for 503 only. The background chat routes answer 503 when the
+ * Core session read could not complete, which is "ask again", not "no" — those
+ * stalls clear in seconds. Every other status stays a single attempt: a 401 is
+ * an answer, and retrying a 502 only doubles the load on something already
+ * struggling.
+ *
+ * Both retries run inside the caller's existing deadline, so the total wait is
+ * still bounded by `timeoutMs`.
+ */
+const RETRY_DELAYS_ON_UNAVAILABLE_MS = [1_000, 3_000];
+
+function wait(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      window.clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = window.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 export async function fetchBackgroundJson(
   url: string,
   timeoutMs: number,
@@ -10,14 +37,23 @@ export async function fetchBackgroundJson(
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(url, {
-      cache: "no-store",
-      redirect: "error",
-      signal: controller.signal,
-    });
-    // `redirect: "error"` already rejects any redirect, so only status remains.
-    if (!response.ok) return null;
-    return await response.json();
+    for (let attempt = 0; ; attempt++) {
+      const response = await fetch(url, {
+        cache: "no-store",
+        redirect: "error",
+        signal: controller.signal,
+      });
+      // `redirect: "error"` already rejects any redirect, so only status remains.
+      if (response.ok) return await response.json();
+
+      const retryDelay =
+        response.status === 503
+          ? RETRY_DELAYS_ON_UNAVAILABLE_MS[attempt]
+          : undefined;
+      if (retryDelay === undefined) return null;
+
+      await wait(retryDelay, controller.signal);
+    }
   } catch {
     return null;
   } finally {

--- a/apps/web/src/lib/ably/auth.client.test.ts
+++ b/apps/web/src/lib/ably/auth.client.test.ts
@@ -42,7 +42,7 @@ describe("fetchAblyBrowserAuthTokenRequest", () => {
     );
 
     await outcome;
-    expect(timeoutMock).toHaveBeenCalledWith(10_000);
+    expect(timeoutMock).toHaveBeenCalledWith(9_000);
   });
 
   it("POSTs to /api/ably/auth with cookies and clientInstanceId", async () => {

--- a/apps/web/src/lib/ably/auth.client.ts
+++ b/apps/web/src/lib/ably/auth.client.ts
@@ -1,8 +1,10 @@
 import type { TokenRequest } from "ably";
 
 const ABLY_BROWSER_AUTH_PATH = "/api/ably/auth";
-// Allow the Core token request its five-second deadline plus proxy overhead.
-const ABLY_BROWSER_AUTH_TIMEOUT_MS = 10_000;
+// 9s: the Core token request's 7s deadline plus proxy overhead, and one second
+// under the ably-js `realtimeRequestTimeout` default. At 10s the two raced and
+// ably-js won, replacing the status we classify here with its own message.
+const ABLY_BROWSER_AUTH_TIMEOUT_MS = 9_000;
 
 export class AblyBrowserAuthError extends Error {
   readonly status: number;

--- a/apps/web/src/lib/ably/auth.ts
+++ b/apps/web/src/lib/ably/auth.ts
@@ -6,8 +6,13 @@ import { CoreApiRequestError } from "@/lib/clients/core.request";
 import { getCoreApiBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 import { joinCoreApiPath } from "@/lib/clients/utils/core-api-base-url.shared";
 
-/** Match Core auth proxy timeouts in apps/web/src/lib/auth/auth.server.ts */
-const CORE_ABLY_TOKEN_REQUEST_TIMEOUT_MS = 5000;
+/**
+ * Innermost hop of the Ably auth budget, which must nest strictly:
+ * 7s here < 9s browser fetch (`auth.client.ts`) < 10s ably-js
+ * `realtimeRequestTimeout`. Overrun the browser hop and ably-js reports its own
+ * opaque timeout instead of the classified error this route produces.
+ */
+const CORE_ABLY_TOKEN_REQUEST_TIMEOUT_MS = 7000;
 
 /**
  * Fetch an Ably TokenRequest from Core (membership-gated room caps, SOK-741;

--- a/apps/web/src/lib/ably/realtime-singleton.client.test.ts
+++ b/apps/web/src/lib/ably/realtime-singleton.client.test.ts
@@ -137,14 +137,14 @@ describe("getAblyRealtimeClient", () => {
     expect(options.authParams).toBeUndefined();
   });
 
-  it("clears the shared singleton when /api/ably/auth returns 401", async () => {
+  it("keeps the shared client when /api/ably/auth returns 401", async () => {
     fetchMock.mockResolvedValue({
       ok: false,
       status: 401,
       text: async () => '{"error":"Unauthorized"}',
     });
 
-    getAblyRealtimeClient();
+    const client = getAblyRealtimeClient();
     const authResult = await invokeAuthCallback();
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -156,9 +156,12 @@ describe("getAblyRealtimeClient", () => {
     );
     expect(authResult.token).toBeNull();
     expect(authResult.error).toEqual(expect.any(String));
-    expect(globalThis.__sokosumiAblyRealtimeClient).toBeUndefined();
-    expect(getConstructedRealtimeClient().close).toHaveBeenCalled();
-    expect(consoleErrorMock).not.toHaveBeenCalled();
+    // close() is terminal and nothing re-creates the instance the mounted
+    // provider holds, so a 401 must stay retriable: Core reported timed-out
+    // session reads as 401 and that killed realtime until a page reload.
+    expect(globalThis.__sokosumiAblyRealtimeClient).toBe(client);
+    expect(getConstructedRealtimeClient().close).not.toHaveBeenCalled();
+    expect(consoleErrorMock).toHaveBeenCalled();
   });
 
   it("does not clear the singleton when /api/ably/auth returns 502", async () => {
@@ -178,43 +181,20 @@ describe("getAblyRealtimeClient", () => {
     expect(consoleErrorMock).toHaveBeenCalled();
   });
 
-  it("does not let a retired client's late 401 close its replacement", async () => {
-    let rejectOldAuth: ((value: Response) => void) | undefined;
-    fetchMock.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          rejectOldAuth = resolve;
-        }),
-    );
-    getAblyRealtimeClient();
-    const oldAuth = invokeAuthCallback();
-
-    fetchMock.mockResolvedValueOnce(
-      new Response("Unauthorized", { status: 401 }),
-    );
-    await invokeAuthCallback();
-    const replacement = getAblyRealtimeClient();
-    const replacementClose = RealtimeMock.mock.instances[1]?.close;
-    rejectOldAuth?.(new Response("Unauthorized", { status: 401 }));
-    await oldAuth;
-
-    expect(globalThis.__sokosumiAblyRealtimeClient).toBe(replacement);
-    expect(replacementClose).not.toHaveBeenCalled();
-  });
-
-  it("recreates a client after a 401 so a later remount can reconnect", async () => {
+  it("reuses the same client after a 401 instead of building a second one", async () => {
     fetchMock.mockResolvedValue({
       ok: false,
       status: 401,
       text: async () => '{"error":"Unauthorized"}',
     });
 
-    getAblyRealtimeClient();
+    const client = getAblyRealtimeClient();
     await invokeAuthCallback();
     RealtimeMock.mockClear();
 
-    const nextClient = getAblyRealtimeClient();
-    expect(RealtimeMock).toHaveBeenCalledTimes(1);
-    expect(globalThis.__sokosumiAblyRealtimeClient).toBe(nextClient);
+    // A second client would hold its own socket outside the React tree, where
+    // no hook attaches channels to it.
+    expect(getAblyRealtimeClient()).toBe(client);
+    expect(RealtimeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/ably/realtime-singleton.client.ts
+++ b/apps/web/src/lib/ably/realtime-singleton.client.ts
@@ -23,16 +23,18 @@ function setGlobalAblyRealtimeClient(client: Ably.Realtime): void {
   globalThis.__sokosumiAblyRealtimeClient = client;
 }
 
-function clearSharedAblyRealtimeClient(client: Ably.Realtime): void {
-  if (getGlobalAblyRealtimeClient() === client) {
-    globalThis.__sokosumiAblyRealtimeClient = undefined;
-  }
-  client.close();
-}
-
+/**
+ * Never close the client here.
+ *
+ * A 401 from `/api/ably/auth` used to mean "the session is gone", so this
+ * closed the shared client. `close()` is terminal and nothing re-creates the
+ * instance the mounted provider holds, so chat notifications stayed dead until
+ * a full page reload. The 401 was often not a logout at all: a Core session
+ * read that timed out was reported as one. Hand every failure back to ably-js
+ * instead and let it retry — a real logout ends the session on its own.
+ */
 function createAblyAuthCallback(
   clientInstanceId: string,
-  onSessionLost: () => void,
 ): NonNullable<Ably.AuthOptions["authCallback"]> {
   return (_tokenParams, callback) => {
     void fetchAblyBrowserAuthTokenRequest(clientInstanceId).then(
@@ -40,11 +42,10 @@ function createAblyAuthCallback(
         callback(null, tokenRequest);
       },
       (error: unknown) => {
-        if (error instanceof AblyBrowserAuthError && error.status === 401) {
-          onSessionLost();
-        } else {
-          console.error("Ably auth request failed", error);
-        }
+        console.error("Ably auth request failed", {
+          status: error instanceof AblyBrowserAuthError ? error.status : null,
+          error,
+        });
         const message = error instanceof Error ? error.message : String(error);
         callback(message, null);
       },
@@ -60,9 +61,7 @@ export function getAblyRealtimeClient(): Ably.Realtime {
 
   const clientInstanceId = getOrCreateAblyClientInstanceId();
   const realtimeClient = new Ably.Realtime({
-    authCallback: createAblyAuthCallback(clientInstanceId, () => {
-      clearSharedAblyRealtimeClient(realtimeClient);
-    }),
+    authCallback: createAblyAuthCallback(clientInstanceId),
     echoMessages: false,
     // Plugins are constructor-only in ably-js, so push rides the shared client
     // rather than a second one. Every route reaches this module through a

--- a/apps/web/src/lib/auth/auth.server.client.ts
+++ b/apps/web/src/lib/auth/auth.server.client.ts
@@ -10,7 +10,8 @@ import { joinCoreApiPath } from "@/lib/clients/utils/core-api-base-url.shared";
 import { getAuthClientPlugins } from "./auth-client.plugins";
 
 const CORE_AUTH_BASE_PATH = "/auth";
-const CORE_AUTH_REQUEST_TIMEOUT_MS = 5000;
+// Keep in step with the server-side budget in `auth.server.ts`.
+const CORE_AUTH_REQUEST_TIMEOUT_MS = 8000;
 
 export function getCoreAuthBaseUrl(): string {
   return joinCoreApiPath(getServerCoreAppBaseUrl(), CORE_AUTH_BASE_PATH);

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -32,7 +32,12 @@ export interface OAuthClientPublic {
 const CORE_GET_SESSION_PATH = "/auth/get-session";
 const CORE_LIST_ACCOUNTS_PATH = "/auth/list-accounts";
 const CORE_GET_OAUTH_CLIENT_PUBLIC_PATH = "/auth/oauth2/public-client";
-const CORE_AUTH_REQUEST_TIMEOUT_MS = 5000;
+// 8s, not 5s. Core answered `/auth/get-session` in 27-70ms in production, so
+// this budget is only ever spent on a stall (cold start, connection storm, a
+// saturated web function). The callers that sit in front of it allow far more:
+// the background chat reads give the browser 20-30s. Five seconds turned those
+// stalls into "no session".
+const CORE_AUTH_REQUEST_TIMEOUT_MS = 8000;
 
 async function fetchCoreAuth<T>(
   path: string,
@@ -102,6 +107,18 @@ async function fetchCoreAuth<T>(
       return err(authReadError);
     }
   } catch (error) {
+    // PPR soft-abort during shell probe — not an auth failure. Rethrow so React
+    // / Cache Components can finish the boundary instead of treating this as a
+    // Core outage.
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "digest" in error &&
+      error.digest === "HANGING_PROMISE_REJECTION"
+    ) {
+      throw error;
+    }
+
     const reason: CoreAuthReadErrorReason =
       error instanceof Error && error.name === "TimeoutError"
         ? "timeout"
@@ -170,69 +187,65 @@ function hasSessionCookie(requestHeaders: Headers): boolean {
   );
 }
 
-async function fetchSession(
+/**
+ * Reads the session from Core, keeping "there is no session" separate from
+ * "Core could not be asked".
+ *
+ * `ok(null)` means the request was answered and carried no session. `err`
+ * means a timeout, a network failure, a non-JSON body, or an unexpected HTTP
+ * status — an outage, not a signed-out user. Collapsing the two made a five
+ * second Core timeout indistinguishable from a logout, so callers answered 401
+ * to users whose session was fine.
+ */
+async function fetchSessionResult(
   requestHeaders: Headers,
   options?: GetSessionOptions,
-): Promise<Session | null> {
+): Promise<Result<Session | null, CoreAuthReadError>> {
   // Skip Core entirely when the browser did not send a session cookie. Auth
   // entry pages call getSession on every visit; anonymous users were paying a
   // full Core RTT for a guaranteed null.
   if (!hasSessionCookie(requestHeaders)) {
-    return null;
+    return ok(null);
   }
 
-  // Concatenate rather than `new URL(path, base)` so a base URL with a
-  // sub-path (e.g. `https://host/core`) is preserved instead of dropped by
-  // absolute-path resolution.
-  const sessionUrl = new URL(
-    joinCoreApiPath(getServerCoreAppBaseUrl(), CORE_GET_SESSION_PATH),
+  const result = await fetchCoreAuth<Session | null>(
+    CORE_GET_SESSION_PATH,
+    requestHeaders,
+    {
+      failureLogMessage: "Failed to fetch session from Core",
+      searchParams: {
+        disableCookieCache: options?.refresh ? "true" : undefined,
+      },
+      // Core answers 200 with a null body for a signed-out browser, so these
+      // statuses are not expected. Keep them out of Sentry anyway: an auth
+      // status is about this request, not about Core being down.
+      sentryIgnoreHttpStatuses: [401, 403, 404],
+    },
   );
 
-  if (options?.refresh) {
-    sessionUrl.searchParams.set("disableCookieCache", "true");
-  }
-
-  try {
-    const response = await fetch(sessionUrl, {
-      headers: buildAuthHeaders(requestHeaders),
-      cache: "no-store",
-      signal: AbortSignal.timeout(CORE_AUTH_REQUEST_TIMEOUT_MS),
-    });
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const body = (await response.json()) as Session | null;
-
-    if (!body?.session || !body.user) {
-      return null;
-    }
-
-    return body;
-  } catch (error) {
-    // PPR soft-abort during shell probe — not an auth failure. Rethrow so React
-    // / Cache Components can finish the boundary instead of treating this as
-    // "no session" and bouncing the user to /signin.
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "digest" in error &&
-      error.digest === "HANGING_PROMISE_REJECTION"
-    ) {
-      throw error;
-    }
-
-    // Core unreachable, timed out, or returned a non-JSON body. Preserve the
-    // null-returning contract callers rely on instead of throwing.
-    console.error("Failed to fetch session from Core", error);
-    return null;
-  }
+  return result.map((body) => (body?.session && body.user ? body : null));
 }
 
-const getCachedSession = cache(async (): Promise<Session | null> => {
-  return fetchSession(await getRequestHeaders());
-});
+const getCachedSessionResult = cache(
+  async (): Promise<Result<Session | null, CoreAuthReadError>> => {
+    return fetchSessionResult(await getRequestHeaders());
+  },
+);
+
+/**
+ * Session read that reports a Core outage instead of hiding it as "no session".
+ * Use from route handlers that would otherwise answer 401 for a timeout; an
+ * `err` belongs in a 503, never a 401.
+ */
+export async function getSessionResult(
+  options?: GetSessionOptions,
+): Promise<Result<Session | null, CoreAuthReadError>> {
+  if (options?.refresh) {
+    return fetchSessionResult(await getRequestHeaders(), options);
+  }
+
+  return getCachedSessionResult();
+}
 
 /**
  * Gets the current user's session information. This function only works with
@@ -243,11 +256,7 @@ const getCachedSession = cache(async (): Promise<Session | null> => {
 export async function getSession(
   options?: GetSessionOptions,
 ): Promise<Session | null> {
-  if (options?.refresh) {
-    return fetchSession(await getRequestHeaders(), options);
-  }
-
-  return getCachedSession();
+  return (await getSessionResult(options)).unwrapOr(null);
 }
 
 const getCachedUserAccounts = cache(


### PR DESCRIPTION
Chat notifications, the unread indicator and bold room names stopped for a
signed-in user and stayed stopped until a full page reload.

## User-facing impact

A brief Core slowdown no longer signs the browser out of realtime. Before this
change one timed-out session read killed the Ably client for the rest of the
page's life.

## Root cause

Three defects stacked.

**1. A timeout was reported as a logout.** `fetchSession` returned `null` both
when Core answered with no session and when it could not be asked at all, so
callers turned an `AbortSignal.timeout` into HTTP 401.

Production web logs, 2026-09-10 08:53:35 UTC:

```
/api/chat/rooms 401 Failed to fetch session from Core
  [Error [TimeoutError]: The operation was aborted due to timeout]
/api/ably/auth  401
```

Core logs for the same window answered `/auth/get-session` at 200 in 30-37ms.
The timeout was on the web side, not Core.

**2. A 401 was terminal.** Since #4221 the Ably singleton called
`client.close()` on 401. `close()` cannot be undone and nothing re-creates the
instance the mounted `AblyProvider` holds, so the browser then logged
`Ably presence enter/update failed: Error: Connection closed` on every presence
tick. Clearing the global also let a later island build a second client outside
the React tree, where no hook attaches channels to it.

**3. The budgets raced.** The browser fetch of `/api/ably/auth` and the ably-js
`realtimeRequestTimeout` default were both 10s, so ably-js often won and
replaced the classified error with its own opaque timeout message.

## Fix

- `getSessionResult()` returns `Result<Session | null, CoreAuthReadError>` via
  the existing `fetchCoreAuth` seam, which already classifies `timeout`,
  `network`, `invalid_json` and `http`. `ok(null)` is a signed-out browser;
  `err` is an outage. `getSession()` keeps its `Session | null` contract through
  `unwrapOr(null)`, so every existing caller is unchanged.
- `respondToBackgroundChatRead` answers 503 with the failure reason for an
  `err`, and keeps 401 only for `ok(null)`.
- The Ably auth callback never closes the client. Every failure goes back to
  ably-js to retry, as the `authUrl` path did before #4221. A real logout ends
  the session on its own.
- Budgets widened and nested strictly:
  `7s route to Core < 9s browser fetch < 10s ably-js`. The Core session read
  goes 5s to 8s; the background chat reads in front of it already allow 20-30s.
- The PPR `HANGING_PROMISE_REJECTION` rethrow moves into `fetchCoreAuth` so
  every Core auth read keeps it.

## Still open

Not in this PR, tracked separately:

- `use-ably-connection-health-publisher.ts` publishes health as
  `connection.state === "connected"` only. An `authorize()` failure can leave
  the socket connected with no channels attached, so the fallback pollers stay
  off while nothing is delivered.
- `use-notification-realtime.tsx` has no polling fallback at all.
- `next.config.ts` sets `tunnelRoute: true`, which mints a new random Sentry
  path per build. One sampled web log held 38 404s across four dead tunnel
  routes, so browser errors from any tab older than the current deploy are
  dropped. This is why the outage went unnoticed.

## Verification

- `pnpm --filter web test`: 678 files, 5122 passed, 1 skipped.
- `pnpm check` and `pnpm typecheck`: clean.
- Mutation-checked both fixes. Restoring the 401-on-timeout collapse fails 2
  tests in `src/app/api/chat`; restoring `client.close()` fails 2 tests in
  `realtime-singleton.client.test.ts`.
- New tests: 503-not-401 for both background chat routes; the Ably client
  survives a 401 and no second client is constructed.
