### PR TITLE
fix(web): hide internal statuses from manual task status select

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
@@ -5,7 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskForm } from "@/app/tasks/components/task-form";
 import { createTask, updateTask } from "@/lib/actions/task/action";
 import { TaskStatus } from "@/lib/clients/generated/core";
-import { TASK_STATUS_DISPLAY_ORDER } from "@/lib/utils/task-status-order";
+import {
+  TASK_STATUS_DISPLAY_ORDER,
+  TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT,
+} from "@/lib/utils/task-status-order";
 import { mockCoworkerOption } from "@/test-fixtures/coworker";
 
 const {
@@ -1186,6 +1189,51 @@ describe("TaskForm", () => {
       "aria-disabled",
       "true",
     );
+  });
+
+  it("hides internal statuses from the edit status dropdown", async () => {
+    const user = userEvent.setup();
+    const hiddenManualStatusLabels: Partial<Record<TaskStatus, string>> = {
+      [TaskStatus.GRANT_PENDING]: "Grant pending",
+      [TaskStatus.AUTHENTICATION_REQUIRED]: "Authentication required",
+      [TaskStatus.OUT_OF_CREDITS]: "Paused: credits needed",
+      [TaskStatus.CREDITS_TOPPED_UP]: "Credits topped up",
+      [TaskStatus.FAILED]: "Failed",
+    };
+
+    render(
+      <TaskForm
+        variant="modal"
+        mode="edit"
+        showCancel={false}
+        labels={{
+          ...baseLabels,
+          statusLabels: {
+            ...baseLabels.statusLabels,
+            ...hiddenManualStatusLabels,
+          },
+        }}
+        coworkerOptions={coworkerOptions}
+        taskId="task-1"
+        initialValues={{
+          name: "Task name",
+          description: "Initial description",
+          assigneeId: "coworker-1",
+          status: TaskStatus.DRAFT,
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Status" }));
+
+    for (const status of TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT) {
+      const label = hiddenManualStatusLabels[status];
+      if (!label) continue;
+      expect(
+        screen.queryByRole("option", { name: label }),
+      ).not.toBeInTheDocument();
+    }
   });
 
   it("saves the status selected in the edit dropdown", async () => {

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -74,7 +74,7 @@ import {
   removeTaskAttachmentLinks,
 } from "@/lib/utils/task-attachments";
 import { metadataToSelection } from "@/lib/utils/task-schedule";
-import { TASK_STATUS_DISPLAY_ORDER } from "@/lib/utils/task-status-order";
+import { getManualTaskStatusSelectOptions } from "@/lib/utils/task-status-order";
 import { MarkdownEditor, type MarkdownEditorHandle } from "./markdown-editor";
 import {
   getDefaultTaskContextSelection,
@@ -660,7 +660,9 @@ export function TaskForm({
     showTaskStep && !isSaveDisabled && !isCreateProjectModalOpen;
   const taskStepTitle = labels.taskStepTitle ?? "What should {name} do?";
   const statusOptions =
-    mode === "create" ? CREATE_STATUS_OPTIONS : TASK_STATUS_DISPLAY_ORDER;
+    mode === "create"
+      ? CREATE_STATUS_OPTIONS
+      : getManualTaskStatusSelectOptions(status);
 
   const handleSave = useCallback(async () => {
     if (isSaveDisabled || (useWizard && step === 1)) return;

--- a/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
@@ -17,7 +17,7 @@ import {
 import { setTaskStatusFromDrag } from "@/lib/actions/task/action";
 import { TaskStatus } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
-import { TASK_STATUS_DISPLAY_ORDER } from "@/lib/utils/task-status-order";
+import { getManualTaskStatusSelectOptions } from "@/lib/utils/task-status-order";
 
 import { TaskReopenToReadyDialog } from "./task-reopen-to-ready-dialog";
 import { getTaskStatusPillTone } from "./task-status-badge";
@@ -157,7 +157,7 @@ export function TaskMetadataStatusField({
           </SelectValue>
         </SelectTrigger>
         <SelectContent align="end">
-          {TASK_STATUS_DISPLAY_ORDER.map((option) => (
+          {getManualTaskStatusSelectOptions(displayStatus).map((option) => (
             <SelectItem
               key={option}
               value={option}

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
@@ -6,7 +6,10 @@ import { TaskMetadata } from "@/app/tasks/components/task-metadata";
 import { defaultOrbSeed } from "@/lib/aurora-orb";
 import { TaskStatus } from "@/lib/clients/generated/core";
 import type { Task } from "@/lib/clients/generated/core/types.gen";
-import { TASK_STATUS_DISPLAY_ORDER } from "@/lib/utils/task-status-order";
+import {
+  TASK_STATUS_DISPLAY_ORDER,
+  TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT,
+} from "@/lib/utils/task-status-order";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -345,6 +348,76 @@ describe("TaskMetadata", () => {
       "text-xs",
     );
     expect(pill?.textContent).toContain("Running");
+  });
+
+  const hiddenManualStatusLabels: Partial<Record<TaskStatus, string>> = {
+    [TaskStatus.GRANT_PENDING]: "Grant pending",
+    [TaskStatus.AUTHENTICATION_REQUIRED]: "Authentication required",
+    [TaskStatus.OUT_OF_CREDITS]: "Paused: credits needed",
+    [TaskStatus.CREDITS_TOPPED_UP]: "Credits topped up",
+    [TaskStatus.FAILED]: "Failed",
+  };
+
+  function buildStatusLabelsForManualSelectTest(): Record<TaskStatus, string> {
+    return Object.fromEntries(
+      TASK_STATUS_DISPLAY_ORDER.map((status) => [
+        status,
+        hiddenManualStatusLabels[status] ??
+          (status === TaskStatus.DRAFT
+            ? "Draft"
+            : status === TaskStatus.QUEUED
+              ? "Queued"
+              : status === TaskStatus.READY
+                ? "Ready"
+                : status === TaskStatus.RUNNING
+                  ? "Running"
+                  : status),
+      ]),
+    ) as Record<TaskStatus, string>;
+  }
+
+  it("hides internal statuses from the manual status dropdown", async () => {
+    const user = userEvent.setup();
+    const statusLabels = buildStatusLabelsForManualSelectTest();
+
+    renderTaskMetadata({
+      task: createTask({ status: TaskStatus.DRAFT }),
+      editable: true,
+      labels: { ...baseLabels, statusLabels },
+      statusFieldLabels: { ...baseStatusFieldLabels, statusLabels },
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Draft" }));
+
+    for (const status of TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT) {
+      const label = hiddenManualStatusLabels[status];
+      if (!label) continue;
+      expect(
+        screen.queryByRole("option", { name: label }),
+      ).not.toBeInTheDocument();
+    }
+  });
+
+  it("keeps the current hidden status in the dropdown when already set", async () => {
+    const user = userEvent.setup();
+    const statusLabels = buildStatusLabelsForManualSelectTest();
+
+    renderTaskMetadata({
+      task: createTask({ status: TaskStatus.FAILED }),
+      editable: true,
+      labels: { ...baseLabels, statusLabels },
+      statusFieldLabels: { ...baseStatusFieldLabels, statusLabels },
+    });
+
+    expect(
+      screen.getByRole("combobox", { name: "Failed" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: "Failed" }));
+    expect(screen.getByRole("option", { name: "Failed" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Grant pending" }),
+    ).not.toBeInTheDocument();
   });
 
   it("disables Queued without a schedule and shows no helper copy (SOK-1033)", async () => {

--- a/apps/web/src/lib/utils/task-status-order.test.ts
+++ b/apps/web/src/lib/utils/task-status-order.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { TaskStatus } from "@/lib/clients/generated/core";
 
-import { TASK_STATUS_DISPLAY_ORDER } from "@/lib/utils/task-status-order";
+import {
+  getManualTaskStatusSelectOptions,
+  TASK_STATUS_DISPLAY_ORDER,
+  TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT,
+} from "@/lib/utils/task-status-order";
 
 describe("TASK_STATUS_DISPLAY_ORDER", () => {
   it("includes every TaskStatus exactly once", () => {
@@ -14,5 +18,32 @@ describe("TASK_STATUS_DISPLAY_ORDER", () => {
     for (const status of allStatuses) {
       expect(orderedStatuses).toContain(status);
     }
+  });
+});
+
+describe("getManualTaskStatusSelectOptions", () => {
+  it("omits internal statuses from manual select options", () => {
+    const options = getManualTaskStatusSelectOptions();
+
+    for (const status of TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT) {
+      expect(options).not.toContain(status);
+    }
+  });
+
+  it("preserves TASK_STATUS_DISPLAY_ORDER for visible options", () => {
+    const hidden = new Set<TaskStatus>(TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT);
+    const expected = TASK_STATUS_DISPLAY_ORDER.filter(
+      (status) => !hidden.has(status),
+    );
+
+    expect(getManualTaskStatusSelectOptions()).toEqual(expected);
+  });
+
+  it("includes the current status when it is hidden", () => {
+    const options = getManualTaskStatusSelectOptions(TaskStatus.FAILED);
+
+    expect(options).toContain(TaskStatus.FAILED);
+    expect(options).not.toContain(TaskStatus.GRANT_PENDING);
+    expect(options).not.toContain(TaskStatus.OUT_OF_CREDITS);
   });
 });

--- a/apps/web/src/lib/utils/task-status-order.ts
+++ b/apps/web/src/lib/utils/task-status-order.ts
@@ -22,3 +22,25 @@ export const TASK_STATUS_DISPLAY_ORDER = [
 ] as const satisfies readonly TaskStatusType[];
 
 export type TaskStatusLabelKey = (typeof TASK_STATUS_DISPLAY_ORDER)[number];
+
+/** Not user-pickable in manual status selects; badges/filters/kanban keep them. */
+export const TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT = [
+  TaskStatus.GRANT_PENDING,
+  TaskStatus.AUTHENTICATION_REQUIRED,
+  TaskStatus.OUT_OF_CREDITS,
+  TaskStatus.CREDITS_TOPPED_UP,
+  TaskStatus.FAILED,
+] as const satisfies readonly TaskStatusType[];
+
+const HIDDEN_FROM_MANUAL_SELECT = new Set<TaskStatusType>(
+  TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT,
+);
+
+export function getManualTaskStatusSelectOptions(
+  currentStatus?: TaskStatusType,
+): readonly TaskStatusType[] {
+  return TASK_STATUS_DISPLAY_ORDER.filter(
+    (status) =>
+      !HIDDEN_FROM_MANUAL_SELECT.has(status) || status === currentStatus,
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Some task statuses are set by agents or internal flows, not by people picking them in the UI. Offering them in the manual status dropdown invites wrong transitions. This change removes grant pending, authentication required, paused credits, credits topped up, and failed from those Selects only.

Badges, filters, kanban columns, and history keep the full status set so existing work still reads correctly.

## Scope

- `TASK_STATUSES_HIDDEN_FROM_MANUAL_SELECT` and `getManualTaskStatusSelectOptions` in `apps/web/src/lib/utils/task-status-order.ts`
- Manual Selects in `task-metadata-status-field.tsx` and edit-mode `task-form.tsx`
- Unit and component tests for the helper and both dropdowns

Out of scope: Core transition rules, filter chips, status badges, create-form Draft/Queued/Ready list.

## Tradeoffs

A dedicated hide list was chosen over `AGENT_ONLY_TASK_STATUSES`, which also covers Queued, input required, and approval required. Those stay pickable.

`TASK_STATUS_DISPLAY_ORDER` stays complete so label builders and completeness tests keep one enum map.

## Blast Radius

Task owners who open the metadata or edit status Select no longer see five internal destinations. Agents and Core events can still set those statuses. If a task already sits on a hidden status, that value remains in the Select so Radix can show the current pill.

## Verification

- `pnpm --filter web test` on `task-status-order.test.ts`, `task-metadata.test.tsx`, and `task-form.test.tsx` — 78 passed (asserts the five labels are absent as options; FAILED remains when it is the current metadata status)
- Live browser walkthrough blocked in this cloud VM: `VERIFY_SOKOSUMI_*` unset, Neon agent DB secrets absent, auth fixtures refuse to seed without a cloud-agent branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d10f60a5-d9cf-4737-8617-84eaf4aa2495?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d10f60a5-d9cf-4737-8617-84eaf4aa2495&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

