### PR TITLE
chore(web): delete unused chat actions, task auto-switch, and orphan agent UI leftovers

### DIFF
--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -495,18 +495,6 @@ export async function listDiscoverableChannelsAction(options?: {
   }
 }
 
-/** Pending room invitations for the signed-in invitee (External sidebar). */
-export async function listPendingChatRoomInvitationsAction(): Promise<
-  RoomActionResult<ChatRoomInvitation[]>
-> {
-  try {
-    const invitations = await chatRoomService.listPendingInvitations();
-    return roomOk(invitations);
-  } catch (error) {
-    return roomCatch(error, "Could not load invitations.");
-  }
-}
-
 export async function acceptChatRoomInvitationAction(
   invitationId: string,
 ): Promise<RoomActionResult<ChatRoomInvitation>> {
@@ -838,17 +826,6 @@ export async function listThreadsAction(
     return roomOk(page);
   } catch (error) {
     return roomCatch(error, "Could not load threads.");
-  }
-}
-
-export async function countUnreadThreadsAction(
-  roomId: string,
-): Promise<RoomActionResult<number>> {
-  try {
-    const count = await chatRoomService.countUnreadThreads(roomId);
-    return roomOk(count);
-  } catch (error) {
-    return roomCatch(error, "Could not load unread thread count.");
   }
 }
 

--- a/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
@@ -7,7 +7,6 @@ import {
 import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
 import { Suspense } from "react";
-import { AutoContextSwitch } from "@/app/components/auto-context-switch";
 import { TaskActivitySection } from "@/app/tasks/components/task-activity";
 import { TaskDescription } from "@/app/tasks/components/task-description";
 import { TaskDetailActions } from "@/app/tasks/components/task-detail-actions";
@@ -51,7 +50,6 @@ import { hasAssignedOrganizationSeat } from "@/lib/services/organization-assigne
 import { projectService } from "@/lib/services/project.service";
 import { sokoBotService } from "@/lib/services/soko-bot.service";
 import { userService } from "@/lib/services/user.service";
-import { resolveAccountName } from "@/lib/utils/account-name";
 import { formatShortDateTime } from "@/lib/utils/datetime";
 import {
   buildVendorGrantReviewHref,
@@ -79,14 +77,6 @@ interface TaskDetailViewProps {
    * able to edit, comment, or mutate the task.
    */
   forceReadOnly?: boolean;
-  /**
-   * Renders {@link AutoContextSwitch} so the active workspace follows the task.
-   * Only safe when the viewer is guaranteed to be a member of the task's
-   * workspace (the user-facing route). The admin route leaves this off — admins
-   * read tasks in workspaces they are not part of, where switching would fail or
-   * be wrong.
-   */
-  enableAutoSwitch?: boolean;
 }
 
 /**
@@ -98,7 +88,6 @@ interface TaskDetailViewProps {
 export async function TaskDetailView({
   task,
   forceReadOnly = false,
-  enableAutoSwitch = false,
 }: TaskDetailViewProps) {
   const taskId = task.id;
   const coworkersPromise = coworkerService.listCoworkers().catch(() => []);
@@ -133,16 +122,6 @@ export async function TaskDetailView({
             sessionPromise={sessionPromise}
           />
         </Suspense>
-        {enableAutoSwitch ? (
-          <Suspense fallback={null}>
-            <TaskDetailAutoSwitch
-              targetOrganizationId={task.workspace.organizationId ?? null}
-              membersPromise={membersPromise}
-              sessionPromise={sessionPromise}
-            />
-          </Suspense>
-        ) : null}
-
         <div className={TASK_DETAIL_GRID_CLASS}>
           <div className={TASK_DETAIL_MAIN_CLASS}>
             <TaskDetailHeader
@@ -275,39 +254,6 @@ async function TaskDetailRealtimeListener({
 
   return (
     <TaskStatusRealtimeListener userId={session.user.id} taskId={taskId} />
-  );
-}
-
-async function TaskDetailAutoSwitch({
-  targetOrganizationId,
-  membersPromise,
-  sessionPromise,
-}: {
-  targetOrganizationId: string | null;
-  membersPromise: Promise<MembersResult>;
-  sessionPromise: Promise<SessionResult>;
-}) {
-  const [members, session, t, tOrganizationSwitcher] = await Promise.all([
-    membersPromise,
-    sessionPromise,
-    getTranslations("App.Tasks.Detail"),
-    getTranslations("Components.OrganizationSwitcher"),
-  ]);
-  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
-  const targetAccountName = resolveAccountName(
-    targetOrganizationId,
-    members,
-    tOrganizationSwitcher("personalAccount"),
-  );
-
-  return (
-    <AutoContextSwitch
-      activeOrganizationId={activeOrganizationId}
-      targetOrganizationId={targetOrganizationId}
-      successMessage={t("switchedWorkspace", {
-        account: targetAccountName,
-      })}
-    />
   );
 }
 

--- a/apps/web/src/components/agents/agent-badge-cloud.tsx
+++ b/apps/web/src/components/agents/agent-badge-cloud.tsx
@@ -1,6 +1,5 @@
 import { TagIcon } from "@/components/agents/tag-icon";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
 
 interface AgentBadgeCloudProps {
   tags: string[];
@@ -27,14 +26,4 @@ function AgentBadgeCloud({ tags }: AgentBadgeCloudProps) {
   );
 }
 
-function AgentBadgeCloudSkeleton() {
-  return (
-    <div className="flex flex-wrap gap-2">
-      {[1, 2, 3].map((_, index) => (
-        <Skeleton key={index} className="h-[22px] w-6 rounded-lg" />
-      ))}
-    </div>
-  );
-}
-
-export { AgentBadgeCloud, AgentBadgeCloudSkeleton };
+export { AgentBadgeCloud };

--- a/apps/web/src/components/agents/agent-detail/examples/index.ts
+++ b/apps/web/src/components/agents/agent-detail/examples/index.ts
@@ -1,1 +1,0 @@
-export * from "./examples";

--- a/apps/web/src/components/chat/__tests__/organization-chat-list-harness.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-harness.tsx
@@ -48,9 +48,6 @@ vi.mock("@/app/chat/actions", () => ({
   ) => acceptInvitationMock(...args),
   declineChatRoomInvitationAction: vi.fn(),
   deleteRoomAction: vi.fn(),
-  listPendingChatRoomInvitationsAction: (
-    ...args: Parameters<typeof listPendingMock>
-  ) => listPendingMock(...args),
   restoreRoomAction: vi.fn(),
 }));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly leftover cleanup in web. No user-facing behavior change.

## What changed

- Delete unused `listPendingChatRoomInvitationsAction` and `countUnreadThreadsAction` from chat server actions. Drop the matching action mock in the organization chat list harness; keep `listPendingMock` on the fetch mock.
- Remove unused `enableAutoSwitch` / `TaskDetailAutoSwitch` from `TaskDetailView`. Workspace switching stays on job panes and task edit via `AutoContextSwitch`.
- Delete orphan `agent-detail/examples/index.ts` barrel (callers already import `./examples/examples`).
- Delete unused `AgentBadgeCloudSkeleton`.

## Out of scope

- Mention textarea utils, coupon redirect, and shipped #4328 / #4329 / #4337 / #4341
- Task edit / status UI (#4308) and other open product PRs
- Whether `countUnreadThreads` in `lib/` is orphaned (follow-on)
- Third-party skills under `.agents/skills`

## Verification

- Grep of each deleted symbol (`listPendingChatRoomInvitationsAction`, `countUnreadThreadsAction`, `enableAutoSwitch`, `TaskDetailAutoSwitch`, `AgentBadgeCloudSkeleton`) is zero matches
- `examples/index.ts` gone; remaining imports are `./examples/examples`
- `pnpm --filter web test` on organization chat list, chat actions, thread list, task detail/edit pages, job panes, and `AutoContextSwitch`: 13 files, 43 tests, all passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14b1b17d-93ad-46e4-b0b8-e7c8c032cf92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14b1b17d-93ad-46e4-b0b8-e7c8c032cf92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

