### PR TITLE
chore(database): replace helpers export * with Core-imported named exports

### DIFF
--- a/packages/database/src/helpers/index.ts
+++ b/packages/database/src/helpers/index.ts
@@ -1,19 +1,75 @@
-export * from "./credit.js";
-export * from "./credit-bucket-scope.js";
-export * from "./enterprise-contract.js";
-export * from "./enterprise-contract-exclusivity.js";
-export * from "./enterprise-contract-grants.js";
-export * from "./enterprise-contract-lifecycle.js";
-export * from "./enterprise-contract-scheduler.js";
-export * from "./free-credits.js";
-export * from "./job.js";
-export * from "./job-sync.js";
-export * from "./organization-billing-plan.js";
-export * from "./organization-member-period-pool-transfer.js";
-export * from "./organization-owner.js";
-export * from "./organization-paid-subscribe-seats.js";
-export * from "./organization-seats.js";
-export * from "./organization-subscription-credit-audience.js";
-export * from "./organization-subscription-exclusivity.js";
-export * from "./signup-bonus-credits.js";
-export * from "./subscription.js";
+export {
+  buildOrganizationInvoiceCreditReferenceId,
+  buildUserInvoiceCreditReferenceId,
+  creditBucketActivatesAtOrBefore,
+  getCreditExpiryDate,
+} from "./credit.js";
+export { hasAssignedOrganizationSeat } from "./credit-bucket-scope.js";
+export {
+  deriveEnterpriseContractEndDate,
+  MIN_ENTERPRISE_CREDITS_PER_MONTH,
+  MIN_ENTERPRISE_PERIOD_COUNT,
+  previewEnterpriseContractPeriods,
+  validateEnterprisePeriodCount,
+  validateMinEnterpriseCreditsPerMonth,
+} from "./enterprise-contract.js";
+export type { PaidSubscriptionBlocker } from "./enterprise-contract-exclusivity.js";
+export {
+  activateEnterpriseContract,
+  cancelEnterpriseContract,
+  EnterpriseContractActivationError,
+  EnterpriseContractLifecycleError,
+  EnterpriseContractNotFoundError,
+} from "./enterprise-contract-lifecycle.js";
+export { runEnterpriseContractSchedulerPass } from "./enterprise-contract-scheduler.js";
+export {
+  GrantFreeCreditsError,
+  grantFreeCredits,
+} from "./free-credits.js";
+export {
+  computeJobStatus,
+  getCompletedAt,
+  getCredits,
+  getResult,
+  getResultHash,
+  isJobStatusSettled,
+  mapJobWithStatus,
+} from "./job.js";
+export {
+  buildJobsNeedingAgentStatusSyncWhere,
+  buildJobsNeedingPurchaseBackfillWhere,
+  buildJobsNeedingPurchaseTransactionSyncWhere,
+  buildJobsPendingLocalRefundWhere,
+} from "./job-sync.js";
+export {
+  type OrganizationBillingPlan,
+  resolveOrganizationBillingPlan,
+} from "./organization-billing-plan.js";
+export { OrganizationOwnerRetentionError } from "./organization-owner.js";
+export {
+  autoAssignSeatsOnPaidSubscribe,
+  unassignSeatsOverPurchasedCapacity,
+} from "./organization-paid-subscribe-seats.js";
+export {
+  ensurePurchasedSeatsSufficient,
+  getUnusedSeatCount,
+  resolvePurchasedSeats,
+} from "./organization-seats.js";
+export {
+  assertOrganizationSubscriptionChangeAllowed,
+  ENTERPRISE_SUBSCRIPTION_EXCLUSIVITY_MESSAGE,
+  hasConsumableEnterpriseContract,
+  OrganizationSubscriptionExclusivityError,
+} from "./organization-subscription-exclusivity.js";
+export { grantSignupBonusCredits } from "./signup-bonus-credits.js";
+export {
+  ACTIVE_SUBSCRIPTION_STATUSES,
+  closeOverdueLocalFreeSubscription,
+  ensureInitialLocalFreeSubscriptionPeriod,
+  ensureNextLocalFreeSubscriptionPeriod,
+  FREE_SUBSCRIPTION_PLAN,
+  FREE_SUBSCRIPTION_PRECREATE_LOOKAHEAD_MS,
+  getNextMonthlyPeriodEnd,
+  isActiveSubscriptionStatus,
+  transitionToNextLocalFreeSubscriptionPeriod,
+} from "./subscription.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces `export *` on `@sokosumi/database/helpers` with named exports of the symbols Core actually imports from that barrel. Implementations stay in place; ~81 other builders/types become package-internal (deep-path or in-package only).

Keep-list is the 53 unique Core named imports from `apps/core` (re-grep immediately before writing the barrel). Types `OrganizationBillingPlan` and `PaidSubscriptionBlocker` are included.

Not in this PR:
- Repository methods (already deep-path after #4347)
- Core seat-test `vi.mock` stub cleanup
- Third-party skills, `packages-chat-catalog`, `core-agents-get-batch-tx`

## Verification

- `pnpm check` and `pnpm typecheck` (husky pre-commit; Core typechecks against the narrowed helpers barrel)
- `pnpm --filter @sokosumi/database test` — 48 files passed, 3 skipped (344 tests passed, 5 skipped)
- `pnpm --filter core test` on `error-handler.test.ts`, `auth.test.ts`, `organization-assigned-seat.test.ts` — 3 files, 88 tests passed
- Runtime barrel has 51 value exports (53 keep-list minus 2 types); internals such as `fetchOrganizationMemberUserIds` are absent from the barrel and still importable via deep path
- `tsc`: `import { fetchOrganizationMemberUserIds } from "@sokosumi/database/helpers"` is TS2305; keep-list type+value imports succeed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a7bcfa9-263e-4b5d-bd58-4dd7ecf6a6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7bcfa9-263e-4b5d-bd58-4dd7ecf6a6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

