### PR TITLE
chore(utils): remove unused drive owned-url helpers

### DIFF
--- a/packages/utils/src/drive-file-path.test.ts
+++ b/packages/utils/src/drive-file-path.test.ts
@@ -7,8 +7,6 @@ import {
   buildUserDriveFilePrefix,
   clampDriveFileName,
   DRIVE_FILE_MAX_NAME_LENGTH,
-  isOwnedOrganizationDriveFileUrl,
-  isOwnedUserDriveFileUrl,
   sanitizeDriveFileName,
 } from "./drive-file-path.js";
 
@@ -32,31 +30,6 @@ describe("drive file path helpers", () => {
         "drive/users/user_123/hello_world.txt",
       );
     });
-
-    it("detects owned user drive file URLs", () => {
-      expect(
-        isOwnedUserDriveFileUrl(
-          "https://blob.example.com/drive/users/user_123/hello_world.txt",
-          "user_123",
-        ),
-      ).toBe(true);
-
-      expect(
-        isOwnedUserDriveFileUrl(
-          "https://blob.example.com/drive/users/user_456/hello_world.txt",
-          "user_123",
-        ),
-      ).toBe(false);
-
-      expect(
-        isOwnedUserDriveFileUrl(
-          "https://blob.example.com/tasks/tsk_123/hello_world-abc.txt",
-          "user_123",
-        ),
-      ).toBe(false);
-
-      expect(isOwnedUserDriveFileUrl("not-a-url", "user_123")).toBe(false);
-    });
   });
 
   describe("organization drive", () => {
@@ -70,33 +43,6 @@ describe("drive file path helpers", () => {
       expect(
         buildOrganizationDriveFilePathname("org_123", "hello world.txt"),
       ).toBe("drive/organizations/org_123/hello_world.txt");
-    });
-
-    it("detects owned organization drive file URLs", () => {
-      expect(
-        isOwnedOrganizationDriveFileUrl(
-          "https://blob.example.com/drive/organizations/org_123/hello_world.txt",
-          "org_123",
-        ),
-      ).toBe(true);
-
-      expect(
-        isOwnedOrganizationDriveFileUrl(
-          "https://blob.example.com/drive/organizations/org_456/hello_world.txt",
-          "org_123",
-        ),
-      ).toBe(false);
-
-      expect(
-        isOwnedOrganizationDriveFileUrl(
-          "https://blob.example.com/drive/users/user_123/hello_world.txt",
-          "org_123",
-        ),
-      ).toBe(false);
-
-      expect(isOwnedOrganizationDriveFileUrl("not-a-url", "org_123")).toBe(
-        false,
-      );
     });
   });
 

--- a/packages/utils/src/drive-file-path.ts
+++ b/packages/utils/src/drive-file-path.ts
@@ -59,39 +59,6 @@ export function buildOrganizationDriveFilePathname(
 }
 
 /**
- * True when `url` points at a blob owned by this user's drive prefix
- * (`drive/users/{userId}/...`). Used for ACL checks and best-effort deletes.
- */
-export function isOwnedUserDriveFileUrl(url: string, userId: string): boolean {
-  try {
-    const parsed = new URL(url);
-    const pathname = parsed.pathname.replace(/^\//, "");
-    return pathname.startsWith(buildUserDriveFilePrefix(userId));
-  } catch {
-    return false;
-  }
-}
-
-/**
- * True when `url` points at a blob owned by this organization's drive prefix
- * (`drive/organizations/{orgId}/...`). Used for ACL checks and best-effort deletes.
- */
-export function isOwnedOrganizationDriveFileUrl(
-  url: string,
-  organizationId: string,
-): boolean {
-  try {
-    const parsed = new URL(url);
-    const pathname = parsed.pathname.replace(/^\//, "");
-    return pathname.startsWith(
-      buildOrganizationDriveFilePrefix(organizationId),
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Max stored display name length for drive files (server-enforced).
  */
 export const DRIVE_FILE_MAX_NAME_LENGTH = 255;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -163,8 +163,6 @@ export {
   DRIVE_FOLDER_MARKER_BASENAME,
   isDriveFolderMarker,
   isDriveFolderMarkerName,
-  isOwnedOrganizationDriveFileUrl,
-  isOwnedUserDriveFileUrl,
   normalizeDriveFolderPath,
   sanitizeDriveFileName,
   validateDriveFolderPath,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly cleanup: delete unused `@sokosumi/utils` Drive URL ownership helpers.

`isOwnedUserDriveFileUrl` and `isOwnedOrganizationDriveFileUrl` had no production callers (only colocated tests and the package index). Sibling helpers `isOwnedTaskFileUrl` / `isOwnedOrganizationLogoUrl` stay — those are used by Core blob deletes.

Drive ACL already gates on pathname via `parseDriveFilePathname`. There is no existing Core `deleteDrive*IfOwned` blob helper to wire into, so this PR deletes rather than inventing product wiring.

## Changes

- Remove both helpers from `packages/utils/src/drive-file-path.ts`
- Drop their public re-exports from `packages/utils/src/index.ts`
- Remove the matching tests from `drive-file-path.test.ts`

## Verification

- `pnpm check` + `pnpm typecheck` (husky precommit)
- `pnpm --filter @sokosumi/utils test packages/utils/src/drive-file-path.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d51a5ad7-d3a7-486e-9434-57e8bbdea872?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d51a5ad7-d3a7-486e-9434-57e8bbdea872&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

