### PR TITLE
chore(utils): delete unused buildVendorLogoContentHashPathname

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -381,7 +381,6 @@ export {
   buildUserUploadPrefix,
 } from "./user-upload-path.js";
 export {
-  buildVendorLogoContentHashPathname,
   buildVendorLogoPathname,
   isOwnedVendorLogoUrl,
 } from "./vendor-logo-path.js";

--- a/packages/utils/src/vendor-logo-path.test.ts
+++ b/packages/utils/src/vendor-logo-path.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  buildVendorLogoContentHashPathname,
   buildVendorLogoPathname,
   buildVendorLogoPrefix,
   isOwnedVendorLogoUrl,
@@ -27,16 +26,6 @@ describe("buildVendorLogoPathname", () => {
   it("falls back when the filename is empty after sanitizing", () => {
     expect(buildVendorLogoPathname(VENDOR_ID, "@@@")).toBe(
       `vendors/${VENDOR_ID}/logos/file`,
-    );
-  });
-});
-
-describe("buildVendorLogoContentHashPathname", () => {
-  it("appends the sha256 hex under the vendor logos prefix", () => {
-    const hash =
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    expect(buildVendorLogoContentHashPathname(VENDOR_ID, hash)).toBe(
-      `vendors/${VENDOR_ID}/logos/${hash}`,
     );
   });
 });

--- a/packages/utils/src/vendor-logo-path.ts
+++ b/packages/utils/src/vendor-logo-path.ts
@@ -24,17 +24,6 @@ export function buildVendorLogoPathname(
 }
 
 /**
- * Content-hash pathname for server-side scrape puts (no random suffix).
- * Example: `vendors/{vendorId}/logos/{sha256Hex}`
- */
-export function buildVendorLogoContentHashPathname(
-  vendorId: string,
-  sha256Hex: string,
-): string {
-  return `${buildVendorLogoPrefix(vendorId)}${sha256Hex}`;
-}
-
-/**
  * True when `url` is a public Vercel Blob URL under this vendor's
  * logos prefix (`/vendors/{vendorId}/logos/…`). Requires HTTPS and a
  * Vercel public blob host so foreign hosts cannot spoof ownership.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delete unused `buildVendorLogoContentHashPathname` from `@sokosumi/utils` (same class as #4357). No callers.

Left unchanged: `buildVendorLogoPathname`, `isOwnedVendorLogoUrl`, `buildVendorLogoPrefix`.

## Verification

- `pnpm --filter @sokosumi/utils test src/vendor-logo-path.test.ts` — 5 remaining tests passed
- `pnpm check && pnpm typecheck` via precommit hook

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b474fce-aea2-41ba-9a48-853a66b32ef2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b474fce-aea2-41ba-9a48-853a66b32ef2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

