### PR TITLE
docs(adr): point 0006 live browse at 0024

### DIFF
--- a/docs/adr/0006-stop-agent-browse-and-app-hire.md
+++ b/docs/adr/0006-stop-agent-browse-and-app-hire.md
@@ -2,6 +2,8 @@
 
 - Status: Partially superseded by [ADR-0024](./0024-restore-agent-catalog-browse-without-app-hire.md). The app Hire ban remains in force; only the “stop agent browse” decision is superseded.
 
+Live browse and discovery follow [ADR-0024](./0024-restore-agent-catalog-browse-without-app-hire.md).
+
 The marketplace no longer offers **browse or Hire in the app**. Users must not discover Agents on `/agents` or start a new Job from gallery or Agent detail. **Core Hire APIs stay.** **Soko Bot (then Hermes)** still Hires via orchestrator `POST /v1/agents/{id}/jobs`. **Coworker** still Hires via `POST /v1/tasks/{id}/jobs`. Task UI assigns a Coworker; it does not Hire an Agent. Existing Jobs stay. Canonical Job URL is `/jobs/{jobId}` so Agent detail can be deleted later without moving Jobs again.
 
 **Why not delete Agent detail now:** Jobs and “your Jobs for this Agent” still hang off `/agents/{id}`. Unlisted detail + list stay this cut; removal is a later decision.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly docs cleanup: `docs-adr-0006-body-vs-0024`.

Under the Status banner, one sentence that live browse/discovery follows ADR 0024. Historical decision untouched. Status not rewritten.

## Change

Adds this line after the existing Status banner in `docs/adr/0006-stop-agent-browse-and-app-hire.md`:

`Live browse and discovery follow ADR-0024.`

## Out of scope

- Historical 0006 decision body (left as written)
- Status line (already handled in #4293)

## Verification

Docs-only. `pnpm check` and `pnpm typecheck` passed on commit. Diff is one sentence.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c41a66a9-adb7-4493-bdf0-b4f2e3182ed9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c41a66a9-adb7-4493-bdf0-b4f2e3182ed9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

