### PR TITLE
fix(web): restore presence mark sizes with whole-pixel halos (SOK-1034)

### DIFF
--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -228,7 +228,7 @@ export function ChatParticipantHoverCard({
               </Avatar>
             )}
             <LiveMemberPresenceDot
-              className="absolute -right-0.5 -bottom-0.5"
+              className="absolute -right-0.5 -bottom-0.5 size-3"
               fallback={profile.presence}
               ground="popover"
               isCoworker={isAi}

--- a/apps/web/src/components/chat/direct-room-avatar-stack.tsx
+++ b/apps/web/src/components/chat/direct-room-avatar-stack.tsx
@@ -129,7 +129,7 @@ export function DirectRoomAvatarStack({
                 </AvatarFallback>
               </Avatar>
               <LiveMemberPresenceDot
-                className="-right-0.5 -bottom-0.5 absolute size-2.5 border-[1.5px]"
+                className="-right-0.5 -bottom-0.5 absolute size-2 border-0"
                 fallback={participant.presence}
                 ground="sidebar"
                 isCoworker={isAi}

--- a/apps/web/src/components/chat/presence-dot.tsx
+++ b/apps/web/src/components/chat/presence-dot.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
  * 15% lightness against `--background` at 4%. That gap is not new, and it is
  * why the sidebar chip already reached for `border-sidebar` by hand before
  * these grounds existed. Matching an accent too needs each row to hand its own
- * painted colour down as a custom property, which is more than a 12px mark is
+ * painted colour down as a custom property, which is more than a 10px mark is
  * worth.
  */
 const GROUND_CLASSES = {
@@ -73,7 +73,13 @@ export function PresenceDot({
         // the ring on the way past. It reaches well beyond the mark's edge by
         // design, so without the clip the ring thins wherever the bite crosses
         // it, and any fill other than the ground would show as a second circle.
-        "relative block size-3 overflow-hidden rounded-full border-2",
+        //
+        // 10px with a 1px halo leaves the 8px core the crescent and the hollow
+        // ring are drawn for, sized for the 24 to 32px avatars most surfaces
+        // use. Whole pixels only: a 1.5px halo blurs on 1x displays. The 20px
+        // sidebar row and the inline marks drop the halo (`size-2 border-0`)
+        // to keep that core; the 48px hover card raises the mark to `size-3`.
+        "relative block size-2.5 overflow-hidden rounded-full border",
         ring,
         presence === "online" && "bg-presence-online",
         presence === "afk" && "bg-presence-afk",
@@ -88,8 +94,8 @@ export function PresenceDot({
       ) : null}
       {/* The offline stroke is the mark itself, so its width is fixed rather
           than inherited from the ring above. Callers override that ring
-          (`border-[1.5px]`, `border-0`) to tune the halo against their ground;
-          inheriting here would erase the mark wherever the halo is `border-0`.
+          (`border-0`) to tune the halo against their ground; inheriting here
+          would erase the mark wherever the halo is `border-0`.
           The disc behind it is filled with the ground rather than left clear,
           so the hollow state reads as a ring and not as a hole showing the
           avatar underneath. */}


### PR DESCRIPTION
## Summary

Follow-up to #4372 (SOK-1034). That PR grew the chat availability marks and introduced a 1.5px halo that blurs on 1x displays. This brings the marks back to their pre-#4372 footprints and keeps every ring and stroke on whole pixels, while the three silhouettes (disc, crescent, hollow ring) stay legible.

## User-facing impact

| Surface | Before #4372 | #4372 | Now |
| --- | --- | --- | --- |
| Sidebar account chip, roster panel, room header (32px avatars) | 10px | 12px | 10px |
| DM sidebar rows (20px avatars) | 8px | 10px | 8px |
| Participant hover card (48px avatar) | 12px | 12px | 12px |
| Inline marks (account menu, You page) | 8px | 8px | 8px |

## Why these values

- The crescent and the hollow offline ring are drawn for an 8px core. A 2px halo at 10px leaves only 6px, and the offline ring collapses into a grey dot.
- Halo goes from 2px to 1px in `PresenceDot`, which keeps the 8px core at a 10px mark. 1.5px was rejected because it rounds unevenly on 1x displays.
- The offline stroke stays at 2px. A 1px stroke reads noticeably thinner than the filled discs next to it at 10px and 12px.
- The DM row uses `size-2 border-0`, the same classes the inline marks already use, so the halo is dropped instead of the core.
- The hover card sets `size-3` explicitly now that the default is smaller.

## Changes

- `apps/web/src/components/chat/presence-dot.tsx`: default `size-2.5 border`, offline stroke `border-2`, comments updated.
- `apps/web/src/components/chat/direct-room-avatar-stack.tsx`: `size-2 border-0`.
- `apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx`: `size-3`.

No `border-[1.5px]` remains in `apps/web`.

## Verification

- `pnpm check` and `pnpm typecheck` (husky precommit): green
- `vitest run` on `presence-dot`, `direct-room-avatar-stack`, `chat-participant-hover-card`, `sidebar-account-chip`, `room-roster-panel`: 5 files, 56 tests passed
- Shapes compared at 3x zoom in light and dark for each surface; the offline ring keeps a visible hole at every size

## Screenshots

Not attached yet. The comparison was done on a static mock of the three silhouettes, not on the running app. Screenshots from the app to follow before marking ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
