### PR TITLE
docs(adr): rewrite ADR 0006 leftover live-rule body to match ADR 0024 browse

### DIFF
--- a/docs/adr/0006-stop-agent-browse-and-app-hire.md
+++ b/docs/adr/0006-stop-agent-browse-and-app-hire.md
@@ -2,16 +2,12 @@
 
 - Status: Partially superseded by [ADR-0024](./0024-restore-agent-catalog-browse-without-app-hire.md). The app Hire ban remains in force; only the “stop agent browse” decision is superseded.
 
-Live browse and discovery follow [ADR-0024](./0024-restore-agent-catalog-browse-without-app-hire.md).
+The app no longer offers **Hire**. Users must not start a new Job from gallery or Agent detail. **Core Hire APIs stay.** **Soko Bot** still Hires via orchestrator `POST /v1/agents/{id}/jobs`. **Coworker** still Hires via `POST /v1/tasks/{id}/jobs`. Task UI assigns a Coworker; it does not Hire an Agent. Existing Jobs stay. Canonical Job URL is `/jobs/{jobId}` so Agent detail can be deleted later without moving Jobs again.
 
-The marketplace no longer offers **browse or Hire in the app**. Users must not discover Agents on `/agents` or start a new Job from gallery or Agent detail. **Core Hire APIs stay.** **Soko Bot (then Hermes)** still Hires via orchestrator `POST /v1/agents/{id}/jobs`. **Coworker** still Hires via `POST /v1/tasks/{id}/jobs`. Task UI assigns a Coworker; it does not Hire an Agent. Existing Jobs stay. Canonical Job URL is `/jobs/{jobId}` so Agent detail can be deleted later without moving Jobs again.
-
-**Why not delete Agent detail now:** Jobs and “your Jobs for this Agent” still hang off `/agents/{id}`. Unlisted detail + list stay this cut; removal is a later decision.
+**Why not delete Agent detail now:** Jobs and “your Jobs for this Agent” still hang off `/agents/{id}`. Removal is a later decision.
 
 **Why not a flag:** App marketplace Hire is gone, not paused.
 
-**Why Core Hire stays:** External / API clients still Hire. Soko Bot (then Hermes) and Coworker are API clients, not marketplace browse. Only the app marketplace loop ends.
+**Why Core Hire stays:** External / API clients still Hire. Soko Bot and Coworker are API clients, not marketplace Hire. Only the app marketplace Hire loop ends.
 
-**Why `GET /v1/agents` stays public:** Web catalog is removed; the list API is not. Admin Agent tools stay.
-
-**Rejected:** Killing `/agents` (Coworker gallery lives there). 404 on Agent detail this cut. Dual-rendered Job pages. New `/jobs` index. Rejecting Core Hire POSTs. Stopping Soko Bot (then Hermes) or Coworker Hire.
+**Rejected:** Killing `/agents` (Coworker gallery lives there). 404 on Agent detail this cut. Dual-rendered Job pages. New `/jobs` index. Rejecting Core Hire POSTs. Stopping Soko Bot or Coworker Hire.

--- a/docs/coworker/vendor-workspace-grants-api.md
+++ b/docs/coworker/vendor-workspace-grants-api.md
@@ -10,8 +10,8 @@ implicitly through task and job endpoints.
 > pickable in chat/tasks for humans uses `CoworkerWorkspaceAccess` instead —
 > see [`coworker-workspace-access-api.md`](./coworker-workspace-access-api.md).
 
-> **Soko Bot** does not authenticate as a coworker. Its Eve runtime receives
-> short-lived, turn-scoped grants and invokes capability-specific Core tools.
+> **Soko Bot** does not authenticate as a coworker. Its in-process Core loop
+> receives short-lived, turn-scoped grants and invokes capability tools.
 > Delegated Coworker work still follows this vendor-grant model.
 
 - **Source of truth (behavior):** `apps/core/src/helpers/access-control.ts`,

--- a/docs/wayfinder/x402-evm/MAP.md
+++ b/docs/wayfinder/x402-evm/MAP.md
@@ -44,5 +44,6 @@ implementation is a separate effort fed by its spec.
 - **Code changes in masumi-registry-service or the payment node** — external
   repos.
 - **Human-coworker task assignment** (Patrick's aside) — separate effort.
-- **End-user visibility or hireability of Bazaar agents** — PR 1 is API-only
-  by explicit product call; the catalog and hire flows do not change.
+- **End-user hireability of Bazaar agents** — PR 1 is API-only by explicit
+  product call; app Hire stays off. Catalog browse was restored (ADR-0024);
+  that does not add in-app x402 hire or pay.

--- a/docs/wayfinder/x402-evm/PR1-SPEC.md
+++ b/docs/wayfinder/x402-evm/PR1-SPEC.md
@@ -19,9 +19,10 @@ API-only pay. Anyone can **list** x402/Bazaar agents on public
 `GET /v1/agents`. A coworker assigned to a task can **pay** a 402 one of
 them returned, charged to the task's org in credits, receiving a signed
 `X-PAYMENT` header to replay with. No end-user hire flow or job row — the
-coworker calls the agent **outside** Soko. Web `/agents` stays
-Coworkers-only (SOK-805). A temporary gallery preview existed 2026-08-14
-and was disabled; x402 is not advertised there.
+coworker calls the agent **outside** Soko. Web `/agents` later restored
+Agent catalog browse (ADR-0024); app Hire stays off (SOK-805). PR 1 remains
+API-only pay. A temporary gallery preview existed 2026-08-14 and was
+disabled; x402 is not a hire flow there.
 
 Out of scope: masumi-job x402 (PR 2), direct CDP-Bazaar crawling (agents must
 be Masumi-registered), end-user hireability.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly cleanup: rewrite leftover live-rule body in ADR 0006 so it matches the post-ADR-0024 world (browse restored) instead of another pointer patch.

## Change

`docs/adr/0006-stop-agent-browse-and-app-hire.md` now states only what ADR 0024 did not restore:

- App Hire stays banned (no new Job from gallery or Agent detail)
- Core Hire APIs stay (`POST /v1/agents/{id}/jobs`, `POST /v1/tasks/{id}/jobs`)
- Canonical Job URL remains `/jobs/{jobId}`
- Agent detail stays because Jobs still hang off `/agents/{id}`

Dropped:

- “then Hermes.”
- Live browse/discovery ban (and the #4364 “follow ADR-0024” pointer line)
- Stale “web catalog is removed” / “unlisted detail” live-rule sentences

Small consistent wording elsewhere:

- `docs/wayfinder/x402-evm/MAP.md` and `PR1-SPEC.md`: catalog browse restored; app Hire still off; PR 1 stays API-only pay (SOK-805 not erased)
- `docs/coworker/vendor-workspace-grants-api.md`: “Eve runtime” → in-process Core loop / capability tools

## Out of scope

- 2026-08 wayfinder specs rewritten as if SOK-805 never happened
- PARITY.md, Apple feature journals
- Renaming `0007-soko-bot-eve-runtime.md`

## Verification

Docs-only. Pre-commit `pnpm check` and `pnpm typecheck` passed. Grep confirms ADR 0006 no longer claims browse is banned or says “then Hermes.”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cff8af3c-9e5a-433e-99dc-593b892899c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cff8af3c-9e5a-433e-99dc-593b892899c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

