### PR TITLE
chore(packages): drop unused database deps and unused tsx devDeps

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -67,13 +67,11 @@
   "dependencies": {
     "@prisma/adapter-pg": "7.10.0",
     "@prisma/client": "7.10.0",
-    "@sokosumi/masumi": "workspace:*",
     "@sokosumi/utils": "workspace:*",
     "neverthrow": "8.2.0",
     "pg": "8.23.0",
     "pg-pool": "3.14.0",
-    "uuid": "14.0.2",
-    "zod": "4.6.2"
+    "uuid": "14.0.2"
   },
   "devDependencies": {
     "@types/node": "24.13.4",

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@types/node": "24.13.4",
     "@typescript/typescript6": "6.0.2",
-    "tsx": "4.23.13",
     "typescript": "7.0.2",
     "vitest": "5.0.0"
   }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,7 +41,6 @@
   "devDependencies": {
     "@types/node": "24.13.4",
     "@typescript/typescript6": "6.0.2",
-    "tsx": "4.23.13",
     "typescript": "7.0.2",
     "vitest": "5.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,9 +665,6 @@ importers:
       '@prisma/client':
         specifier: 7.10.0
         version: 7.10.0(prisma@7.10.0(@types/react-dom@19.2.5(@types/react@19.3.0))(@types/react@19.3.0)(react-dom@19.3.0(react@19.3.0))(react@19.3.0)(typescript@7.0.2))(typescript@7.0.2)
-      '@sokosumi/masumi':
-        specifier: workspace:*
-        version: link:../masumi
       '@sokosumi/utils':
         specifier: workspace:*
         version: link:../utils
@@ -683,9 +680,6 @@ importers:
       uuid:
         specifier: 14.0.2
         version: 14.0.2
-      zod:
-        specifier: 4.6.2
-        version: 4.6.2
     devDependencies:
       '@types/node':
         specifier: 24.13.4
@@ -792,9 +786,6 @@ importers:
       '@typescript/typescript6':
         specifier: 6.0.2
         version: 6.0.2
-      tsx:
-        specifier: 4.23.13
-        version: 4.23.13
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -839,9 +830,6 @@ importers:
       '@typescript/typescript6':
         specifier: 6.0.2
         version: 6.0.2
-      tsx:
-        specifier: 4.23.13
-        version: 4.23.13
       typescript:
         specifier: 7.0.2
         version: 7.0.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Drop unused package dependencies that have zero importers in the relevant package source, then refresh the lockfile importer entries.

Removed:

- `@sokosumi/database`: `@sokosumi/masumi` and `zod`
- `@sokosumi/utils`: unused `tsx` from `devDependencies`
- `@sokosumi/net`: unused `tsx` from `devDependencies`

Kept:

- `pg-pool`, `neverthrow`, and `uuid` on `@sokosumi/database`
- `tsx` on `@sokosumi/database` for data-migration scripts

## Importer check

Verified zero importers before deleting:

- `@sokosumi/masumi` and `zod` do not appear in `packages/database` source, scripts, or Prisma (the only `masumi` hit is seed data in a migration SQL file, not a package import)
- `tsx` is not used by `packages/utils` or `packages/net` scripts; the `"tsx"` string in utils is a file-extension denylist entry, not the runner
- Did not retouch app-level deps

## Verification

- `pnpm install --frozen-lockfile` succeeds
- `pnpm check` and `pnpm typecheck` pass (precommit / turbo)

Linear: none (scoped nightly chore).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76d43b32-a5b0-4b0c-9bcf-ab71230634f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76d43b32-a5b0-4b0c-9bcf-ab71230634f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

