### PR TITLE
chore(web): baseline preview for the color system before/after

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -5,6 +5,11 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Baseline preview only. This comment is the whole diff against main: the
+   preview deploy is path-filtered to apps/web, and an empty PR never starts
+   it. Every color below is main's, unchanged, so this deployment is the
+   "before" half of the color token stack's screenshot comparison. */
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);


### PR DESCRIPTION
## What

Empty PR. Carries no change against `main`.

## Why

The color token stack changes every semantic ramp, the focus ring, and ~25 components. A before/after screenshot comparison needs a rendered "before", and `main` has no preview deployment of its own. This PR gives one.

## Lifecycle

Throwaway. Close it once the before/after comparison is attached to the stack. Do not merge.

## Related

Baseline for the color token stack:
- `docs/color-token-rules`
- `fix/color-token-contrast`
- `refactor/color-token-adoption`
- `chore/remove-dead-color-tokens`
