### PR TITLE
chore(web): delete unused Masumi job-status schema copy from web

### DIFF
--- a/apps/web/src/lib/schemas/job.test.ts
+++ b/apps/web/src/lib/schemas/job.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  jobStatusResponseSchema,
-  provideJobInputSchema,
-} from "@/lib/schemas/job";
+import { provideJobInputSchema } from "@/lib/schemas/job";
 
 describe("provideJobInputSchema", () => {
   it("accepts eventId for provide input payload", () => {
@@ -27,17 +24,5 @@ describe("provideJobInputSchema", () => {
     });
 
     expect(result.success).toBe(false);
-  });
-});
-
-describe("jobStatusResponseSchema", () => {
-  it("parses status payload without id", () => {
-    const parsed = jobStatusResponseSchema.parse({
-      status: "running",
-      result: null,
-      input_schema: null,
-    });
-
-    expect(parsed.status).toBe("running");
   });
 });

--- a/apps/web/src/lib/schemas/job.ts
+++ b/apps/web/src/lib/schemas/job.ts
@@ -3,7 +3,6 @@ import {
   type InputSchemaSchemaType,
   inputGroupsSchema,
   inputSchema,
-  inputSchemaResponseSchema,
 } from "@sokosumi/masumi/schemas";
 import * as z from "zod";
 
@@ -20,57 +19,6 @@ export const jobDetailsNameFormSchema = (
 
 export type JobDetailsNameFormSchemaType = z.infer<
   ReturnType<typeof jobDetailsNameFormSchema>
->;
-
-// Helper function to create a conditional required field validation
-function requireFieldWhenStatus<T extends Record<string, unknown>>(
-  status: string,
-  fieldName: string,
-  fieldLabel?: string,
-) {
-  return (data: T, ctx: z.RefinementCtx) => {
-    if (data.status === status) {
-      const value = data[fieldName];
-      const isEmpty =
-        value == null ||
-        (Array.isArray(value) && value.length === 0) ||
-        (typeof value === "string" && value.length === 0);
-
-      if (isEmpty) {
-        ctx.addIssue({
-          code: "custom",
-          message: `${fieldLabel ?? fieldName} is required when status is ${status}`,
-          path: [fieldName],
-        });
-      }
-    }
-  };
-}
-
-// Agent job status values - single source of truth
-export const JOB_STATUS_VALUES = [
-  "awaiting_payment",
-  "awaiting_input",
-  "running",
-  "completed",
-  "failed",
-] as const;
-
-export type JobStatusValue = (typeof JOB_STATUS_VALUES)[number];
-
-export const jobStatusResponseSchema = z
-  .object({
-    status: z.enum(JOB_STATUS_VALUES),
-    input_schema: inputSchemaResponseSchema.nullish(),
-    result: z.string().nullish(),
-  })
-  .superRefine((data, ctx) => {
-    requireFieldWhenStatus("awaiting_input", "input_schema")(data, ctx);
-    requireFieldWhenStatus("completed", "result")(data, ctx);
-  });
-
-export type JobStatusResponseSchemaType = z.infer<
-  typeof jobStatusResponseSchema
 >;
 
 export const provideJobInputSchema = z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the unused Masumi job-status schema copy from the web app. Canonical schema stays in `@sokosumi/masumi`. Web had no remaining callers.

Deleted from `apps/web/src/lib/schemas/job.ts`:
- `JOB_STATUS_VALUES`
- `JobStatusValue`
- `requireFieldWhenStatus`
- `jobStatusResponseSchema`
- `JobStatusResponseSchemaType`

Kept: `provideJobInputSchema`, `flattenInputs`, `isGroupedSchema`, and `jobDetailsNameFormSchema`.

Dropped only the `describe("jobStatusResponseSchema")` block from `job.test.ts`. Did not import the Masumi status schema into web.

## Verification

- `pnpm check` and `pnpm typecheck` (pre-commit)
- `pnpm --filter web test src/lib/schemas/job.test.ts` (after PR open)

## Linear

Nightly cleanup area: web-dead-job-status-schema.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb38ab02-97a1-4569-b9f1-b0e2993d7ce8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb38ab02-97a1-4569-b9f1-b0e2993d7ce8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

