### PR TITLE
fix(web): rework the chat jump highlight (SOK-1038)

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-search-highlight.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-search-highlight.test.ts
@@ -23,6 +23,48 @@ describe("search jump highlight", () => {
       block: "center",
     });
     expect(article.dataset.searchLanded).toBe("true");
+    // The mark is styled in globals.css from the attribute alone, so the
+    // helper must not also mutate the class list.
+    expect(article.className).toBe("");
+  });
+
+  it("drops the mark when the hold ends", () => {
+    vi.useFakeTimers();
+    const article = document.createElement("article");
+    article.setAttribute("data-message-id", "msg-3");
+    article.scrollIntoView = vi.fn();
+    document.body.append(article);
+
+    highlightRoomMessageElement("msg-3");
+    expect(article.dataset.searchLanded).toBe("true");
+
+    vi.advanceTimersByTime(2500);
+    expect(article.dataset.searchLanded).toBeUndefined();
+  });
+
+  it("keeps one mark when a second jump lands inside the hold", () => {
+    vi.useFakeTimers();
+    const first = document.createElement("article");
+    first.setAttribute("data-message-id", "msg-4");
+    first.scrollIntoView = vi.fn();
+    const second = document.createElement("article");
+    second.setAttribute("data-message-id", "msg-5");
+    second.scrollIntoView = vi.fn();
+    document.body.append(first, second);
+
+    highlightRoomMessageElement("msg-4");
+    vi.advanceTimersByTime(1000);
+    highlightRoomMessageElement("msg-5");
+
+    expect(first.dataset.searchLanded).toBeUndefined();
+    expect(second.dataset.searchLanded).toBe("true");
+
+    // The first jump's timer must not clear the second jump's mark early.
+    vi.advanceTimersByTime(1500);
+    expect(second.dataset.searchLanded).toBe("true");
+
+    vi.advanceTimersByTime(1000);
+    expect(second.dataset.searchLanded).toBeUndefined();
   });
 
   it("quote jump still uses smooth scroll and does not paint search highlight", () => {

--- a/apps/web/src/app/(app)/chat/components/membership-status-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/membership-status-row.tsx
@@ -22,7 +22,9 @@ export function MembershipStatusRow({ message }: { message: ChatRoomMessage }) {
       id={`message-${message.id}`}
       data-message-id={message.id}
       data-membership-status={membership.action}
-      className="flex items-center justify-center py-2"
+      // relative isolate: a jump can land here too, and the highlight in
+      // globals.css paints on ::before/::after at z-index -1.
+      className="relative isolate flex items-center justify-center py-2"
       role="status"
     >
       <p className="text-muted-foreground text-center text-xs">{text}</p>

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -399,11 +399,27 @@ export function scrollToRoomMessageElement(
   return true;
 }
 
+/** Keep in sync with --chat-jump-hold in globals.css. */
 const ROOM_MESSAGE_HIGHLIGHT_MS = 2500;
 
 /**
+ * One mark at a time. Two jumps inside the hold would otherwise leave the first
+ * row marked for good, and the second row's timer would clear it early.
+ */
+let activeHighlight: { element: HTMLElement; timer: number } | null = null;
+
+function clearActiveHighlight() {
+  if (activeHighlight == null) {
+    return;
+  }
+  window.clearTimeout(activeHighlight.timer);
+  delete activeHighlight.element.dataset.searchLanded;
+  activeHighlight = null;
+}
+
+/**
  * Scroll into view and mark the row as landed for a moment when the node
- * exists. The row styles the mark itself, off `data-search-landed`, so a
+ * exists. The mark is styled from `data-search-landed` in globals.css, so a
  * React re-render inside that moment cannot wipe it, as it would a class
  * added here.
  */
@@ -417,10 +433,12 @@ export function highlightRoomMessageElement(messageId: string): boolean {
   if (!target) {
     return false;
   }
+  clearActiveHighlight();
   target.dataset.searchLanded = "true";
-  window.setTimeout(() => {
-    delete target.dataset.searchLanded;
-  }, ROOM_MESSAGE_HIGHLIGHT_MS);
+  activeHighlight = {
+    element: target,
+    timer: window.setTimeout(clearActiveHighlight, ROOM_MESSAGE_HIGHLIGHT_MS),
+  };
   return true;
 }
 

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -2211,10 +2211,11 @@ export function ChatMessageRow({
       data-message-id={message.id}
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
-        // Landed mark: a left rail plus a tint fading rightwards, drawn by a
-        // pseudo-element under the content (`isolate` scopes its -z-10 to the
-        // row). Nothing paints outside the row, so the scroller cannot clip it.
-        "group relative isolate -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-md before:border-l-[3px] before:border-primary before:bg-linear-to-r before:from-primary/12 before:to-transparent before:opacity-0 before:transition-opacity before:duration-700 before:ease-out motion-reduce:before:transition-none data-[search-landed=true]:before:opacity-100 data-[search-landed=true]:before:duration-[180ms]",
+        // Landed mark: a left rail plus a wash, drawn on ::before/::after under
+        // the content (`isolate` scopes their z-index -1 to the row). Nothing
+        // paints outside the row, so the scroller cannot clip it. The styling
+        // itself lives in globals.css, keyed on data-search-landed.
+        "group relative isolate -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45",
         reserveHoverActionGutter && "[@media(hover:hover)]:pr-48",
         showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
         isContinuation

--- a/apps/web/src/app/(app)/chat/components/room-shell-layout.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-shell-layout.tsx
@@ -94,6 +94,8 @@ export function RoomShellLayout({
       <div ref={listScrollerRef} className={ROOM_SHELL_SCROLLER_CLASSNAME}>
         <div
           ref={listContentRef}
+          // Scopes the jump-highlight spotlight in globals.css to this list.
+          data-chat-message-list
           className={ROOM_MESSAGE_LIST_CONTENT_CLASSNAME}
           style={listContentStyle}
         >

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -252,6 +252,9 @@ export function ThreadPanel({
         <div ref={scrollerRef} className={CHAT_MESSAGE_LIST_SCROLLER_CLASS}>
           <div
             ref={contentRef}
+            // A jump can land in a thread too, so the spotlight in globals.css
+            // scopes to this list the same way it does the room transcript.
+            data-chat-message-list
             className="flex min-w-0 w-full flex-col justify-end px-4 pt-4 pb-0"
             style={
               contentMinHeight != null

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -906,3 +906,134 @@ body[data-agent-fullbleed="true"] main[data-app-main] [data-app-main-inner] {
     color: var(--foreground);
   }
 }
+
+/* Chat jump highlight — a search hit, notification deep link, or reply jump
+   landed on this message. Keep the hold in sync with ROOM_MESSAGE_HIGHLIGHT_MS
+   in apps/web/src/app/(app)/chat/components/room-helpers.ts. */
+[data-message-id][data-search-landed="true"] {
+  --chat-jump-hold: 2500ms;
+  /* Dark runs stronger: a light primary over a 4% ground lifts far less than
+     the same mix of a saturated primary over white. */
+  --chat-jump-wash-lead: 16%;
+  --chat-jump-wash-mid: 11%;
+  --chat-jump-wash-edge: 10%;
+}
+
+.dark [data-message-id][data-search-landed="true"] {
+  --chat-jump-wash-lead: 26%;
+  --chat-jump-wash-mid: 20%;
+  --chat-jump-wash-edge: 18%;
+}
+
+/* Wash: tint holds its strength all the way to the right edge so a wide row
+   stays marked instead of trailing off. Opens from the centre. */
+[data-message-id][data-search-landed="true"]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    to right,
+    color-mix(in oklch, var(--primary) var(--chat-jump-wash-lead), transparent)
+      0%,
+    color-mix(in oklch, var(--primary) var(--chat-jump-wash-mid), transparent)
+      45%,
+    color-mix(in oklch, var(--primary) var(--chat-jump-wash-edge), transparent)
+      100%
+  );
+  animation: chat-jump-wash var(--chat-jump-hold) ease-out forwards;
+}
+
+/* Rail: marks where the row starts. */
+[data-message-id][data-search-landed="true"]::after {
+  content: "";
+  position: absolute;
+  top: 0.1875rem;
+  bottom: 0.1875rem;
+  left: 0;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--primary);
+  pointer-events: none;
+  animation: chat-jump-rail var(--chat-jump-hold) ease-out forwards;
+}
+
+/* Spotlight: the rest of the transcript steps back while the hold lasts. It
+   runs on the same timeline as the mark, so the dim never outlives it. */
+[data-chat-message-list]:has([data-search-landed="true"])
+[data-message-id]:not([data-search-landed="true"]) {
+  animation: chat-jump-dim var(--chat-jump-hold, 2500ms) ease-out forwards;
+}
+
+@keyframes chat-jump-wash {
+  0% {
+    opacity: 0;
+    transform: scaleX(0.55);
+  }
+  10% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+  76% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scaleX(1);
+  }
+}
+
+@keyframes chat-jump-dim {
+  0% {
+    opacity: 1;
+  }
+  10% {
+    opacity: 0.75;
+  }
+  76% {
+    opacity: 0.75;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes chat-jump-rail {
+  0% {
+    opacity: 0;
+    transform: scaleY(0.15);
+  }
+  10% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  76% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scaleY(1);
+  }
+}
+
+/* Reduced motion: hold the mark steady, then drop it. No wipe, no fade, and
+   no spotlight — dimming the surrounding text would take it under the contrast
+   floor for the whole hold, which the rail and wash already do without. */
+@media (prefers-reduced-motion: reduce) {
+  [data-message-id][data-search-landed="true"]::before,
+  [data-message-id][data-search-landed="true"]::after {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  [data-chat-message-list]:has([data-search-landed="true"])
+    [data-message-id]:not([data-search-landed="true"]) {
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Closes SOK-1038.

## What changed

A search hit, notification deep link, or reply jump used to mark the landed message with a full-strength 2px ring over a 20% fill, then drop both in a single frame. It read as a selection box, it fought the row hover fill, and the removal looked like a glitch.

The new mark ("Landing"):

- a 3px primary rail on the left edge, wiping open from the centre;
- a wash that starts at the rail and **holds** its strength to the right edge instead of trailing off, so a wide message stays marked;
- the rest of the transcript steps back by a quarter for the hold.

The dim runs on the same timeline as the mark, so it can never outlive it. Dark carries a stronger wash: a light primary over a 4% ground lifts far less than the same mix of a saturated primary over white.

## Single source of truth

The old treatment was declared twice, in the row's Tailwind classes and in a class list `highlightRoomMessageElement` added and removed by timer. It now lives only in `globals.css`, keyed on `data-search-landed`, and the helper just sets and clears that attribute.

## Relationship to #4376

#4376 landed a rail plus a tint fading to transparent while this branch was open. This supersedes that treatment: the rail stays, the tint becomes a wash that holds 10% to the right edge so a wide message stays marked, and the styling moves from the row's Tailwind classes to `globals.css`. Its clipping fix is preserved — the mark still paints inside the row on `::before`/`::after` under `isolate`, so the scroller cannot clip it. Its rationale for attribute-driven styling (a React re-render inside the hold cannot wipe an attribute the way it wipes an added class) is kept in the helper's doc comment.

The defects fixed below (overlapping jumps, thread panel, membership rows) are not addressed by #4376.

## Also fixed

- **Overlapping jumps.** The hold timer was never cancelled, so a second jump inside the first left two rows marked and cleared the new one early. The helper now cancels the running hold. Covered by a test that fails without the fix.
- **Threads.** A jump can land in the thread panel, so its list carries the same `data-chat-message-list` hook and gets the same treatment.
- **Membership rows.** They carry `data-message-id` too, so a jump can land on one. They had no positioning context, which would have let the rail and wash escape to an ancestor.

## Accessibility

`prefers-reduced-motion` holds the mark steady and cuts it, with no wipe and no dim. Dimming the surrounding messages would take their text under the contrast floor for the full 2.5s, and the rail and wash carry the signal without it.

## Verification

- `pnpm --filter web test 'src/app/(app)/chat'` — 109 files, 917 tests passed
- `pnpm check` — clean
- `pnpm typecheck` — 19 tasks successful

**Not verified:** I have not seen this in a running transcript. `verify-sokosumi doctor` reports `verify_credentials_email=unset`, `verify_credentials_password=unset` and `fixture_auth=skip`, so there is no account to sign in with on that machine. Screenshots in light and dark still need to be attached before this leaves draft.

Two variant-lab treatments (rail + wash) and a spotlight were combined here after review of eighteen options.
