### PR TITLE
chore(utils): unexport leftover unused symbols from package index

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,13 +14,10 @@ export {
   betterAuthUserAdditionalFields,
 } from "./better-auth-client-schema.js";
 export {
-  type ResolveBetterAuthCookiePrefixParams,
   resolveBetterAuthCookieName,
   resolveBetterAuthCookiePrefix,
 } from "./better-auth-cookie-prefix.js";
 export {
-  type ResolveBetterAuthProductionUrlParams,
-  type ResolveBetterAuthPublicBaseUrlParams,
   resolveBetterAuthProductionUrl,
   resolveBetterAuthPublicBaseUrl,
 } from "./better-auth-public-url.js";
@@ -64,8 +61,6 @@ export {
   CHAT_ROOM_MESSAGES_MESSAGE_KEY,
 } from "./chat-notification-message-keys.js";
 export {
-  ABLY_CLIENT_INSTANCE_ID_PATTERN,
-  ABLY_PRESENCE_CLIENT_ID_SEPARATOR,
   aggregateChatPresenceByUserId,
   buildAblyPresenceClientId,
   type ChatPresenceMemberData,
@@ -97,7 +92,6 @@ export {
 export {
   buildRoomQuoteSnippetParts,
   type ChatRoomQuoteAttachment,
-  type ChatRoomQuoteSnippetParts,
 } from "./chat-room-quote-snippet.js";
 export {
   CHAT_ROOM_COLLECTIONS,
@@ -113,7 +107,6 @@ export {
   buildCoworkerImagePathname,
   COWORKER_IMAGE_ALLOWED_MIME_TYPES,
   COWORKER_IMAGE_MAX_SIZE_BYTES,
-  extensionForCoworkerImageMime,
   isCoworkerImageAllowedContentType,
   isOwnedCoworkerImageUrl,
 } from "./coworker-image-upload.js";
@@ -124,11 +117,8 @@ export {
   type CreditTopUpTier,
   getCreditTopUpLookupKeyByCredits,
   getCreditTopUpTotalMinorUnits,
-  HIGH_CREDIT_TOPUP_LOOKUP_KEY,
   isPositiveIntegerCredits,
-  MID_CREDIT_TOPUP_LOOKUP_KEY,
   STANDARD_CREDIT_TOPUP_TIERS,
-  type StandardCreditTopUpLookupKey,
   selectCreditTopUpTier,
   ZERO_MARGIN_CREDIT_TOPUP_LOOKUP_KEY,
 } from "./credit-topup-pricing.js";
@@ -145,10 +135,7 @@ export {
   buildProjectDesignMdPrefix,
   buildUserDesignMdPathname,
 } from "./design-md-path.js";
-export {
-  DESIGN_MD_BLOB_PATH_PREFIX,
-  isDesignMdBlobUrl,
-} from "./design-md-url.js";
+export { isDesignMdBlobUrl } from "./design-md-url.js";
 export {
   buildOrganizationDriveFilePathname,
   buildOrganizationDriveFilePathnameWithFolder,
@@ -161,8 +148,6 @@ export {
   buildUserDriveFolderMarkerPathname,
   buildUserDriveFolderPrefix,
   clampDriveFileName,
-  DRIVE_FILE_MAX_NAME_LENGTH,
-  DRIVE_FOLDER_MARKER_BASENAME,
   isDriveFolderMarker,
   isDriveFolderMarkerName,
   normalizeDriveFolderPath,
@@ -181,7 +166,6 @@ export {
 } from "./file-url.js";
 export { sniffImageMimeFromBytes } from "./image-mime.js";
 export {
-  IPFS_GATEWAY_PREFIX,
   normalizeOrganizationLogo,
   resolveIpfsOrHttpUrl,
   sanitizeOrganizationLogoForApi,
@@ -190,7 +174,6 @@ export { buildJobBlobPathname } from "./job-blob-path.js";
 export { linkifyBareDomainsInMarkdown } from "./linkify-bare-domains.js";
 export {
   type ChannelLinkIdentity,
-  type ChannelLinkMatch,
   type ChannelLinkTarget,
   channelLinkInsertText,
   collectChannelLinksInMarkdown,
@@ -210,7 +193,6 @@ export { MARKDOWN_FENCED_BLOCK_REGEX } from "./markdown-fenced-block.js";
 export {
   escapeMarkdownLinkUrl,
   findMarkdownLinks,
-  type MarkdownLinkMatch,
   replaceMarkdownLinks,
   unescapeMarkdownLinkUrl,
 } from "./markdown-links.js";
@@ -226,12 +208,10 @@ export {
 export {
   type MetadataRecord,
   serializeMetadataRecord,
-  stringifyMetadataRecord,
 } from "./metadata-record.js";
 export { isNmkrEmail } from "./nmkr-email.js";
 export {
   BROWSER_ONLY_NOTIFICATION_KINDS,
-  type BrowserOnlyNotificationKind,
   isBrowserOnlyNotification,
 } from "./notification-feed-kinds.js";
 export {
@@ -242,16 +222,12 @@ export {
   notificationDefault,
 } from "./notification-preferences.js";
 export {
-  type BuildOAuthClientScopeParamOptions,
   buildOAuthClientGrantTypes,
   buildOAuthClientScopeParam,
   hasCoreApiOAuthScope,
   hasOfflineAccessOAuthScope,
   OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES,
   OAUTH_PROVIDER_SCOPES,
-  OAUTH_SCOPE_CORE_API,
-  OAUTH_SCOPE_OFFLINE_ACCESS,
-  OAUTH_SCOPE_OPENID,
   type OAuthClientGrantType,
 } from "./oauth-scopes.js";
 export {
@@ -271,7 +247,6 @@ export {
   evaluateInviteLinkStatus,
   type InviteLinkPresentStatus,
   type InviteLinkStatus,
-  type InviteLinkStatusFields,
 } from "./organization-invite-link.js";
 export {
   buildOrganizationLogoContentHashPathname,
@@ -301,10 +276,7 @@ export {
   isProjectLogoBlobUrl,
 } from "./project-logo-path.js";
 export { SokosumiJobStatus } from "./sokosumi-job-status.js";
-export {
-  hasStripeBillingAddressWithCountry,
-  type StripeBillingAddressLike,
-} from "./stripe-billing-address.js";
+export { hasStripeBillingAddressWithCountry } from "./stripe-billing-address.js";
 export {
   canArchiveTaskStatus,
   getTaskCannotArchiveMessage,
@@ -334,7 +306,6 @@ export {
   FILE_UPLOAD_MAX_SIZE_BYTES,
   isOwnedTaskFileUrl,
   resolveTaskFileContentType,
-  TASK_FILE_MAX_NAME_LENGTH,
   TASK_FILE_MAX_SIZE_BYTES,
 } from "./task-file-upload.js";
 export {
@@ -355,7 +326,6 @@ export {
 export { isValidTimezone } from "./timezone.js";
 export {
   selectUnfurlCandidateUrls,
-  type UnfurlPreviewContent,
   unfurlCardHasPreviewContent,
 } from "./unfurl-urls.js";
 export {
@@ -370,10 +340,7 @@ export {
   resolveAccountDisplayName,
 } from "./user-name.js";
 export {
-  isUserUploadAllowedContentType,
-  normalizeUserUploadContentType,
   resolveUserUploadContentType,
-  USER_UPLOAD_ALLOWED_CONTENT_TYPE_SET,
   USER_UPLOAD_ALLOWED_CONTENT_TYPES,
 } from "./user-upload-content-type.js";
 export {
@@ -387,9 +354,6 @@ export {
 export {
   buildWebhookFailureContext,
   DEFAULT_WEBHOOK_TIMEOUT_MS,
-  MAX_REPORTED_WEBHOOK_BODY_LENGTH,
-  type PostWebhookOptions,
-  type PostWebhookResult,
   postWebhook,
 } from "./webhook.js";
 export {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Area: **packages-utils-index-unexport-round-2**

Stop re-exporting leftover unused symbols from `packages/utils/src/index.ts`. Source modules are unchanged; relative imports inside `@sokosumi/utils` still work. Does not replay #4355.

Each name was re-grepped across `apps/` and `packages/` before removal. Remaining hits are the defining module, colocated tests, and/or other `packages/utils` relative imports. The only extra hit is a Swift comment naming `ABLY_CLIENT_INSTANCE_ID_PATTERN` (not a package import).

## Unexported

Constants: `ABLY_CLIENT_INSTANCE_ID_PATTERN`, `ABLY_PRESENCE_CLIENT_ID_SEPARATOR`, `DESIGN_MD_BLOB_PATH_PREFIX`, `DRIVE_FILE_MAX_NAME_LENGTH`, `DRIVE_FOLDER_MARKER_BASENAME`, `HIGH_CREDIT_TOPUP_LOOKUP_KEY`, `MID_CREDIT_TOPUP_LOOKUP_KEY`, `IPFS_GATEWAY_PREFIX`, `MAX_REPORTED_WEBHOOK_BODY_LENGTH`, `OAUTH_SCOPE_CORE_API`, `OAUTH_SCOPE_OFFLINE_ACCESS`, `OAUTH_SCOPE_OPENID`, `TASK_FILE_MAX_NAME_LENGTH`, `USER_UPLOAD_ALLOWED_CONTENT_TYPE_SET`

Types: `BrowserOnlyNotificationKind`, `BuildOAuthClientScopeParamOptions`, `ChannelLinkMatch`, `ChatRoomQuoteSnippetParts`, `InviteLinkStatusFields`, `MarkdownLinkMatch`, `PostWebhookOptions`, `PostWebhookResult`, `ResolveBetterAuthCookiePrefixParams`, `ResolveBetterAuthProductionUrlParams`, `ResolveBetterAuthPublicBaseUrlParams`, `StandardCreditTopUpLookupKey`, `StripeBillingAddressLike`, `UnfurlPreviewContent`

Functions: `extensionForCoworkerImageMime`, `isUserUploadAllowedContentType`, `normalizeUserUploadContentType`, `stringifyMetadataRecord`

## Skipped

None of the listed candidates. All were still in the barrel and unused outside `packages/utils`.

## Verification

- `pnpm exec biome check packages/utils/src/index.ts` — 1 file, no fixes
- `pnpm --filter @sokosumi/utils typecheck` — pass
- `pnpm --filter @sokosumi/utils test` — 66 files, 645 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d18589bc-9acb-47fe-b037-6030042dd44b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d18589bc-9acb-47fe-b037-6030042dd44b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

