### PR TITLE
chore(database): named-export job types and delete unused jobOrderBy

### DIFF
--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -17,6 +17,19 @@ export {
   agentTagsInclude,
 } from "./types/agent.js";
 export { InvitationStatus } from "./types/invitation.js";
-export * from "./types/job.js";
+export {
+  finalizedAgentJobStatuses,
+  finalizedOnChainJobStatuses,
+  type JobWithListSummaryRelations,
+  type JobWithSokosumiStatus,
+  type JobWithSummaryRelations,
+  jobForStatusComputeSelect,
+  jobInclude,
+  jobListSummaryInclude,
+  jobWithEvents,
+  jobWithPurchase,
+  jobWithShare,
+  jobWithTransaction,
+} from "./types/job.js";
 export { MemberRole } from "./types/organization.js";
 export { workspaceRelationInclude } from "./types/workspace.js";

--- a/packages/database/src/types/job.ts
+++ b/packages/database/src/types/job.ts
@@ -179,10 +179,6 @@ export const jobInclude = {
   ...jobWithShare,
 } as const;
 
-export const jobOrderBy = {
-  createdAt: "desc",
-} as const;
-
 export type JobWithRelations = Prisma.JobGetPayload<{
   include: typeof jobInclude;
 }>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces `export * from "./types/job.js"` on the `@sokosumi/database` barrel with named exports Core and `@sokosumi/database/types/job` already consume. Deletes unused `jobOrderBy` (zero callers, including in-package).

Named-exported (re-grep confirmed each has callers):
- `jobInclude`
- `jobWithEvents`
- `jobWithPurchase`
- `jobWithShare`
- `jobWithTransaction`
- `jobForStatusComputeSelect`
- `jobListSummaryInclude`
- `JobWithListSummaryRelations`
- `JobWithSummaryRelations`
- `JobWithSokosumiStatus`
- `finalizedAgentJobStatuses`
- `finalizedOnChainJobStatuses`

Deleted:
- `jobOrderBy`

Left alone: helpers barrel, agent-types, remaining `types/job.ts` internals still used via `@sokosumi/database/types/job`.

## Verification

- `pnpm check` and `pnpm typecheck` (husky pre-commit; Core + database included)
- `pnpm --filter @sokosumi/database test` — 48 files passed, 3 skipped (344 tests passed, 5 skipped)
- Re-grep: `jobOrderBy` has zero matches; every keep-list symbol still has Core and/or in-package callers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b49de344-92a3-4e1c-aa50-28af68433e7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b49de344-92a3-4e1c-aa50-28af68433e7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

