### PR TITLE
chore(web): migrate notice actions from retired { ok; data } to ActionResultDto value

### DIFF
--- a/apps/web/src/app/(app)/components/app-shell-overlays.tsx
+++ b/apps/web/src/app/(app)/components/app-shell-overlays.tsx
@@ -16,7 +16,7 @@ export default async function AppShellOverlays() {
   await connection();
   const pendingNoticesResult = await getPendingNoticesAction();
   const pendingNotices = pendingNoticesResult.ok
-    ? pendingNoticesResult.data
+    ? pendingNoticesResult.value
     : [];
   const legalNotices = pendingNotices.filter(
     (notice: Notice) => notice.kind === NoticeKind.LEGAL_TERMS,

--- a/apps/web/src/app/(app)/components/notice-dialog-context.tsx
+++ b/apps/web/src/app/(app)/components/notice-dialog-context.tsx
@@ -71,7 +71,7 @@ export function NoticeDialogProvider({
   async function handleNoticeAcknowledged() {
     const result = await getPendingNoticesAction();
     if (result.ok) {
-      const pendingNotices = result.data;
+      const pendingNotices = result.value;
       setLegalNotices(
         pendingNotices.filter(
           (notice) => notice.kind === NoticeKind.LEGAL_TERMS,

--- a/apps/web/src/lib/actions/notice/action.test.ts
+++ b/apps/web/src/lib/actions/notice/action.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const getPendingNoticesMock = vi.fn();
+const acknowledgeNoticeMock = vi.fn();
+const toCoreApiActionErrorMock = vi.fn();
+
+vi.mock("@/lib/clients/core.client", () => ({
+  coreClient: {
+    getPendingNotices: (...args: unknown[]) => getPendingNoticesMock(...args),
+    acknowledgeNotice: (...args: unknown[]) => acknowledgeNoticeMock(...args),
+  },
+  toCoreApiActionError: (...args: unknown[]) =>
+    toCoreApiActionErrorMock(...args),
+}));
+
+import { acknowledgeNoticeAction, getPendingNoticesAction } from "./action";
+
+const NOTICES = [{ id: "notice-1", kind: "ANNOUNCEMENT" }];
+
+describe("notice actions ActionResultDto", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toCoreApiActionErrorMock.mockImplementation((error: unknown) => ({
+      code: "INTERNAL_SERVER_ERROR",
+      message: error instanceof Error ? error.message : "Unexpected error",
+    }));
+  });
+
+  it("maps pending notices to { ok: true, value } without a data field", async () => {
+    getPendingNoticesMock.mockResolvedValue(NOTICES);
+
+    const result = await getPendingNoticesAction();
+
+    expect(result).toEqual({ ok: true, value: NOTICES });
+    expect(result).not.toHaveProperty("data");
+  });
+
+  it("maps acknowledge success to { ok: true, value: undefined } without a data field", async () => {
+    acknowledgeNoticeMock.mockResolvedValue({ id: "ack-1" });
+
+    const result = await acknowledgeNoticeAction("notice-1");
+
+    expect(acknowledgeNoticeMock).toHaveBeenCalledWith("notice-1");
+    expect(result).toEqual({ ok: true, value: undefined });
+    expect(result).not.toHaveProperty("data");
+  });
+
+  it("maps Core failures to { ok: false, error }", async () => {
+    getPendingNoticesMock.mockRejectedValue(new Error("boom"));
+
+    const result = await getPendingNoticesAction();
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "INTERNAL_SERVER_ERROR", message: "boom" },
+    });
+  });
+});

--- a/apps/web/src/lib/actions/notice/action.ts
+++ b/apps/web/src/lib/actions/notice/action.ts
@@ -1,40 +1,32 @@
 "use server";
 
+import { err, ok } from "neverthrow";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import type { ActionError } from "@/lib/actions/errors";
 import { coreClient, toCoreApiActionError } from "@/lib/clients/core.client";
-import type { Notice } from "@/lib/clients/generated/core";
-import { NoticeKind } from "@/lib/clients/generated/core";
-
-export type PendingNotice = Notice;
-export type NoticeAcknowledgment = Awaited<
-  ReturnType<typeof coreClient.acknowledgeNotice>
->;
+import type { Notice, NoticeKind } from "@/lib/clients/generated/core";
 
 export async function getPendingNoticesAction(
   kind?: NoticeKind,
-): Promise<
-  { ok: true; data: PendingNotice[] } | { ok: false; error: ActionError }
-> {
+): Promise<ActionResultDto<Notice[], ActionError>> {
   try {
     const notices = await coreClient.getPendingNotices(kind);
-    return { ok: true, data: notices };
+    return toActionResult(ok(notices));
   } catch (error) {
-    return { ok: false, error: toCoreApiActionError(error) };
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 }
 
 export async function acknowledgeNoticeAction(
   noticeId: string,
-): Promise<
-  { ok: true; data: NoticeAcknowledgment } | { ok: false; error: ActionError }
-> {
+): Promise<ActionResultDto<void, ActionError>> {
   try {
-    const data = await coreClient.acknowledgeNotice(noticeId);
-    return {
-      ok: true,
-      data,
-    };
+    await coreClient.acknowledgeNotice(noticeId);
+    return toActionResult(ok(undefined));
   } catch (error) {
-    return { ok: false, error: toCoreApiActionError(error) };
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Notice server actions were the last `lib/actions` callers still returning the retired `{ ok: true; data }` envelope.

This maps `getPendingNoticesAction` and `acknowledgeNoticeAction` through neverthrow + `toActionResult`, so they return `ActionResultDto` (`value` on success). Callers in `notice-dialog-context.tsx` and `app-shell-overlays.tsx` now read `result.value` instead of `result.data`. `notice-dialog.tsx` already only checked `result.ok` / `result.error`. Dead `PendingNotice` / `NoticeAcknowledgment` aliases are gone.

A small contract test in `apps/web/src/lib/actions/notice/action.test.ts` asserts the ActionResultDto shape (success has `value`, not `data`).

No schema/migrations. No Core OpenAPI `result.data` envelopes touched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77c424bd-4214-4840-a18f-88d4e4c95ee1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77c424bd-4214-4840-a18f-88d4e4c95ee1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

