### PR TITLE
build(apple): add six native syntax grammars

### DIFF
--- a/apps/apple/PARITY.md
+++ b/apps/apple/PARITY.md
@@ -3,7 +3,7 @@
 ## Resume checkpoint
 
 - Current slice: **10 — rich message text**. Native dependency [PR #4368](https://github.com/masumi-network/sokosumi/pull/4368) merged. Rendering remains in progress on `codex/apple-rich-message-rendering`; no renderer PR yet.
-- Separate approved dependency follow-up: `codex/apple-additional-grammars`, based on main `667feb522`. Adds six missing native grammars (Kotlin, Objective-C, XML, Make, Diff, INI), initially linked only by dependency tests. User explicitly approved these additions on 2026-09-10.
+- Separate approved dependency follow-up: [PR #4370](https://github.com/masumi-network/sokosumi/pull/4370), `codex/apple-additional-grammars`, based on main `667feb522`. Adds six missing native grammars (Kotlin, Objective-C, XML, Make, Diff, INI), initially linked only by dependency tests. User explicitly approved these additions on 2026-09-10.
 - Verification: 177 Chat tests, Xcode build/app tests, iOS 17 cross-build of the Chat test target (including all six native grammars), SwiftFormat and strict SwiftLint passed. No user-facing highlighting or scrolling fix is claimed by this dependency change.
 - Next: verify and merge the grammar dependency PR before integrating it into slice 10. Existing room scrolling lag is under investigation; automated native scroll input currently fails with `noWindowsAvailable`, so no performance fix is claimed. See the [native rendering design](docs/rich-message-rendering.md).
 - The recurring “Continue Apple chat after PR changes” automation remains deleted. Coordinate ownership before resuming from another app.

--- a/apps/apple/PARITY.md
+++ b/apps/apple/PARITY.md
@@ -2,9 +2,10 @@
 
 ## Resume checkpoint
 
-- Current slice: **10 — rich message text**, branch `codex/apple-native-syntax-dependencies`, based on main `afbbd5f86`. Native dependency [PR #4368](https://github.com/masumi-network/sokosumi/pull/4368) is open as a draft before rendering implementation.
-- Slice 09b merged in [PR #4361](https://github.com/masumi-network/sokosumi/pull/4361). Head `19b4c3a29` passed Apple CI: Xcode build/app tests, all package tests, lint/format.
-- Next: wait for CI/review and human merge of PR #4368, then complete slice 10. Dependency verification passed: Chat 176 tests, Xcode app build/tests, lint/format, and iOS17 cross-build of the Chat test target including native grammar/query products. The user rejected JavaScript-based rendering. See the [native rendering design](docs/rich-message-rendering.md).
+- Current slice: **10 — rich message text**. Native dependency [PR #4368](https://github.com/masumi-network/sokosumi/pull/4368) merged. Rendering remains in progress on `codex/apple-rich-message-rendering`; no renderer PR yet.
+- Separate approved dependency follow-up: `codex/apple-additional-grammars`, based on main `667feb522`. Adds six missing native grammars (Kotlin, Objective-C, XML, Make, Diff, INI), initially linked only by dependency tests. User explicitly approved these additions on 2026-09-10.
+- Verification: 177 Chat tests, Xcode build/app tests, iOS 17 cross-build of the Chat test target (including all six native grammars), SwiftFormat and strict SwiftLint passed. No user-facing highlighting or scrolling fix is claimed by this dependency change.
+- Next: verify and merge the grammar dependency PR before integrating it into slice 10. Existing room scrolling lag is under investigation; automated native scroll input currently fails with `noWindowsAvailable`, so no performance fix is claimed. See the [native rendering design](docs/rich-message-rendering.md).
 - The recurring “Continue Apple chat after PR changes” automation remains deleted. Coordinate ownership before resuming from another app.
 
 ### PR #4361 minor review follow-up

--- a/apps/apple/Packages/SokosumiChat/Package.resolved
+++ b/apps/apple/Packages/SokosumiChat/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "aa1c5b88007f7de54f5f21afff56638f71cd4bacf66e3057ce739744fbc812e9",
+  "originHash" : "2f8aaf1f817a69c55f79d6e9bd83a509e0c891d96483ec2910568d05222bcfe2",
   "pins" : [
     {
       "identity" : "openapikit",
@@ -107,6 +107,60 @@
       "state" : {
         "revision" : "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
         "version" : "0.25.10"
+      }
+    },
+    {
+      "identity" : "tree-sitter-diff",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-diff",
+      "state" : {
+        "revision" : "ada384ac7bfc1307f32de474620120add29998fb",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "tree-sitter-ini",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/justinmk/tree-sitter-ini",
+      "state" : {
+        "revision" : "f0285fe577ad298ad79f8633e643ad60646e3027",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "tree-sitter-kotlin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-kotlin",
+      "state" : {
+        "revision" : "77dd60ea0a9003ce062c9728a513ffe1aaff8c82",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "tree-sitter-make",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-make",
+      "state" : {
+        "revision" : "5e9e8f8ff3387b0edcaa90f46ddf3629f4cfeb1d",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "tree-sitter-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-objc",
+      "state" : {
+        "revision" : "18802acf31d0b5c1c1d50bdbc9eb0e1636cab9ed",
+        "version" : "3.0.2"
+      }
+    },
+    {
+      "identity" : "tree-sitter-xml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-xml",
+      "state" : {
+        "revision" : "4b64dd3a03ec002258d6268d712fd93716d6ab57",
+        "version" : "0.7.0"
       }
     },
     {

--- a/apps/apple/Packages/SokosumiChat/Package.swift
+++ b/apps/apple/Packages/SokosumiChat/Package.swift
@@ -15,6 +15,12 @@ let package = Package(
     .package(path: "../CoreAPI"),
     .package(url: "https://github.com/tree-sitter/swift-tree-sitter", exact: "0.10.0"),
     .package(url: "https://github.com/simonbs/TreeSitterLanguages", exact: "0.1.10"),
+    .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-kotlin", exact: "1.1.0"),
+    .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-objc", exact: "3.0.2"),
+    .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-xml", exact: "0.7.0"),
+    .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-make", exact: "1.1.1"),
+    .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-diff", exact: "0.2.0"),
+    .package(url: "https://github.com/justinmk/tree-sitter-ini", exact: "1.4.0"),
     .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.8.2"),
     // Direct `import HTTPTypes` needs a declared dependency: SwiftPM links
     // the transitive closure, but Xcode links each product against its
@@ -39,6 +45,12 @@ let package = Package(
         .product(name: "TreeSitterSwiftQueries", package: "TreeSitterLanguages"),
         .product(name: "TreeSitterJSON", package: "TreeSitterLanguages"),
         .product(name: "TreeSitterJSONQueries", package: "TreeSitterLanguages"),
+        .product(name: "TreeSitterKotlin", package: "tree-sitter-kotlin"),
+        .product(name: "TreeSitterObjc", package: "tree-sitter-objc"),
+        .product(name: "TreeSitterXML", package: "tree-sitter-xml"),
+        .product(name: "TreeSitterMake", package: "tree-sitter-make"),
+        .product(name: "TreeSitterDiff", package: "tree-sitter-diff"),
+        .product(name: "TreeSitterIni", package: "tree-sitter-ini"),
         .product(name: "CoreAPI", package: "CoreAPI"),
         .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
         .product(name: "HTTPTypes", package: "swift-http-types")

--- a/apps/apple/Packages/SokosumiChat/Tests/SokosumiChatTests/NativeSyntaxDependencyTests.swift
+++ b/apps/apple/Packages/SokosumiChat/Tests/SokosumiChatTests/NativeSyntaxDependencyTests.swift
@@ -1,10 +1,16 @@
 import Foundation
 import SwiftTreeSitter
 import Testing
+import TreeSitterDiff
+import TreeSitterIni
 import TreeSitterJSON
 import TreeSitterJSONQueries
+import TreeSitterKotlin
+import TreeSitterMake
+import TreeSitterObjc
 import TreeSitterSwift
 import TreeSitterSwiftQueries
+import TreeSitterXML
 
 struct NativeSyntaxDependencyTests {
   @Test func swiftHighlightsUnicodeSource() throws {
@@ -17,6 +23,25 @@ struct NativeSyntaxDependencyTests {
   @Test func jsonHighlightsWithoutEditorFrameworks() throws {
     let captures = try highlight("{\"count\": 42}", language: tree_sitter_json(), queryURL: TreeSitterJSONQueries.Query.highlightsFileURL)
     #expect(captures.contains { $0.0 == "number" && $0.1 == "42" })
+  }
+
+  @Test func additionalGrammarsParseUnicodeSource() throws {
+    let fixtures: [(OpaquePointer, String)] = [
+      (tree_sitter_kotlin(), "val greeting = \"Hello 👋\""),
+      (tree_sitter_objc(), "void greet(void) { NSString *s = @\"Hello 👋\"; }"),
+      (tree_sitter_xml(), "<greeting>Hello 👋</greeting>"),
+      (tree_sitter_make(), "all:\n\techo 'Hello 👋'\n"),
+      (tree_sitter_diff(), "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n@@ -1 +1 @@\n-old\n+Hello 👋\n"),
+      (tree_sitter_ini(), "[greeting]\nmessage=Hello 👋\n")
+    ]
+    for (pointer, source) in fixtures {
+      let parser = Parser()
+      try parser.setLanguage(Language(language: pointer))
+      let tree = try #require(parser.parse(source))
+      let root = try #require(tree.rootNode)
+      #expect(!root.hasError)
+      #expect(root.range == NSRange(location: 0, length: (source as NSString).length))
+    }
   }
 
   private func highlight(_ source: String, language: OpaquePointer, queryURL: URL) throws -> [(String, String)] {

--- a/apps/apple/docs/rich-message-rendering.md
+++ b/apps/apple/docs/rich-message-rendering.md
@@ -39,3 +39,24 @@ Required tests: block/inline fixtures, nested structures, tables, unsupported/ma
 - TreeSitterLanguages resolves Runestone 0.4.2 transitively. No Runestone product, UIKit editor, or JavaScript runtime is linked by the dependency tests.
 - Representative dependency tests run Swift and JSON highlight queries; Swift verifies UTF-16 capture ranges across emoji text. Dependency products are test-only until the renderer integrates them in slice 10.
 - macOS: Chat 176 tests passed, Xcode app suite passed, Swift lint/format passed. iOS17 compatibility build is recorded in PARITY.md when complete.
+
+## Additional native grammars (approved 2026-09-10)
+
+TreeSitterLanguages does not provide the six grammars below. Use their native
+SwiftPM packages with the existing SwiftTreeSitter binding; no JavaScript engine
+or web view is required. The separate dependency PR links them into tests first.
+Rendering and language detection remain part of slice 10 after this PR merges.
+
+| Language | Package | Exact version | License |
+| --- | --- | --- | --- |
+| Kotlin | tree-sitter-grammars/tree-sitter-kotlin | 1.1.0 | MIT |
+| Objective-C | tree-sitter-grammars/tree-sitter-objc | 3.0.2 | MIT |
+| XML | tree-sitter-grammars/tree-sitter-xml | 0.7.0 | MIT |
+| Make | tree-sitter-grammars/tree-sitter-make | 1.1.1 | MIT |
+| Diff | tree-sitter-grammars/tree-sitter-diff | 0.2.0 | MIT |
+| INI | justinmk/tree-sitter-ini | 1.4.0 | Apache-2.0 |
+
+The dependency tests parse Unicode fixtures and validate UTF-16 source ranges
+for every grammar. They prove parser compatibility, not finished highlighting.
+Query integration and the remaining web language registry gaps still need to be
+covered by the renderer implementation.


### PR DESCRIPTION
Adds the six approved native grammars missing from TreeSitterLanguages: Kotlin 1.1.0, Objective-C 3.0.2, XML 0.7.0, Make 1.1.1, Diff 0.2.0, and INI 1.4.0. This prepares native code-block highlighting for Apple chat without a JavaScript runtime.

This is the separately approved dependency follow-up to #4368. Products are linked only to dependency tests until the renderer integrates them after merge. Message rendering, automatic language detection, attachments, and the reported scrolling regression are outside this PR. No web files or API contracts change. PARITY.md records the boundary and next step.

Web behavior: [Markdown renderer](https://github.com/masumi-network/sokosumi/blob/667feb522/apps/web/src/components/markdown.tsx), [room message row](https://github.com/masumi-network/sokosumi/blob/667feb522/apps/web/src/app/(app)/chat/components/room-message-row.tsx).

Verification:
- `swift test --package-path apps/apple/Packages/SokosumiChat`: 177 tests passed; all six grammars parse Unicode fixtures with correct UTF-16 ranges.
- `xcodebuild test -only-testing:SokosumiTests` with macOS arm64, ad-hoc signing, and package-plugin validation skipped: passed.
- iOS 17 cross-build of `SokosumiChatTests`, including the native grammar products: passed.
- SwiftFormat, strict SwiftLint, and diff checks: passed.

There is no UI change to screenshot or manually exercise yet. Run the dependency tests to verify this PR; syntax highlighting arrives with the rendering slice.
