### PR TITLE
fix(chat): mark landed message with a rail instead of a ring

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-search-highlight.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-search-highlight.test.ts
@@ -23,8 +23,6 @@ describe("search jump highlight", () => {
       block: "center",
     });
     expect(article.dataset.searchLanded).toBe("true");
-    expect(article.className).toContain("ring-primary");
-    expect(article.className).toContain("bg-primary/");
   });
 
   it("quote jump still uses smooth scroll and does not paint search highlight", () => {

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -400,13 +400,13 @@ export function scrollToRoomMessageElement(
 }
 
 const ROOM_MESSAGE_HIGHLIGHT_MS = 2500;
-const ROOM_MESSAGE_HIGHLIGHT_CLASSES = [
-  "ring-2",
-  "ring-primary",
-  "bg-primary/20",
-] as const;
 
-/** Scroll into view and apply a short-lived highlight when the node exists. */
+/**
+ * Scroll into view and mark the row as landed for a moment when the node
+ * exists. The row styles the mark itself, off `data-search-landed`, so a
+ * React re-render inside that moment cannot wipe it, as it would a class
+ * added here.
+ */
 export function highlightRoomMessageElement(messageId: string): boolean {
   if (!scrollToRoomMessageElement(messageId, { behavior: "auto" })) {
     return false;
@@ -418,10 +418,8 @@ export function highlightRoomMessageElement(messageId: string): boolean {
     return false;
   }
   target.dataset.searchLanded = "true";
-  target.classList.add(...ROOM_MESSAGE_HIGHLIGHT_CLASSES);
   window.setTimeout(() => {
     delete target.dataset.searchLanded;
-    target.classList.remove(...ROOM_MESSAGE_HIGHLIGHT_CLASSES);
   }, ROOM_MESSAGE_HIGHLIGHT_MS);
   return true;
 }

--- a/apps/web/src/app/(app)/chat/components/room-message-list-skeleton.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-list-skeleton.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
  * Instant loading and progressive shell must share this exactly.
  */
 export const ROOM_MESSAGE_LIST_CONTENT_CLASSNAME =
-  "flex min-h-full min-w-0 w-full flex-col justify-end px-5 pt-6 pb-1";
+  "flex min-h-full min-w-0 w-full flex-col justify-end px-5 pt-6 pb-0";
 
 interface MessageSkeletonRow {
   /** Author name bone width. */

--- a/apps/web/src/app/(app)/chat/components/room-message-list-skeleton.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-list-skeleton.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
  * Instant loading and progressive shell must share this exactly.
  */
 export const ROOM_MESSAGE_LIST_CONTENT_CLASSNAME =
-  "flex min-h-full min-w-0 w-full flex-col justify-end px-5 pt-6 pb-0";
+  "flex min-h-full min-w-0 w-full flex-col justify-end px-5 pt-6 pb-1";
 
 interface MessageSkeletonRow {
   /** Author name bone width. */

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -2211,7 +2211,10 @@ export function ChatMessageRow({
       data-message-id={message.id}
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
-        "group relative -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 data-[search-landed=true]:bg-primary/10 data-[search-landed=true]:ring-1 data-[search-landed=true]:ring-primary/50",
+        // Landed mark: a left rail plus a tint fading rightwards, drawn by a
+        // pseudo-element under the content (`isolate` scopes its -z-10 to the
+        // row). Nothing paints outside the row, so the scroller cannot clip it.
+        "group relative isolate -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-md before:border-l-[3px] before:border-primary before:bg-linear-to-r before:from-primary/12 before:to-transparent before:opacity-0 before:transition-opacity before:duration-700 motion-reduce:before:transition-none data-[search-landed=true]:before:opacity-100 data-[search-landed=true]:before:duration-[180ms]",
         reserveHoverActionGutter && "[@media(hover:hover)]:pr-48",
         showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
         isContinuation

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -2211,7 +2211,7 @@ export function ChatMessageRow({
       data-message-id={message.id}
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
-        "group relative -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 data-[search-landed=true]:bg-primary/20 data-[search-landed=true]:ring-2 data-[search-landed=true]:ring-primary",
+        "group relative -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 data-[search-landed=true]:bg-primary/10 data-[search-landed=true]:ring-1 data-[search-landed=true]:ring-primary/50",
         reserveHoverActionGutter && "[@media(hover:hover)]:pr-48",
         showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
         isContinuation

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -2214,7 +2214,7 @@ export function ChatMessageRow({
         // Landed mark: a left rail plus a tint fading rightwards, drawn by a
         // pseudo-element under the content (`isolate` scopes its -z-10 to the
         // row). Nothing paints outside the row, so the scroller cannot clip it.
-        "group relative isolate -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-md before:border-l-[3px] before:border-primary before:bg-linear-to-r before:from-primary/12 before:to-transparent before:opacity-0 before:transition-opacity before:duration-700 motion-reduce:before:transition-none data-[search-landed=true]:before:opacity-100 data-[search-landed=true]:before:duration-[180ms]",
+        "group relative isolate -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-md before:border-l-[3px] before:border-primary before:bg-linear-to-r before:from-primary/12 before:to-transparent before:opacity-0 before:transition-opacity before:duration-700 before:ease-out motion-reduce:before:transition-none data-[search-landed=true]:before:opacity-100 data-[search-landed=true]:before:duration-[180ms]",
         reserveHoverActionGutter && "[@media(hover:hover)]:pr-48",
         showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
         isContinuation


### PR DESCRIPTION
## Summary

Clicking a notification for the newest message in a room highlighted it with the bottom edge of the ring cut off. The highlight was also heavier than it needs to be. This PR replaces the ring with a left rail and a soft tint that cannot clip.

**Cause of the clipping.** The message list content ends with `pb-0`, so the last row sits flush against the scroller's bottom edge. The old highlight ring was a box-shadow drawn outside the row, and shadows add no scroll extent, so `overflow-y-auto` clipped it. Only the last message was affected; rows in the middle of the list are centred and fully visible.

## Changes

- **Landed mark is a rail, not a ring.** A 3px primary rail on the left of the row with a 12% tint that fades out to the right. It fades in over 180ms, holds for 2.5s, and releases over 700ms with an ease-out curve. Respects `prefers-reduced-motion`.
- **Nothing paints outside the row.** The rail and tint live on a `before` pseudo-element drawn under the row's content. The row is `isolate`, so the pseudo-element's negative z-index stays inside the row and sits above the row's own hover background. The scroller cannot clip the mark, so no list padding change is needed.
- **One owner for the style.** `highlightRoomMessageElement` only toggles `data-search-landed`; the row styles itself off that attribute. The helper no longer adds highlight classes on top, which a React re-render inside the highlight window could wipe.
- Test asserts the landed mark rather than class names.

## Why a rail

A rail reads as a distinct element, so a reader who looks away during the hold still finds the message. It matches the left accent the quote card in the same row already uses. And it does not compete with `hover:bg-muted/45`, which a tint set on `background-color` would.

## User-facing impact

- Jumping to the newest message from a notification, search, or the pinned list shows the whole highlight.
- The highlight is lighter: a thin rail and a faint tint instead of a heavy solid outline. It fades in quickly and eases out instead of snapping.

## Verification

- `pnpm exec biome check` on changed files: clean.
- `pnpm --filter web test` on the chat highlight, notification jump, deep link, skeleton, and message row tests: pass.
- `pnpm typecheck` via the pre-commit hook: green.
- Throwaway browser harness with the real scroller, content, and row class strings, dark and light, Sokosumi primary tokens: rail and tint render fully inside the row on the last message, and the landed state reports a computed 180ms transition. The local stack had no Core or sign-in credentials, so this was not re-checked against a live room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
