### PR TITLE
chore(utils): unexport unused public index symbols

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -70,16 +70,12 @@ export {
   type ChatPresenceState,
   isValidAblyClientInstanceId,
   type PresenceConnectionInput,
-  parseChatPresenceMemberData,
-  parseUserIdFromAblyPresenceClientId,
 } from "./chat-presence.js";
 export { CHAT_PRESENCE_ONLINE_WINDOW_MS } from "./chat-presence-windows.js";
 export {
   buildCoworkerChatRoomFilePathname,
-  buildCoworkerChatRoomFilePrefix,
   buildSokoBotChatRoomFilePathname,
   buildUserChatRoomFilePathname,
-  buildUserChatRoomFilePrefix,
   CHAT_ROOM_FILE_MAX_SIZE_BYTES,
 } from "./chat-room-file-upload.js";
 export {
@@ -106,18 +102,13 @@ export {
   CHAT_ROOMS_CHANGED_EVENT_NAME,
   type ChatRoomCollection,
 } from "./chat-rooms-changed.js";
-export {
-  CHAT_UI_REASONING_PART_TYPE_VALUES,
-  CHAT_UI_REASONING_PART_TYPES,
-  isChatUiProviderReasoningPartType,
-} from "./chat-ui-reasoning-part-types.js";
+export { isChatUiProviderReasoningPartType } from "./chat-ui-reasoning-part-types.js";
 export {
   CORE_API_ERROR_KINDS,
   type CoreApiErrorKind,
 } from "./core-api-error-kind.js";
 export {
   buildCoworkerImagePathname,
-  buildCoworkerImagePrefix,
   COWORKER_IMAGE_ALLOWED_MIME_TYPES,
   COWORKER_IMAGE_MAX_SIZE_BYTES,
   extensionForCoworkerImageMime,
@@ -127,7 +118,6 @@ export {
 export { convertCentsToCredits, convertCreditsToCents } from "./credit.js";
 export {
   BASE_CREDIT_TOPUP_LOOKUP_KEY,
-  CREDIT_TOPUP_LOOKUP_KEYS,
   type CreditTopUpLookupKey,
   type CreditTopUpTier,
   getCreditTopUpLookupKeyByCredits,
@@ -149,11 +139,9 @@ export {
   buildAdHocDesignMdPathname,
   buildAdHocDesignMdPrefix,
   buildOrganizationDesignMdPathname,
-  buildOrganizationDesignMdPrefix,
   buildProjectDesignMdPathname,
   buildProjectDesignMdPrefix,
   buildUserDesignMdPathname,
-  buildUserDesignMdPrefix,
 } from "./design-md-path.js";
 export {
   DESIGN_MD_BLOB_PATH_PREFIX,
@@ -179,11 +167,9 @@ export {
   isOwnedUserDriveFileUrl,
   normalizeDriveFolderPath,
   sanitizeDriveFileName,
-  sanitizeDriveFolderName,
   validateDriveFolderPath,
 } from "./drive-file-path.js";
 export {
-  FILE_EXTENSION_ALLOWLIST,
   getExtensionFromUrl,
   getUrlBasename,
   isFileLikeUrl,
@@ -200,10 +186,7 @@ export {
   resolveIpfsOrHttpUrl,
   sanitizeOrganizationLogoForApi,
 } from "./ipfs-url.js";
-export {
-  buildJobBlobPathname,
-  buildJobBlobPrefix,
-} from "./job-blob-path.js";
+export { buildJobBlobPathname } from "./job-blob-path.js";
 export { linkifyBareDomainsInMarkdown } from "./linkify-bare-domains.js";
 export {
   type ChannelLinkIdentity,
@@ -272,13 +255,7 @@ export {
   type OAuthClientGrantType,
 } from "./oauth-scopes.js";
 export {
-  DALLE_TEXT_TO_IMAGE_REACT_ACTION,
-  extractReactEnvelope,
-  findJsonObjectEnd,
   isReactJsonFencePrefixCandidate,
-  normalizeReactEnvelopeTrailingText,
-  OPENROUTER_IMAGE_GENERATION_REACT_ACTION,
-  type ParseReactEnvelopeBufferResult,
   parseReactEnvelopeBuffer,
 } from "./openrouter-react-image-envelope.js";
 export {
@@ -299,7 +276,6 @@ export {
 export {
   buildOrganizationLogoContentHashPathname,
   buildOrganizationLogoPathname,
-  buildOrganizationLogoPrefix,
   isOwnedOrganizationLogoUrl,
 } from "./organization-logo-path.js";
 export {
@@ -317,12 +293,10 @@ export {
 export {
   buildProjectBriefingPathname,
   buildProjectContextMdPathname,
-  buildProjectFilesPrefix,
   buildProjectFilesRootPrefix,
 } from "./project-files-path.js";
 export {
   buildProjectLogoContentHashPathname,
-  buildProjectLogoPrefix,
   isOwnedProjectLogoUrl,
   isProjectLogoBlobUrl,
 } from "./project-logo-path.js";
@@ -335,7 +309,6 @@ export {
   canArchiveTaskStatus,
   getTaskCannotArchiveMessage,
   isTaskArchivableStatus,
-  TASK_ARCHIVABLE_STATUSES,
   type TaskArchivableStatus,
 } from "./task-archive.js";
 export {
@@ -353,17 +326,14 @@ export {
 } from "./task-context-attachment.js";
 export {
   isTaskEditableStatus,
-  TASK_EDITABLE_STATUSES,
   type TaskEditableStatus,
 } from "./task-editable.js";
 export {
   buildTaskFilePathname,
-  buildTaskFilePrefix,
   clampTaskFileName,
   FILE_UPLOAD_MAX_SIZE_BYTES,
   isOwnedTaskFileUrl,
   resolveTaskFileContentType,
-  sanitizeTaskFileFilename,
   TASK_FILE_MAX_NAME_LENGTH,
   TASK_FILE_MAX_SIZE_BYTES,
 } from "./task-file-upload.js";
@@ -374,13 +344,8 @@ export {
   type TaskScheduleMetadata,
   type TaskScheduleMetadataV1,
   type TaskScheduleMetadataV2,
-  taskScheduleMetadataSchema,
-  taskScheduleMetadataV2Schema,
-  taskScheduleOnceMetadataV2Schema,
-  taskScheduleRecurringMetadataV2Schema,
 } from "./task-schedule.js";
 export {
-  AGENT_ONLY_TASK_STATUSES,
   canUserTransitionTaskStatus,
   isAgentOnlyTaskStatus,
   type TaskAssigneeKind,
@@ -416,12 +381,10 @@ export {
 export {
   buildUserUploadPathname,
   buildUserUploadPrefix,
-  sanitizeUserUploadFilename,
 } from "./user-upload-path.js";
 export {
   buildVendorLogoContentHashPathname,
   buildVendorLogoPathname,
-  buildVendorLogoPrefix,
   isOwnedVendorLogoUrl,
 } from "./vendor-logo-path.js";
 export {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Area: **packages-utils-index-unexport**

Narrow the public surface of `@sokosumi/utils` by stopping re-exports of unused symbols from `packages/utils/src/index.ts`. Source modules are unchanged; module-local relative imports still work.

`CoreApiErrorKind` and `SessionRecord` stay exported (documented public API).

## Unexported names and evidence

Each name was re-grepped across `apps/` and `packages/` before removal. Remaining hits are only the defining module, its colocated tests, and/or other `packages/utils` relative imports.

### Prefix builders

| Name | Evidence |
| --- | --- |
| `buildCoworkerChatRoomFilePrefix` | Zero `@sokosumi/utils` callers; used by `chat-room-file-upload.ts` + test |
| `buildUserChatRoomFilePrefix` | Same; used by `chat-room-file-upload.ts` + test |
| `buildCoworkerImagePrefix` | Zero external callers; `coworker-image-upload.ts` + test |
| `buildJobBlobPrefix` | Zero external callers; `job-blob-path.ts` + test |
| `buildOrganizationDesignMdPrefix` | Zero external callers; `design-md-path.ts` + test |
| `buildUserDesignMdPrefix` | Same; `design-md-path.ts` + test |
| `buildOrganizationLogoPrefix` | Zero external callers; `organization-logo-path.ts` + test |
| `buildProjectFilesPrefix` | Zero external callers; `project-files-path.ts` + test |
| `buildProjectLogoPrefix` | Zero external callers; `project-logo-path.ts` + test |
| `buildTaskFilePrefix` | Zero external callers; `task-file-upload.ts` + test |
| `buildVendorLogoPrefix` | Zero external callers; `vendor-logo-path.ts` + test |

### Internal sanitizers

| Name | Evidence |
| --- | --- |
| `sanitizeDriveFolderName` | Zero app/package callers; wraps `sanitizeUserUploadFilename` in `drive-file-path.ts` |
| `sanitizeTaskFileFilename` | Zero app/package callers; `task-file-upload.ts` + test |
| `sanitizeUserUploadFilename` | Zero `@sokosumi/utils` callers; used via relative imports inside `packages/utils` |

Kept: `sanitizeOrganizationLogoForApi` (`apps/core/src/schemas/organization.schema.ts`).

### OpenRouter internals

| Name | Evidence |
| --- | --- |
| `findJsonObjectEnd` | Zero external callers; used by `parseReactEnvelopeBuffer` |
| `normalizeReactEnvelopeTrailingText` | Zero external callers; module + colocated test |
| `extractReactEnvelope` | Zero imports (JSDoc mention only in `packages/ai-provider`) |
| `DALLE_TEXT_TO_IMAGE_REACT_ACTION` | Zero external callers; module-local constant |
| `OPENROUTER_IMAGE_GENERATION_REACT_ACTION` | Same |
| `ParseReactEnvelopeBufferResult` | Type used only inside `openrouter-react-image-envelope.ts` |

Kept: `parseReactEnvelopeBuffer`, `isReactJsonFencePrefixCandidate` (`packages/ai-provider/src/stream/responses-sse-to-v4-stream.ts`).

### Presence parsers

| Name | Evidence |
| --- | --- |
| `parseChatPresenceMemberData` | Zero app/package callers; used by `aggregateChatPresenceByUserId` + test |
| `parseUserIdFromAblyPresenceClientId` | Same |

Kept: `parseChatRoomIdFromChannelName`, `parseOrganizationIdFromPresenceChannelName`.

### Unused Zod values

| Name | Evidence |
| --- | --- |
| `taskScheduleMetadataSchema` | Zero app/package callers; used by `parseTaskScheduleMetadata` |
| `taskScheduleMetadataV2Schema` | Zero app/package callers; module-local |
| `taskScheduleOnceMetadataV2Schema` | Same |
| `taskScheduleRecurringMetadataV2Schema` | Same |

Kept: `parseTaskScheduleMetadata` and the `TaskScheduleMetadata*` types.

### Unused constant arrays

| Name | Evidence |
| --- | --- |
| `AGENT_ONLY_TASK_STATUSES` | Zero app/package callers; used by `isAgentOnlyTaskStatus` |
| `CHAT_UI_REASONING_PART_TYPE_VALUES` | Zero external callers; module + colocated test |
| `CHAT_UI_REASONING_PART_TYPES` | Zero external callers; used by `isChatUiProviderReasoningPartType` |
| `CREDIT_TOPUP_LOOKUP_KEYS` | Zero app/package callers; used to derive `CreditTopUpLookupKey` |
| `FILE_EXTENSION_ALLOWLIST` | Zero app/package callers; used by `isFileLikeUrl` |
| `TASK_ARCHIVABLE_STATUSES` | Zero `@sokosumi/utils` callers; module + colocated test |
| `TASK_EDITABLE_STATUSES` | Same |

Kept: `BROWSER_ONLY_NOTIFICATION_KINDS` (`apps/core/src/helpers/notification-feed.ts`).

## Verification

- `pnpm check` (repo-wide Biome)
- `pnpm typecheck` (turbo; web + core still resolve remaining exports)
- `pnpm --filter @sokosumi/utils test` — 66 files, 602 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c822c1b-693b-46e1-a706-f7d866616cd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c822c1b-693b-46e1-a706-f7d866616cd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

