### PR TITLE
refactor(web): sanitize composer markdown before it reaches innerHTML

### DIFF
--- a/apps/web/src/lib/utils/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.test.ts
@@ -4,6 +4,7 @@ import {
   htmlToMarkdown,
   markdownToHtml,
   normalizeLooseInlineMarkdown,
+  sanitizeComposerHtml,
   wrapInlineMarkdownMarker,
 } from "@/lib/utils/composer-markdown-dom";
 
@@ -191,5 +192,195 @@ describe("wrapInlineMarkdownMarker", () => {
   it("keeps empty or whitespace-only content unmarked", () => {
     expect(wrapInlineMarkdownMarker("", "**", "**")).toBe("");
     expect(wrapInlineMarkdownMarker("   ", "**", "**")).toBe("   ");
+  });
+});
+
+describe("sanitizeComposerHtml", () => {
+  it("keeps every tag the composer emits", () => {
+    const html =
+      "<h1>a</h1><h2>b</h2><h3>c</h3><ul><li>d</li></ul><ol><li>e</li></ol>" +
+      "<blockquote>f</blockquote><pre><code>g</code></pre>" +
+      "<strong>h</strong><em>i</em><s>j</s><u>k</u><code>l</code><br>";
+    const root = document.createElement("div");
+    root.innerHTML = sanitizeComposerHtml(html);
+    expect(
+      Array.from(root.querySelectorAll("*")).map((element) =>
+        element.tagName.toLowerCase(),
+      ),
+    ).toEqual([
+      "h1",
+      "h2",
+      "h3",
+      "ul",
+      "li",
+      "ol",
+      "li",
+      "blockquote",
+      "pre",
+      "code",
+      "strong",
+      "em",
+      "s",
+      "u",
+      "code",
+      "br",
+    ]);
+    expect(root.textContent).toBe("abcdefghijkl");
+  });
+
+  it("keeps the attributes htmlToMarkdown reads back", () => {
+    const html =
+      '<span data-mention-key="user_1" data-mention-slug="alice" ' +
+      'class="text-primary" contenteditable="false">@Alice</span>' +
+      '<span data-channel-label="general" contenteditable="false">#general</span>' +
+      '<pre><code data-language="ts">x</code></pre>' +
+      '<a href="https://a.test/">link</a>';
+    const root = document.createElement("div");
+    root.innerHTML = sanitizeComposerHtml(html);
+
+    const mention = root.querySelector("[data-mention-key]");
+    expect(mention?.getAttribute("data-mention-slug")).toBe("alice");
+    expect(mention?.getAttribute("contenteditable")).toBe("false");
+    expect(mention?.getAttribute("class")).toBe("text-primary");
+    expect(
+      root
+        .querySelector("[data-channel-label]")
+        ?.getAttribute("contenteditable"),
+    ).toBe("false");
+    expect(root.querySelector("code")?.getAttribute("data-language")).toBe(
+      "ts",
+    );
+    expect(root.querySelector("a")?.getAttribute("href")).toBe(
+      "https://a.test/",
+    );
+  });
+
+  it("strips tags the composer never emits", () => {
+    const sanitized = sanitizeComposerHtml(
+      '<img src="x"><table><tr><td>t</td></tr></table><p>keep</p>',
+    );
+    expect(sanitized).not.toContain("<img");
+    expect(sanitized).not.toContain("<table");
+    expect(sanitized).toContain("keep");
+  });
+
+  it("strips scripts and event handlers", () => {
+    const sanitized = sanitizeComposerHtml(
+      '<script>alert(1)</script><strong onmouseover="alert(1)">hi</strong>' +
+        '<img src=x onerror="alert(1)">',
+    );
+    const root = document.createElement("div");
+    root.innerHTML = sanitized;
+    expect(root.querySelector("script")).toBeNull();
+    expect(root.querySelector("img")).toBeNull();
+    expect(
+      Array.from(root.querySelector("strong")?.attributes ?? []).map(
+        (attribute) => attribute.name,
+      ),
+    ).toEqual([]);
+  });
+
+  it("strips javascript: hrefs while keeping http and mailto", () => {
+    expect(
+      sanitizeComposerHtml('<a href="javascript:alert(1)">x</a>'),
+    ).not.toContain("javascript:");
+    expect(sanitizeComposerHtml('<a href="mailto:a@b.test">x</a>')).toContain(
+      "mailto:a@b.test",
+    );
+  });
+
+  it("strips inline styles", () => {
+    expect(
+      sanitizeComposerHtml('<strong style="color:red">x</strong>'),
+    ).not.toContain("style");
+  });
+});
+
+describe("markdownToHtml sanitization boundary", () => {
+  function roundTrip(
+    source: string,
+    resolve?: Parameters<typeof markdownToHtml>[1],
+    options?: Parameters<typeof markdownToHtml>[2],
+  ): string {
+    const root = document.createElement("div");
+    root.innerHTML = markdownToHtml(source, resolve, options);
+    return htmlToMarkdown(root).trim();
+  }
+
+  it("round-trips a known mention chip", () => {
+    const source = "ping @user_1:alice-smith hey";
+    expect(
+      roundTrip(source, (mentionKey, mentionSlug) =>
+        mentionKey === "user_1"
+          ? { displayName: "Alice Smith", isKnown: true }
+          : { displayName: mentionSlug, isKnown: false },
+      ),
+    ).toBe(source);
+  });
+
+  it("round-trips an unknown mention chip", () => {
+    const source = "ping @missing:ghost hey";
+    expect(roundTrip(source)).toBe(source);
+  });
+
+  it("round-trips a channel link chip", () => {
+    expect(
+      roundTrip("see #general please", undefined, {
+        channelLinks: [{ name: "general", slug: "general" }],
+      }),
+    ).toBe("see #general please");
+  });
+
+  it("round-trips fenced code with and without a language", () => {
+    expect(roundTrip("```ts\nconst a = 1;\n```")).toBe(
+      "```ts\nconst a = 1;\n```",
+    );
+    expect(roundTrip("```\nplain\n```")).toBe("```\nplain\n```");
+  });
+
+  it("round-trips links", () => {
+    expect(roundTrip("[x](https://a.test/)")).toBe("[x](https://a.test/)");
+    expect(roundTrip("[mail](mailto:a@b.test)")).toBe(
+      "[mail](mailto:a@b.test)",
+    );
+  });
+
+  it("round-trips every inline format", () => {
+    const source = "a _b_ **c** ~~d~~ `e` <u>f</u>";
+    expect(roundTrip(source)).toBe(source);
+  });
+
+  it("keeps chips non-editable after sanitization", () => {
+    const root = document.createElement("div");
+    root.innerHTML = markdownToHtml(
+      "hi @missing:ghost and #general",
+      undefined,
+      {
+        channelLinks: [{ name: "general", slug: "general" }],
+      },
+    );
+    const chips = root.querySelectorAll(
+      "[data-mention-key], [data-channel-label]",
+    );
+    expect(chips).toHaveLength(2);
+    for (const chip of Array.from(chips)) {
+      expect(chip.getAttribute("contenteditable")).toBe("false");
+    }
+  });
+
+  it("does not double-encode entities the escape pass already produced", () => {
+    expect(roundTrip("a & b < c")).toBe("a & b < c");
+    expect(roundTrip("```\na & b < c\n```")).toBe("```\na & b < c\n```");
+    expect(roundTrip("[a & b](https://a.test/)")).toBe(
+      "[a & b](https://a.test/)",
+    );
+  });
+
+  it("renders literal HTML text as text", () => {
+    const html = markdownToHtml("<script>alert(1)</script>");
+    const root = document.createElement("div");
+    root.innerHTML = html;
+    expect(root.querySelector("script")).toBeNull();
+    expect(root.textContent).toBe("<script>alert(1)</script>");
   });
 });

--- a/apps/web/src/lib/utils/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.test.ts
@@ -289,6 +289,12 @@ describe("sanitizeComposerHtml", () => {
     );
   });
 
+  it("strips protocol-relative hrefs", () => {
+    const root = document.createElement("div");
+    root.innerHTML = sanitizeComposerHtml('<a href="//evil.test/x">x</a>');
+    expect(root.querySelector("a")?.getAttribute("href")).toBeNull();
+  });
+
   it("strips inline styles", () => {
     expect(
       sanitizeComposerHtml('<strong style="color:red">x</strong>'),
@@ -366,6 +372,39 @@ describe("markdownToHtml sanitization boundary", () => {
     for (const chip of Array.from(chips)) {
       expect(chip.getAttribute("contenteditable")).toBe("false");
     }
+  });
+
+  it("serializes exactly as the browser does, so the editors can skip a write", () => {
+    // Both composers guard their innerHTML write with
+    // `editor.innerHTML !== markdownToHtml(value)`. A serialization the
+    // browser rewrites makes that guard never hold.
+    const sources = [
+      "a\nb",
+      "# h",
+      "- a\n- b",
+      "1. one",
+      "> q",
+      "```\nx\n```",
+      "**b** _i_ ~~s~~ `c` <u>u</u>",
+      "[x](https://a.test/)",
+      "hi @missing:ghost",
+    ];
+    for (const source of sources) {
+      const html = markdownToHtml(source);
+      const root = document.createElement("div");
+      root.innerHTML = html;
+      expect(root.innerHTML).toBe(html);
+    }
+  });
+
+  it("renders headings, lists and blockquotes through the boundary", () => {
+    const root = document.createElement("div");
+    root.innerHTML = markdownToHtml("# h\n## h2\n- a\n1. one\n> q");
+    expect(root.querySelector("h1")?.textContent).toBe("h");
+    expect(root.querySelector("h2")?.textContent).toBe("h2");
+    expect(root.querySelector("ul li")?.textContent).toBe("a");
+    expect(root.querySelector("ol li")?.textContent).toBe("one");
+    expect(root.querySelector("blockquote")?.textContent).toBe("q");
   });
 
   it("does not double-encode entities the escape pass already produced", () => {

--- a/apps/web/src/lib/utils/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.test.ts
@@ -289,33 +289,6 @@ describe("sanitizeComposerHtml", () => {
     );
   });
 
-  it("admits no void tag other than br", () => {
-    // normalizeVoidTagSerialization rewrites only <br />. Any other void tag
-    // in the allow-list would keep sanitize-html's XML-style serialization
-    // and break the editors' skip-the-write guard.
-    const voidTags = [
-      "area",
-      "base",
-      "basefont",
-      "col",
-      "embed",
-      "hr",
-      "img",
-      "input",
-      "link",
-      "meta",
-      "param",
-      "source",
-      "track",
-      "wbr",
-    ];
-    for (const tag of voidTags) {
-      const sanitized = sanitizeComposerHtml(`<${tag}>`);
-      expect(sanitized).toBe("");
-    }
-    expect(sanitizeComposerHtml("a<br>b")).toBe("a<br>b");
-  });
-
   it("strips protocol-relative hrefs", () => {
     const root = document.createElement("div");
     root.innerHTML = sanitizeComposerHtml('<a href="//evil.test/x">x</a>');
@@ -401,12 +374,13 @@ describe("markdownToHtml sanitization boundary", () => {
     }
   });
 
-  it("serializes markup as the browser does, so the editors can skip a write", () => {
+  it("serializes exactly as the browser does, so the editors can skip a write", () => {
     // Both composers guard their innerHTML write with
     // `editor.innerHTML !== markdownToHtml(value)`. A serialization the
-    // browser rewrites makes that guard never hold. Scope is markup only:
-    // a non-breaking space in the text still re-serializes to &nbsp;, which
-    // predates the sanitizer and is not fixed here.
+    // browser rewrites makes that guard never hold, so the editor DOM is
+    // replaced on every sync. The last four cases each broke a different
+    // serializer rule: a void tag, a non-breaking space, `<` in an attribute
+    // value, and a restore placeholder swallowed into an attribute.
     const sources = [
       "a\nb",
       "# h",
@@ -417,6 +391,10 @@ describe("markdownToHtml sanitization boundary", () => {
       "**b** _i_ ~~s~~ `c` <u>u</u>",
       "[x](https://a.test/)",
       "hi @missing:ghost",
+      "a\u00a0b",
+      "[l<x](https://y.test/<)",
+      "@a:b<u>x</u>",
+      "@a:b[x](https://y.test/)",
     ];
     for (const source of sources) {
       const html = markdownToHtml(source);

--- a/apps/web/src/lib/utils/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.test.ts
@@ -444,6 +444,20 @@ describe("markdownToHtml sanitization boundary", () => {
     );
   });
 
+  it("strips attributes a restored token injects into a chip", () => {
+    // The mention slug swallows the link placeholder, so the link HTML is
+    // restored inside an attribute value where the element-context escaping
+    // does not apply. Without the boundary the browser reads `https:` and
+    // `y.test` off the chip as bare attributes.
+    const root = document.createElement("div");
+    root.innerHTML = markdownToHtml("@a:b[x](https://y.test/)");
+    const chip = root.querySelector("[data-mention-key]");
+    expect(chip).not.toBeNull();
+    expect(
+      Array.from(chip?.attributes ?? []).map((attribute) => attribute.name),
+    ).toEqual(["data-mention-key", "data-mention-slug"]);
+  });
+
   it("renders literal HTML text as text", () => {
     const html = markdownToHtml("<script>alert(1)</script>");
     const root = document.createElement("div");

--- a/apps/web/src/lib/utils/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.test.ts
@@ -427,13 +427,26 @@ describe("markdownToHtml sanitization boundary", () => {
     // restored inside an attribute value where the element-context escaping
     // does not apply. Without the boundary the browser reads `https:` and
     // `y.test` off the chip as bare attributes.
+    //
+    // This input also mangles the user's own text, on main as well as here.
+    // That is a separate defect in the mention regex; this case asserts only
+    // that nothing outside the allow-list survives.
+    const allowed = [
+      "class",
+      "contenteditable",
+      "data-channel-label",
+      "data-mention-key",
+      "data-mention-slug",
+    ];
     const root = document.createElement("div");
     root.innerHTML = markdownToHtml("@a:b[x](https://y.test/)");
     const chip = root.querySelector("[data-mention-key]");
     expect(chip).not.toBeNull();
-    expect(
-      Array.from(chip?.attributes ?? []).map((attribute) => attribute.name),
-    ).toEqual(["data-mention-key", "data-mention-slug"]);
+    const names = Array.from(chip?.attributes ?? []).map(
+      (attribute) => attribute.name,
+    );
+    expect(names).not.toHaveLength(0);
+    expect(names.filter((name) => !allowed.includes(name))).toEqual([]);
   });
 
   it("renders literal HTML text as text", () => {

--- a/apps/web/src/lib/utils/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.test.ts
@@ -289,6 +289,33 @@ describe("sanitizeComposerHtml", () => {
     );
   });
 
+  it("admits no void tag other than br", () => {
+    // normalizeVoidTagSerialization rewrites only <br />. Any other void tag
+    // in the allow-list would keep sanitize-html's XML-style serialization
+    // and break the editors' skip-the-write guard.
+    const voidTags = [
+      "area",
+      "base",
+      "basefont",
+      "col",
+      "embed",
+      "hr",
+      "img",
+      "input",
+      "link",
+      "meta",
+      "param",
+      "source",
+      "track",
+      "wbr",
+    ];
+    for (const tag of voidTags) {
+      const sanitized = sanitizeComposerHtml(`<${tag}>`);
+      expect(sanitized).toBe("");
+    }
+    expect(sanitizeComposerHtml("a<br>b")).toBe("a<br>b");
+  });
+
   it("strips protocol-relative hrefs", () => {
     const root = document.createElement("div");
     root.innerHTML = sanitizeComposerHtml('<a href="//evil.test/x">x</a>');
@@ -374,10 +401,12 @@ describe("markdownToHtml sanitization boundary", () => {
     }
   });
 
-  it("serializes exactly as the browser does, so the editors can skip a write", () => {
+  it("serializes markup as the browser does, so the editors can skip a write", () => {
     // Both composers guard their innerHTML write with
     // `editor.innerHTML !== markdownToHtml(value)`. A serialization the
-    // browser rewrites makes that guard never hold.
+    // browser rewrites makes that guard never hold. Scope is markup only:
+    // a non-breaking space in the text still re-serializes to &nbsp;, which
+    // predates the sanitizer and is not fixed here.
     const sources = [
       "a\nb",
       "# h",

--- a/apps/web/src/lib/utils/composer-markdown-dom.test.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.test.ts
@@ -445,7 +445,6 @@ describe("markdownToHtml sanitization boundary", () => {
     const names = Array.from(chip?.attributes ?? []).map(
       (attribute) => attribute.name,
     );
-    expect(names).not.toHaveLength(0);
     expect(names.filter((name) => !allowed.includes(name))).toEqual([]);
   });
 

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -141,12 +141,12 @@ function normalizeVoidTagSerialization(html: string): string {
  * choice changes where this runs: `markdownToHtml` already needs a DOM,
  * because the chip builders call `document.createElement`.
  *
- * No test pins the call from `markdownToHtml` to here, and none can without
- * spying on the sanitizer. Every interpolation is escaped before it reaches
- * the builder and both chip builders write `textContent`, so no reachable
- * input produces dirty HTML for this to strip. What the tests do pin is the
- * allow-list: drop an attribute and the round-trip cases fail, which is the
- * failure mode that loses user content.
+ * The boundary is load-bearing, not belt-and-braces. Escaping each
+ * interpolation is not enough, because a token can be restored into an
+ * attribute value rather than into element content, where element-context
+ * escaping does not apply: `@a:b[x](https://y.test/)` lets the mention slug
+ * swallow the link placeholder and injects `https:` and `y.test` as bare
+ * attributes on the chip. That is what this strips.
  */
 export function sanitizeComposerHtml(html: string): string {
   return normalizeVoidTagSerialization(

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -137,9 +137,16 @@ function normalizeVoidTagSerialization(html: string): string {
  *
  * Not `sanitizeMarkdown`: that is the room presentation policy, and it drops
  * `pre`, `blockquote`, `s`, and every chip attribute. `sanitize-html` rather
- * than DOMPurify because it takes per-tag attribute allow-lists and needs no
- * DOM, which keeps this function and `markdownToHtml` pure. `htmlToMarkdown`,
- * the reverse direction, still needs a DOM.
+ * than DOMPurify because it takes per-tag attribute allow-lists. Neither
+ * choice changes where this runs: `markdownToHtml` already needs a DOM,
+ * because the chip builders call `document.createElement`.
+ *
+ * No test pins the call from `markdownToHtml` to here, and none can without
+ * spying on the sanitizer. Every interpolation is escaped before it reaches
+ * the builder and both chip builders write `textContent`, so no reachable
+ * input produces dirty HTML for this to strip. What the tests do pin is the
+ * allow-list: drop an attribute and the round-trip cases fail, which is the
+ * failure mode that loses user content.
  */
 export function sanitizeComposerHtml(html: string): string {
   return normalizeVoidTagSerialization(

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -127,8 +127,9 @@ const COMPOSER_ALLOWED_ATTRIBUTES: Record<string, string[]> = {
  * Not `sanitizeMarkdown`: that is the room presentation policy, and it drops
  * `pre`, `blockquote`, `s`, and every chip attribute. `sanitize-html` rather
  * than DOMPurify because it takes per-tag attribute allow-lists. This needs a
- * DOM, which costs nothing: `markdownToHtml` already needs one, because the
- * chip builders call `document.createElement`.
+ * DOM. Both call sites already run browser-only, and `markdownToHtml` already
+ * needs a DOM whenever the text carries a chip, because the chip builders call
+ * `document.createElement`. What changes is that plain text needs one too.
  *
  * The boundary is load-bearing, not belt-and-braces. Escaping each
  * interpolation is not enough, because a token can be restored into an

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -119,17 +119,6 @@ const COMPOSER_ALLOWED_ATTRIBUTES: Record<string, string[]> = {
 };
 
 /**
- * `sanitize-html` writes void tags XML-style (`<br />`); a browser serializes
- * the same node as `<br>`. Both composers skip their `innerHTML` write while
- * `editor.innerHTML === markdownToHtml(value)`, so a mismatch here makes every
- * multi-line value rewrite the editor DOM. `br` is the only void tag the
- * composer allow-list admits.
- */
-function normalizeVoidTagSerialization(html: string): string {
-  return html.replace(/<br \/>/g, "<br>");
-}
-
-/**
  * Boundary between the hand-built composer HTML and the two `markdownToHtml`
  * call sites, both of which assign the result to `innerHTML`. The transform
  * escapes its input and gates each interpolation; this rejects anything those
@@ -137,9 +126,9 @@ function normalizeVoidTagSerialization(html: string): string {
  *
  * Not `sanitizeMarkdown`: that is the room presentation policy, and it drops
  * `pre`, `blockquote`, `s`, and every chip attribute. `sanitize-html` rather
- * than DOMPurify because it takes per-tag attribute allow-lists. Neither
- * choice changes where this runs: `markdownToHtml` already needs a DOM,
- * because the chip builders call `document.createElement`.
+ * than DOMPurify because it takes per-tag attribute allow-lists. This needs a
+ * DOM, which costs nothing: `markdownToHtml` already needs one, because the
+ * chip builders call `document.createElement`.
  *
  * The boundary is load-bearing, not belt-and-braces. Escaping each
  * interpolation is not enough, because a token can be restored into an
@@ -149,18 +138,26 @@ function normalizeVoidTagSerialization(html: string): string {
  * attributes on the chip. That is what this strips.
  */
 export function sanitizeComposerHtml(html: string): string {
-  return normalizeVoidTagSerialization(
-    sanitizeHtml(html, {
-      allowedTags: COMPOSER_ALLOWED_TAGS,
-      allowedAttributes: COMPOSER_ALLOWED_ATTRIBUTES,
-      // No allowedClasses: chip and code classes are Tailwind utilities that
-      // change with styling, so an allow-list of values would break on restyle.
-      disallowedTagsMode: "discard",
-      // The transform only ever emits http, https and mailto, already gated by
-      // normalizeUrl. Protocol-relative URLs are not a composer feature.
-      allowProtocolRelative: false,
-    }),
-  );
+  const sanitized = sanitizeHtml(html, {
+    allowedTags: COMPOSER_ALLOWED_TAGS,
+    allowedAttributes: COMPOSER_ALLOWED_ATTRIBUTES,
+    // No allowedClasses: chip and code classes are Tailwind utilities that
+    // change with styling, so an allow-list of values would break on restyle.
+    disallowedTagsMode: "discard",
+    // The transform only ever emits http, https and mailto, already gated by
+    // normalizeUrl. Protocol-relative URLs are not a composer feature.
+    allowProtocolRelative: false,
+  });
+
+  // Re-serialize through the DOM. `sanitize-html` writes void tags XML-style
+  // (`<br />`) and escapes `<` inside attribute values; a browser does
+  // neither. Both composers skip their `innerHTML` write while
+  // `editor.innerHTML === markdownToHtml(value)`, so any such difference
+  // makes the editor DOM rewrite on every sync. Parsing sanitized markup
+  // back out is what makes the two strings comparable.
+  const host = document.createElement("div");
+  host.innerHTML = sanitized;
+  return host.innerHTML;
 }
 
 /**

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -5,6 +5,7 @@ import {
   replaceMarkdownLinks,
   unescapeMarkdownLinkUrl,
 } from "@sokosumi/utils";
+import sanitizeHtml from "sanitize-html";
 
 import {
   createChannelLinkSpan,
@@ -81,6 +82,57 @@ function defaultResolveMentionDisplay(
     displayName: mentionSlug,
     isKnown: false,
   };
+}
+
+// The composer allow-list is the set of tags `markdownToHtml` emits, and the
+// set of attributes `htmlToMarkdown` reads back. Change the two together: an
+// attribute dropped here is silently lost from the user's stored markdown.
+const COMPOSER_ALLOWED_TAGS = [
+  "a",
+  "blockquote",
+  "br",
+  "code",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "li",
+  "ol",
+  "pre",
+  "s",
+  "span",
+  "strong",
+  "u",
+  "ul",
+] as const;
+
+const COMPOSER_ALLOWED_ATTRIBUTES: Record<string, string[]> = {
+  a: ["href"],
+  code: ["class", "data-language"],
+  span: [
+    "class",
+    "contenteditable",
+    "data-channel-label",
+    "data-mention-key",
+    "data-mention-slug",
+  ],
+};
+
+/**
+ * Boundary between the hand-built composer HTML and the two `innerHTML` sinks.
+ * The transform escapes its input and gates each interpolation; this rejects
+ * anything those passes let through, so no single site has to be perfect.
+ */
+export function sanitizeComposerHtml(html: string): string {
+  if (!html) return "";
+
+  return sanitizeHtml(html, {
+    allowedTags: [...COMPOSER_ALLOWED_TAGS],
+    allowedAttributes: COMPOSER_ALLOWED_ATTRIBUTES,
+    // No allowedClasses: chip and code classes are Tailwind utilities that
+    // change with styling, so an allow-list of values would break on restyle.
+    disallowedTagsMode: "discard",
+  });
 }
 
 /**
@@ -282,9 +334,11 @@ export function markdownToHtml(
     return result.replace(block.token, () => block.html);
   }, withRestoredLinks);
 
-  return underlineTokens.reduce((result, underline) => {
+  const restored = underlineTokens.reduce((result, underline) => {
     return result.replace(underline.token, () => underline.html);
   }, withRestoredCode);
+
+  return sanitizeComposerHtml(restored);
 }
 
 function getCodeContent(codeContainer: HTMLElement): string {

--- a/apps/web/src/lib/utils/composer-markdown-dom.ts
+++ b/apps/web/src/lib/utils/composer-markdown-dom.ts
@@ -104,7 +104,7 @@ const COMPOSER_ALLOWED_TAGS = [
   "strong",
   "u",
   "ul",
-] as const;
+];
 
 const COMPOSER_ALLOWED_ATTRIBUTES: Record<string, string[]> = {
   a: ["href"],
@@ -119,20 +119,41 @@ const COMPOSER_ALLOWED_ATTRIBUTES: Record<string, string[]> = {
 };
 
 /**
- * Boundary between the hand-built composer HTML and the two `innerHTML` sinks.
- * The transform escapes its input and gates each interpolation; this rejects
- * anything those passes let through, so no single site has to be perfect.
+ * `sanitize-html` writes void tags XML-style (`<br />`); a browser serializes
+ * the same node as `<br>`. Both composers skip their `innerHTML` write while
+ * `editor.innerHTML === markdownToHtml(value)`, so a mismatch here makes every
+ * multi-line value rewrite the editor DOM. `br` is the only void tag the
+ * composer allow-list admits.
+ */
+function normalizeVoidTagSerialization(html: string): string {
+  return html.replace(/<br \/>/g, "<br>");
+}
+
+/**
+ * Boundary between the hand-built composer HTML and the two `markdownToHtml`
+ * call sites, both of which assign the result to `innerHTML`. The transform
+ * escapes its input and gates each interpolation; this rejects anything those
+ * passes let through, so no single site has to be perfect.
+ *
+ * Not `sanitizeMarkdown`: that is the room presentation policy, and it drops
+ * `pre`, `blockquote`, `s`, and every chip attribute. `sanitize-html` rather
+ * than DOMPurify because it takes per-tag attribute allow-lists and needs no
+ * DOM, which keeps this function and `markdownToHtml` pure. `htmlToMarkdown`,
+ * the reverse direction, still needs a DOM.
  */
 export function sanitizeComposerHtml(html: string): string {
-  if (!html) return "";
-
-  return sanitizeHtml(html, {
-    allowedTags: [...COMPOSER_ALLOWED_TAGS],
-    allowedAttributes: COMPOSER_ALLOWED_ATTRIBUTES,
-    // No allowedClasses: chip and code classes are Tailwind utilities that
-    // change with styling, so an allow-list of values would break on restyle.
-    disallowedTagsMode: "discard",
-  });
+  return normalizeVoidTagSerialization(
+    sanitizeHtml(html, {
+      allowedTags: COMPOSER_ALLOWED_TAGS,
+      allowedAttributes: COMPOSER_ALLOWED_ATTRIBUTES,
+      // No allowedClasses: chip and code classes are Tailwind utilities that
+      // change with styling, so an allow-list of values would break on restyle.
+      disallowedTagsMode: "discard",
+      // The transform only ever emits http, https and mailto, already gated by
+      // normalizeUrl. Protocol-relative URLs are not a composer feature.
+      allowProtocolRelative: false,
+    }),
+  );
 }
 
 /**


### PR DESCRIPTION
Closes SOK-1031.

## User-facing impact

None intended. Same chips, same formatting, same stored markdown. One behavior does improve: both composers skip rewriting their DOM when the rendered HTML is unchanged, and that guard now holds for four inputs where it did not, three of which were already broken on `main`.

## What this does

`markdownToHtml` builds an HTML string by hand and both composers assign it to `innerHTML`. Nothing checked the finished string, so safety rested on the whole-input escape pass, the code-language allow-list and the URL scheme gate all staying correct together.

This adds one boundary at the end of the transform, after every token restore:

- `sanitize-html` with a per-tag allow-list, derived from the attributes `htmlToMarkdown` reads back, so a chip attribute cannot be dropped without a failing round-trip test.
- The sanitized markup is then re-serialized through a detached element, which makes the output browser-canonical. That covers void tags, attribute-value escaping and non-breaking spaces at once.

## The boundary is load-bearing

The ticket described this as hardening with no reachable hole. That turned out to be wrong, and the PR carries the case:

```
input:  @a:b[x](https://y.test/)
without the boundary the browser reads these attributes off the chip:
  data-mention-key, data-mention-slug, https:, y.test
```

A mention slug can swallow a restore placeholder, so link HTML is restored inside an attribute value where element-context escaping does not apply. A fuzz pass over the placeholder, channel-label, code-language and URL paths found no reachable `on*` handler and no `javascript:` href, so no such claim is made here.

Removing the boundary fails two tests; widening the `span` allow-list to `*` fails one.

## Deviation from the ticket

The ticket specified DOMPurify. This uses `sanitize-html`, which takes per-tag attribute allow-lists and is already pinned and already shipped to this app's client path. No dependency is added. The ticket's stated reason for rejecting `sanitizeMarkdown` was its policy, not its library.

## Verification

- `pnpm exec vitest run` in `apps/web`: 680 files, 5174 passed, 1 skipped
- `pnpm typecheck`: 19/19 tasks pass
- `pnpm check`: 3885 files, no fixes applied
- Six review passes; three found real defects in earlier commits of this branch, all fixed here

## Out of scope, filed separately

SOK-1037: the same input mangles the user's own text and loses the link, on `main` and on every revision back to the commit that created the composer. That is the mention regex, not the sanitizer, and it is untouched here.