### PR TITLE
chore(core): delete narrating comments in drive routes (+ one notification)

### DIFF
--- a/apps/core/src/routes/v1/drive/files/[id]/delete.ts
+++ b/apps/core/src/routes/v1/drive/files/[id]/delete.ts
@@ -56,16 +56,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     const { pathname } = body;
 
-    // Parse pathname to determine scope and owner
     const { scope, ownerId } = parseDriveFilePathname(
       pathname,
       userContext.userId,
     );
 
-    // Verify access
     await requireDriveFileAccess(authContext, scope, ownerId);
 
-    // Check if file exists
     try {
       await head(pathname, { token });
     } catch (error) {
@@ -75,7 +72,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       throw error;
     }
 
-    // Delete the blob
     await del(pathname, { token });
 
     return c.body(null, 204);

--- a/apps/core/src/routes/v1/drive/files/[id]/patch.ts
+++ b/apps/core/src/routes/v1/drive/files/[id]/patch.ts
@@ -67,16 +67,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     const { oldPathname, newFilename } = body;
 
-    // Parse pathname to determine scope and owner
     const { scope, ownerId } = parseDriveFilePathname(
       oldPathname,
       userContext.userId,
     );
 
-    // Verify access
     await requireDriveFileAccess(authContext, scope, ownerId);
 
-    // Extract parent folder path from old pathname
     const prefix =
       scope === "user"
         ? buildUserDriveFilePrefix(ownerId)
@@ -91,7 +88,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const folderPath =
       lastSlashIndex >= 0 ? relativePathname.slice(0, lastSlashIndex) : "";
 
-    // Build new pathname, preserving parent folder
     const sanitizedName = clampDriveFileName(newFilename);
     const newPathname =
       scope === "user"
@@ -106,7 +102,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             sanitizedName,
           );
 
-    // Get source blob metadata for preservation
     let sourceMetadata;
     try {
       sourceMetadata = await head(oldPathname, { token });
@@ -117,15 +112,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       throw error;
     }
 
-    // Check if target already exists (file or folder)
     try {
       await head(newPathname, { token });
-      // If head succeeds, target file exists
       throw conflict("Target pathname already exists");
     } catch (error) {
       // If it's a not-found error, target doesn't exist (expected)
       if (error instanceof BlobNotFoundError) {
-        // Target file doesn't exist, proceed
       } else if (
         error &&
         typeof error === "object" &&
@@ -135,12 +127,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         // Re-throw our own conflict errors
         throw error;
       } else {
-        // Unexpected error from head
         throw error;
       }
     }
 
-    // Check if a folder with the same name exists
     const folderPrefix = `${newPathname}/`;
     const folderCheck = await list({
       prefix: folderPrefix,
@@ -165,7 +155,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         ),
       });
     } catch (error) {
-      // Map Blob errors to HTTP responses
       if (error instanceof BlobNotFoundError) {
         throw notFound("Source file not found");
       }
@@ -182,7 +171,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       throw error;
     }
 
-    // Extract filename from new pathname
     const pathSegments = newPathname.split("/");
     const name = pathSegments[pathSegments.length - 1] || "unnamed";
 

--- a/apps/core/src/routes/v1/drive/files/move.ts
+++ b/apps/core/src/routes/v1/drive/files/move.ts
@@ -84,7 +84,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const targetFolderPath = normalizeDriveFolderPath(body.targetFolderPath);
 
     if (body.itemType === "file") {
-      // Move file
       const { scope, ownerId } = parseDriveFilePathname(
         body.sourcePathname,
         userContext.userId,
@@ -92,7 +91,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       await requireDriveFileAccess(authContext, scope, ownerId);
 
-      // Get source metadata
       let sourceMetadata;
       try {
         sourceMetadata = await head(body.sourcePathname, { token });
@@ -103,31 +101,26 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         throw error;
       }
 
-      // Extract filename from source
       const sourceSegments = body.sourcePathname.split("/");
       const filename = sourceSegments[sourceSegments.length - 1] || "unnamed";
 
-      // Reject moving the reserved marker file
       if (isDriveFolderMarkerName(filename)) {
         throw badRequest(
           "Cannot move the reserved folder marker file (__drive_folder__)",
         );
       }
 
-      // Build target pathname
       const targetPrefix =
         scope === "user"
           ? buildUserDriveFolderPrefix(ownerId, targetFolderPath)
           : buildOrganizationDriveFolderPrefix(ownerId, targetFolderPath);
       const targetPathname = `${targetPrefix}${filename}`;
 
-      // Check if target exists (file or folder)
       try {
         await head(targetPathname, { token });
         throw conflict("Target file already exists");
       } catch (error) {
         if (error instanceof BlobNotFoundError) {
-          // Target file doesn't exist, proceed
         } else if (
           error &&
           typeof error === "object" &&
@@ -140,7 +133,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         }
       }
 
-      // Check if a folder with the same name exists
       const folderPrefix = `${targetPathname}/`;
       const folderCheck = await list({
         prefix: folderPrefix,
@@ -151,7 +143,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         throw conflict("A folder with that name already exists");
       }
 
-      // Rename file
       const maxAge = parseCacheControlMaxAge(sourceMetadata.cacheControl);
       await rename(body.sourcePathname, targetPathname, {
         token,
@@ -165,7 +156,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     }
 
     if (body.itemType === "folder") {
-      // Move folder - requires explicit scope + organizationId
       if (!body.scope) {
         throw unprocessableEntity("scope is required for folder moves");
       }
@@ -216,7 +206,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         throw badRequest("Invalid scope. Must be 'me' or 'org'.");
       }
 
-      // Check if source folder exists
       const sourceCheck = await list({
         prefix: oldPrefix,
         token,
@@ -232,7 +221,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           ? buildUserDriveFolderPrefix(ownerId, newFolderPath)
           : buildOrganizationDriveFolderPrefix(ownerId, newFolderPath);
 
-      // Reject moving a folder into its own descendant
       if (
         newPrefix === oldPrefix ||
         newPrefix.startsWith(`${oldPrefix}`) // oldPrefix already ends with /
@@ -240,7 +228,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         throw badRequest("Cannot move a folder into its own descendant");
       }
 
-      // Check if target exists
       const targetCheck = await list({
         prefix: newPrefix,
         token,
@@ -259,7 +246,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         if (!(error instanceof BlobNotFoundError)) {
           throw error;
         }
-        // File doesn't exist, proceed
       }
 
       // Collect all pathnames under source prefix (capped at MAX+1 for detection)
@@ -306,17 +292,14 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           try {
             const targetCheck = await head(newPathname, { token });
             if (targetCheck) {
-              // Already exists at target, skip
               return;
             }
           } catch (error) {
             if (!(error instanceof BlobNotFoundError)) {
               throw error;
             }
-            // Target doesn't exist, proceed with rename
           }
 
-          // Get source metadata
           let sourceMetadata;
           try {
             sourceMetadata = await head(sourcePathname, { token });
@@ -328,7 +311,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             throw error;
           }
 
-          // Rename
           const maxAge = parseCacheControlMaxAge(sourceMetadata.cacheControl);
           try {
             await rename(sourcePathname, newPathname, {

--- a/apps/core/src/routes/v1/drive/files/post.ts
+++ b/apps/core/src/routes/v1/drive/files/post.ts
@@ -107,14 +107,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const displayName = clampDriveFileName(body.filename || "file");
     const folderPath = normalizeDriveFolderPath(body.folder ?? "");
 
-    // Check if filename conflicts with reserved marker basename
     if (isDriveFolderMarkerName(displayName)) {
       throw badRequest(
         "File name conflicts with a reserved system name. Please choose a different name.",
       );
     }
 
-    // ACL checks and owner resolution
     let pathname: string;
 
     if (body.scope === "me") {
@@ -130,7 +128,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         throw unprocessableEntity("organizationId is required when scope=org");
       }
       const ownerId = body.organizationId;
-      // Verifies membership
       await requireOrganizationDriveFileUploadAccess(authContext, ownerId);
       pathname = buildOrganizationDriveFilePathnameWithFolder(
         ownerId,
@@ -141,15 +138,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       throw badRequest("Invalid scope. Must be 'me' or 'org'.");
     }
 
-    // Check if target pathname already exists (file or folder)
     try {
       await head(pathname, { token });
-      // If head succeeds, target file exists
       throw conflict("Target pathname already exists");
     } catch (error) {
       // If it's a not-found error, target doesn't exist (expected)
       if (error instanceof BlobNotFoundError) {
-        // Target file doesn't exist, proceed
       } else if (
         error &&
         typeof error === "object" &&
@@ -159,12 +153,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         // Re-throw our own conflict errors
         throw error;
       } else {
-        // Unexpected error from head
         throw error;
       }
     }
 
-    // Check if a folder with the same name exists
     const folderPrefix = `${pathname}/`;
     const folderCheck = await list({
       prefix: folderPrefix,

--- a/apps/core/src/routes/v1/drive/folders/post.ts
+++ b/apps/core/src/routes/v1/drive/folders/post.ts
@@ -114,14 +114,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     }
 
     // Check if a file with the same name exists (without the trailing slash)
-    const filePathname = prefix.slice(0, -1); // Remove trailing slash
+    const filePathname = prefix.slice(0, -1);
     try {
       await head(filePathname, { token });
-      // If head succeeds, a file with the folder's name exists
       throw conflict("A file with that name already exists");
     } catch (error) {
       if (error instanceof BlobNotFoundError) {
-        // File doesn't exist, proceed
       } else if (
         error &&
         typeof error === "object" &&

--- a/apps/core/src/routes/v1/drive/folders/rename.ts
+++ b/apps/core/src/routes/v1/drive/folders/rename.ts
@@ -119,7 +119,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       throw notFound("Source folder not found");
     }
 
-    // Check if target folder prefix already has blobs (conflict)
     const targetCheck = await list({
       prefix: newPrefix,
       token,
@@ -138,10 +137,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       if (!(error instanceof BlobNotFoundError)) {
         throw error;
       }
-      // File doesn't exist, proceed
     }
 
-    // Reject renaming a folder into its own descendant
     if (
       newPrefix === oldPrefix ||
       newPrefix.startsWith(`${oldPrefix}`) // oldPrefix already ends with /
@@ -193,17 +190,14 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         try {
           const targetCheck = await head(newPathname, { token });
           if (targetCheck) {
-            // Already exists at target, skip
             return;
           }
         } catch (error) {
           if (!(error instanceof BlobNotFoundError)) {
             throw error;
           }
-          // Target doesn't exist, proceed with rename
         }
 
-        // Get source metadata
         let sourceMetadata;
         try {
           sourceMetadata = await head(sourcePathname, { token });
@@ -215,7 +209,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           throw error;
         }
 
-        // Rename
         const maxAge = parseCacheControlMaxAge(sourceMetadata.cacheControl);
         try {
           await rename(sourcePathname, newPathname, {

--- a/apps/core/src/routes/v1/drive/tasks/copy.ts
+++ b/apps/core/src/routes/v1/drive/tasks/copy.ts
@@ -137,7 +137,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const fileName = taskFile.name;
     const mimeType = taskFile.mimeType;
 
-    // Determine destination pathname
     let destPathname: string;
     if (body.scope === "me") {
       const ownerId = userContext.userId;
@@ -147,7 +146,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         sanitizeDriveFileName(fileName),
       );
     } else {
-      // scope === "org"
       if (!body.organizationId) {
         throw badRequest("organizationId is required when scope=org");
       }
@@ -159,13 +157,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       );
     }
 
-    // Check for name collision in dest Drive
     try {
       await head(destPathname, { token });
       throw conflict("A file with that name already exists in Drive");
     } catch (error) {
       if (error instanceof BlobNotFoundError) {
-        // File doesn't exist, proceed
       } else if (
         error &&
         typeof error === "object" &&
@@ -178,7 +174,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       }
     }
 
-    // Also check if a folder with the same prefix exists
     const folderPrefix = `${destPathname}/`;
     const existingFolder = await list({
       prefix: folderPrefix,
@@ -189,7 +184,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       throw conflict("A folder with that name already exists in Drive");
     }
 
-    // Copy blob: fetch source then put to dest
     let sourceBlob: ArrayBuffer;
     try {
       const fetchResult = await ssrfSafeFetch(sourceUrl, {

--- a/apps/core/src/routes/v1/drive/tasks/get.ts
+++ b/apps/core/src/routes/v1/drive/tasks/get.ts
@@ -238,7 +238,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       baseTaskWhere.status = { not: TaskStatus.DRAFT };
     }
 
-    // Apply coworker access filter if needed
     let coworkerAccess:
       | {
           coworkerId: string;
@@ -479,7 +478,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       return ok(c, driveTasksListSchema.parse(items), paginationMeta);
     }
 
-    // Determine level
     if (taskId) {
       await requireTaskReadForRouteVars(c.var, taskId);
 
@@ -661,7 +659,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       return ok(c, driveTasksListSchema.parse(items), paginationMeta);
     }
 
-    // Level 1: Project rows + no-project row, sorted by latest file updatedAt desc
     // Key project rows by tasks in the Drive workspace, not by Project.workspaceId
     // (transferred tasks may have Task.workspaceId !== Project.workspaceId)
 
@@ -677,7 +674,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       .map((group) => group.projectId)
       .filter((id): id is string => id !== null);
 
-    // Fetch all projects by id + no-project count
     const MAX_PROJECTS_FOR_SORT = 10000;
     const [allProjects, noProjectTasksCount] = await Promise.all([
       projectIds.length > 0
@@ -708,7 +704,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       }),
     ]);
 
-    // Build map of found projects
     const projectMap = new Map(allProjects.map((p) => [p.id, p]));
 
     // Emit project rows for all projectIds, using fallback for missing projects
@@ -721,7 +716,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       };
     });
 
-    // Build combined list: projects + no-project row
     interface SortableItem {
       type: "project" | "no-project";
       id: string;
@@ -731,7 +725,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     }
 
     const sortableItems: SortableItem[] = projectsToEmit.map((project) => {
-      // Find latest file time across all tasks in project
       let latestTime = 0;
       for (const task of project.tasks) {
         const fileTime = task.files[0]?.updatedAt.getTime() ?? 0;
@@ -752,9 +745,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       };
     });
 
-    // Add no-project row if it has tasks with files
     if (noProjectTasksCount > 0) {
-      // Find latest file time for no-project tasks
       const latestNoProjectFile = await prisma.taskFile.findFirst({
         where: {
           task: {
@@ -807,14 +798,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       return a.id.localeCompare(b.id) * dir;
     });
 
-    // Apply cursor pagination on sorted combined list
     let startIndex = 0;
     if (cursor) {
       const cursorIndex = sortableItems.findIndex((item) => item.id === cursor);
       if (cursorIndex < 0) {
         throw badRequest("Invalid pagination cursor");
       }
-      startIndex = cursorIndex + 1; // Skip cursor item
+      startIndex = cursorIndex + 1;
     }
 
     const pagedItems = sortableItems.slice(startIndex, startIndex + take);

--- a/apps/core/src/routes/v1/notifications/[id]/read/patch.ts
+++ b/apps/core/src/routes/v1/notifications/[id]/read/patch.ts
@@ -74,7 +74,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireOwnerUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    // Check ownership
     const notification = await prisma.notification.findUnique({
       where: { id },
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Comment-only cleanup in Core Drive handlers plus one notification route. No logic, typing, or API changes.

**Removed** narrating comments that restated the next line (parse/verify/check/rename/copy, empty “proceed” catches, `// Check ownership` on notification read).

**Kept** why comments: retry-safe skip, descendant cap (`MAX+1`), bounded batches / no unbounded accumulation, banner/publish semantics, ACL-before-status leak, Prisma type-sort fallback, transferred-task workspace keying, `@vercel/blob` non-empty marker body, `newPrefix` trailing-slash file collision, swallow expected `BlobNotFoundError` / rethrow own conflict.

`folders/delete.ts` had only why comments, so it was left unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab48e62b-196f-4370-8208-9699168bf6d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab48e62b-196f-4370-8208-9699168bf6d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

