### PR TITLE
chore(masumi): named exports for schemas index

### DIFF
--- a/packages/masumi/src/schemas/index.ts
+++ b/packages/masumi/src/schemas/index.ts
@@ -1,16 +1,65 @@
 // Agent schemas
-export * from "./agent/input_schema.schema.js";
-export * from "./agent/provide_input.schema.js";
-export * from "./agent/start_job.schema.js";
-export * from "./agent/status.schema.js";
+export {
+  type InputSchemaResponseSchemaType,
+  inputSchemaResponseSchema,
+} from "./agent/input_schema.schema.js";
+export {
+  type ProvideInputRequestSchemaType,
+  type ProvideInputResponseSchemaType,
+  provideInputRequestSchema,
+  provideInputResponseSchema,
+} from "./agent/provide_input.schema.js";
+export {
+  type StartFreeJobResponseSchemaType,
+  type StartPaidJobResponseSchemaType,
+  startFreeJobResponseSchema,
+  startPaidJobResponseSchema,
+} from "./agent/start_job.schema.js";
+export {
+  type JobStatusResponseSchemaType,
+  jobStatusResponseSchema,
+} from "./agent/status.schema.js";
 
 // Input schemas
-export * from "./input/blank-numeric-input.js";
-export * from "./input/input.schema.js";
-export * from "./input/validation.schema.js";
+export { preprocessBlankNumericInput } from "./input/blank-numeric-input.js";
+export {
+  type InputBooleanSchemaType,
+  type InputCheckboxSchemaType,
+  type InputColorSchemaType,
+  type InputDateSchemaType,
+  type InputDatetimeSchemaType,
+  type InputEmailSchemaType,
+  type InputFieldSchemaType,
+  type InputFileSchemaType,
+  type InputGroupSchemaType,
+  type InputHiddenSchemaType,
+  type InputMonthSchemaType,
+  type InputMultiselectSchemaType,
+  type InputNoneSchemaType,
+  type InputNumberSchemaType,
+  type InputOptionSchemaType,
+  type InputPasswordSchemaType,
+  type InputRadioGroupSchemaType,
+  type InputRangeSchemaType,
+  type InputSchemaSchemaType,
+  type InputSchemaType,
+  type InputSearchSchemaType,
+  type InputStringSchemaType,
+  type InputTelSchemaType,
+  type InputTextareaSchemaType,
+  type InputTextSchemaType,
+  type InputTimeSchemaType,
+  type InputUrlSchemaType,
+  type InputWeekSchemaType,
+  inputGroupsSchema,
+  inputSchema,
+  inputSchemaSchema,
+  normalizeAndValidateInputSchema,
+} from "./input/input.schema.js";
+export type { ValidationSchemaType } from "./input/validation.schema.js";
 
 // x402 schemas
-export * from "./x402/payment-required.canonical.js";
+export { canonicalJsonKey } from "./x402/payment-required.canonical.js";
 // Named, not `export *`: the limits module is mostly internal fence
 // constants for the normalizer stack. Only the names apps actually consume
 // cross the package boundary; everything else stays reachable through the
@@ -23,6 +72,13 @@ export {
   X402_MAX_TIMEOUT_SECONDS,
   X402_MIN_TIMEOUT_SECONDS,
 } from "./x402/payment-required.limits.js";
-export * from "./x402/payment-required.schema.js";
-export * from "./x402/payment-required.supported.js";
-export * from "./x402/payment-required.wild.js";
+export {
+  isX402PaymentIdentifierAdvertised,
+  narrowToChosenRequirement,
+  normalizeX402PaymentRequiredWithSources,
+  type X402NormalizedRequirementSource,
+  type X402PaymentRequired,
+  type X402PaymentRequirements,
+} from "./x402/payment-required.schema.js";
+export { X402_SUPPORTED_SCHEMES } from "./x402/payment-required.supported.js";
+export { normalizeX402NetworkId } from "./x402/payment-required.wild.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace `export *` in `@sokosumi/masumi/schemas` with named exports for symbols that apps and packages actually import.

## Grep method

Searched the monorepo (skipping `node_modules`, `dist`, `.agents/skills`) for:

- `from "@sokosumi/masumi/schemas"`
- relative imports into `schemas/index.js` (`packages/masumi/src/clients/agent.client.ts`)

No `export * as` / namespace imports. No deep `@sokosumi/masumi/schemas/...` paths. In-package tests import sibling modules, not the barrel.

## Kept (60 names, real importers)

**Agent:** `inputSchemaResponseSchema`, `InputSchemaResponseSchemaType`, `provideInputRequestSchema`, `ProvideInputRequestSchemaType`, `provideInputResponseSchema`, `ProvideInputResponseSchemaType`, `startFreeJobResponseSchema`, `StartFreeJobResponseSchemaType`, `startPaidJobResponseSchema`, `StartPaidJobResponseSchemaType`, `jobStatusResponseSchema`, `JobStatusResponseSchemaType`

**Input:** `preprocessBlankNumericInput`, `normalizeAndValidateInputSchema`, `inputSchema`, `inputSchemaSchema`, `inputGroupsSchema`, `ValidationSchemaType`, and the `Input*SchemaType` field/group types used by web job-input UI

**x402:** `canonicalJsonKey`, `truncateEcho`, `X402_MAX_AMOUNT_DIGITS`, `X402_MAX_ENCODED_PAYLOAD_LENGTH`, `X402_MAX_TIMEOUT_SECONDS`, `X402_MIN_TIMEOUT_SECONDS`, `isX402PaymentIdentifierAdvertised`, `narrowToChosenRequirement`, `normalizeX402PaymentRequiredWithSources`, `X402NormalizedRequirementSource`, `X402PaymentRequired`, `X402PaymentRequirements`, `X402_SUPPORTED_SCHEMES`, `normalizeX402NetworkId`

Limits barrel was already named; left as-is.

## Dropped (no barrel importers)

- Agent request/status extras: `startJobRequestSchema`, `StartJobRequestSchemaType`, `JOB_STATUS`, `JobStatus`
- Per-field Zod objects (`inputNoneSchema`, `inputStringSchema`, `inputFieldSchema`, `inputFieldsSchema`, `inputDataSchema`, …) and unused inferred types (`InputFieldsSchemaType`, `InputDataSchemaType`, `InputGroupsSchemaType`)
- Per-rule validation schemas (`validationSchema`, `optionalValidationSchema`, …)
- x402 internals still used inside the package: `normalizeX402PaymentRequired`, `x402PaymentRequiredSchema`, `x402PaymentRequirementsSchema`, `X402NormalizedPaymentRequired`, `X402_PAYMENT_IDENTIFIER_EXTENSION_KEY`, `selectPayableRequirement`, `wildPaymentRequiredSchema`, `WildX402Requirement`, `X402_SUPPORTED_ASSET_TRANSFER_METHOD`, `x402ExtensionsSchema`, `x402ExtraSchema`, `wildX402ExtraSchema`, plus the unused limits fence constants

`JOB_STATUS` / `JobStatus` stay defined in `status.schema.ts` (the job-status response schema still uses them). They are just no longer public barrel exports.

Source modules, generated OpenAPI, and other packages are untouched.

## Out of scope (noted, not this PR)

- `packages/masumi/src/types/index.ts` still uses `export *`
- A test comment in `payment-required.schema.test.ts` still says the node-shape schemas are exported from `schemas/index.ts`; tests import those schemas from the sibling module

## Verification

- `pnpm --filter @sokosumi/masumi typecheck` — pass
- `pnpm --filter @sokosumi/masumi test` — 18 files, 411 tests
- `pnpm typecheck --filter=@sokosumi/masumi --filter=@sokosumi/core --filter=web` — 12 turbo tasks, including masumi rebuild

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ca9fb01-b39c-4521-8600-60747a3195c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ca9fb01-b39c-4521-8600-60747a3195c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

