### PR TITLE
chore(masumi): unexport internal schemas/tools/clients leftover after named-export round

### DIFF
--- a/packages/masumi/AGENTS.md
+++ b/packages/masumi/AGENTS.md
@@ -63,9 +63,8 @@ const agentClient = createAgentClient({
 
 ```typescript
 import {
-  jobStatusResponseSchema,
-  inputSchemaResponseSchema,
   type InputSchemaType,
+  type JobStatusResponseSchemaType,
 } from "@sokosumi/masumi/schemas";
 ```
 

--- a/packages/masumi/src/clients/agent.client.ts
+++ b/packages/masumi/src/clients/agent.client.ts
@@ -4,19 +4,25 @@ import { err, ok, type Result } from "neverthrow";
 import { hashCanonicalJsonValue, hashInputSchema } from "../hash/hash.js";
 import {
   type InputSchemaResponseSchemaType,
-  type InputSchemaType,
   inputSchemaResponseSchema,
-  type JobStatusResponseSchemaType,
-  jobStatusResponseSchema,
+} from "../schemas/agent/input_schema.schema.js";
+import {
   type ProvideInputRequestSchemaType,
   type ProvideInputResponseSchemaType,
   provideInputRequestSchema,
   provideInputResponseSchema,
+} from "../schemas/agent/provide_input.schema.js";
+import {
   type StartFreeJobResponseSchemaType,
   type StartPaidJobResponseSchemaType,
   startFreeJobResponseSchema,
   startPaidJobResponseSchema,
-} from "../schemas/index.js";
+} from "../schemas/agent/start_job.schema.js";
+import {
+  type JobStatusResponseSchemaType,
+  jobStatusResponseSchema,
+} from "../schemas/agent/status.schema.js";
+import type { InputSchemaType } from "../schemas/input/input.schema.js";
 import type { Agent } from "../types/agent.js";
 import { safeAddPathComponent } from "../utils/url.js";
 

--- a/packages/masumi/src/clients/index.ts
+++ b/packages/masumi/src/clients/index.ts
@@ -1,26 +1,18 @@
-export type {
-  AgentClientConfig,
-  AgentJobInputFailure,
-  AgentJobStartFailure,
-} from "./agent.client.js";
+export type { AgentJobStartFailure } from "./agent.client.js";
 export { createAgentClient } from "./agent.client.js";
 export {
   createPaymentClient,
   doesResolvedPurchaseSellerMatch,
   type MasumiPurchaseDiffEntry,
-  type MasumiPurchaseDiffFailure,
   type MasumiTaskPurchaseInput,
   type PurchaseFailure,
 } from "./masumi-payment.client.js";
 export type {
   X402AvailableNetwork,
   X402KeySpendCaps,
-  X402PayFailure,
-  X402PayInput,
   X402SignedPayment,
   X402Wallet,
   X402WalletBalance,
-  X402WalletBalanceInput,
 } from "./masumi-payment-x402.js";
 export { createRegistryClient } from "./masumi-registry.client.js";
 export type { PostPurchaseResponses } from "./openapi/generated/payment/index.js";

--- a/packages/masumi/src/schemas/index.ts
+++ b/packages/masumi/src/schemas/index.ts
@@ -1,24 +1,9 @@
 // Agent schemas
-export {
-  type InputSchemaResponseSchemaType,
-  inputSchemaResponseSchema,
-} from "./agent/input_schema.schema.js";
-export {
-  type ProvideInputRequestSchemaType,
-  type ProvideInputResponseSchemaType,
-  provideInputRequestSchema,
-  provideInputResponseSchema,
-} from "./agent/provide_input.schema.js";
-export {
-  type StartFreeJobResponseSchemaType,
-  type StartPaidJobResponseSchemaType,
-  startFreeJobResponseSchema,
-  startPaidJobResponseSchema,
+export type {
+  StartFreeJobResponseSchemaType,
+  StartPaidJobResponseSchemaType,
 } from "./agent/start_job.schema.js";
-export {
-  type JobStatusResponseSchemaType,
-  jobStatusResponseSchema,
-} from "./agent/status.schema.js";
+export type { JobStatusResponseSchemaType } from "./agent/status.schema.js";
 
 // Input schemas
 export { preprocessBlankNumericInput } from "./input/blank-numeric-input.js";

--- a/packages/masumi/src/tools/design-md/index.ts
+++ b/packages/masumi/src/tools/design-md/index.ts
@@ -1,33 +1,8 @@
 export { createDesignMdClient } from "./client.js";
-export {
-  DEFAULT_DESIGN_MD_API_URL,
-  DEFAULT_DESIGN_MD_POLL_INTERVAL_MS,
-} from "./constants.js";
 export { buildDesignMdPreviewUrl } from "./preview-url.js";
 export {
   type DesignMdDonePayload,
-  type DesignMdFailedPayload,
   type DesignMdJobPayload,
-  type DesignMdQueuedPayload,
-  type DesignMdRunningPayload,
-  type DesignMdSubmitInput,
-  designMdApiResponseSchema,
-  designMdDonePayloadSchema,
-  designMdFailedPayloadSchema,
-  designMdQueuedPayloadSchema,
-  designMdRunningPayloadSchema,
-  designMdSubmitInputSchema,
   isDesignMdJobInProgress,
 } from "./schemas.js";
-export type {
-  DesignMdClient,
-  DesignMdClientConfig,
-  DesignMdClientError,
-  DesignMdGenerateUntilDoneInput,
-  DesignMdHttpError,
-  DesignMdJobFailedError,
-  DesignMdJsonParseError,
-  DesignMdNetworkError,
-  DesignMdRequestOptions,
-  DesignMdSchemaValidationError,
-} from "./types.js";
+export type { DesignMdClient, DesignMdClientError } from "./types.js";

--- a/packages/masumi/src/types/index.ts
+++ b/packages/masumi/src/types/index.ts
@@ -1,2 +1,2 @@
-export * from "./agent.js";
-export * from "./input-types.js";
+export type { Agent } from "./agent.js";
+export { InputFormat, InputType, InputValidation } from "./input-types.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly leftover after the named-export round (#4358). Shrink `@sokosumi/masumi` public barrels so only app-consumed names stay exported. Implementations stay in place.

## Changes

- Point `agent.client.ts` at schema modules directly so provide/start schemas can leave the public schemas barrel.
- Keep `StartFreeJobResponseSchemaType` / `StartPaidJobResponseSchemaType` / `JobStatusResponseSchemaType` on `/schemas` (Core still imports them). Drop the unused request/response schema values and provide-input names.
- `/tools`: keep `createDesignMdClient`, `buildDesignMdPreviewUrl`, `isDesignMdJobInProgress`, `DesignMdClient`, `DesignMdClientError`, `DesignMdDonePayload`, `DesignMdJobPayload`. Unexport `DEFAULT_DESIGN_MD_*` and the unused DesignMd error/payload schemas.
- `/clients`: unexport `AgentClientConfig`, `AgentJobInputFailure`, `MasumiPurchaseDiffFailure`, `X402PayFailure`, `X402PayInput`, `X402WalletBalanceInput`.
- `/types`: unexport `OutputFormat` (enum stays internal). Not migrated to a const map.

Does not replay #4351/#4358. Generated OpenAPI bodies untouched.

## Verification

- `pnpm check` + `pnpm typecheck` (husky): pass, including web and Core against the narrowed barrels
- `pnpm --filter @sokosumi/masumi test`: 18 files, 411 tests
- Dist `.d.ts` barrels no longer export the unexported names; `OutputFormat` remains in `input-types.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a327cc7e-7984-4105-ab8a-bdadbb00b193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a327cc7e-7984-4105-ab8a-bdadbb00b193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

