### PR TITLE
fix(core): keep legacy auth ids out of the uuid soko bot mention lookup

### DIFF
--- a/apps/core/src/helpers/chat-mention-names.test.ts
+++ b/apps/core/src/helpers/chat-mention-names.test.ts
@@ -23,6 +23,8 @@ import { loadChatMentionNames } from "./chat-mention-names";
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const ADA_ID = "019fc7e4-e4bd-7005-900c-66e44d33f5e4";
 const BEN_ID = "019fc7e4-e4bd-7005-900c-66e44d33f5e5";
+/** A member who signed up before Better Auth issued uuid ids. */
+const LEGACY_AUTH_ID = "Xk3mQp7RvT2yLb9Nc4Wd8Hf6Jg1Zs5Aq";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -119,5 +121,77 @@ describe("loadChatMentionNames", () => {
     expect(names.get(ADA_ID)).toBe("Ada Lovelace");
     expect(txUserFindMany).toHaveBeenCalledTimes(1);
     expect(userMemberFindManyMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `sokoBotId` is a `uuid` column, so Postgres rejects a legacy auth id
+   * outright rather than matching nothing. That throw reaches the
+   * notification fan-out before it has written anybody a row, which costs
+   * every recipient of the message their notification.
+   */
+  it("keeps a legacy auth id out of the soko bot lookup", async () => {
+    await loadChatMentionNames({
+      roomId: ROOM_ID,
+      content: `@${LEGACY_AUTH_ID} and @${BEN_ID} please`,
+    });
+
+    expect(sokoBotMemberFindManyMock).toHaveBeenCalledWith({
+      where: { roomId: ROOM_ID, sokoBotId: { in: [BEN_ID] } },
+      select: { sokoBot: { select: { id: true, name: true } } },
+    });
+  });
+
+  it("skips the soko bot lookup when no key is a uuid", async () => {
+    await loadChatMentionNames({
+      roomId: ROOM_ID,
+      content: `@${LEGACY_AUTH_ID} please`,
+    });
+
+    expect(sokoBotMemberFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("still names a member carrying a legacy auth id", async () => {
+    userMemberFindManyMock.mockResolvedValue([
+      { user: { id: LEGACY_AUTH_ID, name: "Ada Lovelace" } },
+    ]);
+
+    const names = await loadChatMentionNames({
+      roomId: ROOM_ID,
+      content: `@${LEGACY_AUTH_ID} can you take this one`,
+    });
+
+    expect(names.get(LEGACY_AUTH_ID)).toBe("Ada Lovelace");
+    expect(userMemberFindManyMock).toHaveBeenCalledWith({
+      where: { roomId: ROOM_ID, userId: { in: [LEGACY_AUTH_ID] } },
+      select: { user: { select: { id: true, name: true } } },
+    });
+  });
+
+  /**
+   * Postgres parses a uuid with or without hyphens, and minds neither the
+   * version nibble nor the variant one. A key it would have matched must not
+   * be filtered out before it gets there.
+   *
+   * Both off-spec nibbles are exercised, so tightening the pattern to an RFC
+   * version or variant class fails here rather than passing and dropping
+   * those keys in silence.
+   */
+  it("keeps hyphenless and off-spec uuid keys in the soko bot lookup", async () => {
+    const hyphenless = "019fc7e4e4bd7005900c66e44d33f5e4";
+    // Version nibble `0` and variant nibble `c`, neither of which is RFC.
+    const offSpecNibbles = "019fc7e4-e4bd-0005-c00c-66e44d33f5e4";
+
+    await loadChatMentionNames({
+      roomId: ROOM_ID,
+      content: `@${hyphenless} @${offSpecNibbles} please`,
+    });
+
+    expect(sokoBotMemberFindManyMock).toHaveBeenCalledWith({
+      where: {
+        roomId: ROOM_ID,
+        sokoBotId: { in: [hyphenless, offSpecNibbles] },
+      },
+      select: { sokoBot: { select: { id: true, name: true } } },
+    });
   });
 });

--- a/apps/core/src/helpers/chat-mention-names.ts
+++ b/apps/core/src/helpers/chat-mention-names.ts
@@ -9,6 +9,29 @@ type MentionNameClient = Pick<
 >;
 
 /**
+ * What the `uuid` column accepts, which is what may be compared against it.
+ *
+ * `sokoBotId` is `uuid`, and a human mention key can be a legacy 32-character
+ * auth id. Postgres rejects that comparison outright rather than matching
+ * nothing, and the throw reaches the notification fan-out before it has
+ * written anybody a row, so one such key costs every recipient of the message
+ * their notification.
+ *
+ * Deliberately wider than a schema validator: hyphens are optional and the
+ * version and variant nibbles are any hex, so every shape `readChatMentionKeys`
+ * emits that the column would have matched still reaches it. A key that is hex
+ * in this shape and names no bot simply comes back empty, which is the answer
+ * it had before.
+ *
+ * Not every spelling Postgres itself parses. It also takes a hyphen after any
+ * group of four digits, and a brace-wrapped uuid, neither of which the mention
+ * token regex can produce. Widen this alongside that regex rather than ahead
+ * of it: a shape nothing writes is a shape nothing here can be tested against.
+ */
+const UUID_TEXT_REGEX =
+  /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
+
+/**
  * The display names the room shows for the members a message mentions.
  *
  * Human mentions use `@<member id>`. Existing human mentions and current
@@ -63,10 +86,14 @@ export async function loadChatMentionNames(params: {
     }
   }
 
-  const sokoBotMembers = await client.chatRoomSokoBotMember.findMany({
-    where: { roomId: params.roomId, sokoBotId: { in: keys } },
-    select: { sokoBot: { select: { id: true, name: true } } },
-  });
+  const sokoBotKeys = keys.filter((key) => UUID_TEXT_REGEX.test(key));
+  const sokoBotMembers =
+    sokoBotKeys.length === 0
+      ? []
+      : await client.chatRoomSokoBotMember.findMany({
+          where: { roomId: params.roomId, sokoBotId: { in: sokoBotKeys } },
+          select: { sokoBot: { select: { id: true, name: true } } },
+        });
   for (const member of sokoBotMembers) {
     if (member.sokoBot.name) {
       names.set(member.sokoBot.id, member.sokoBot.name);


### PR DESCRIPTION
Fixes SOK-1043.

## What broke

Chat notifications stopped arriving for several people on 2026-09-11. Mentions produced nothing, in the notification center or as an OS banner, while plain direct messages kept working.

`loadChatMentionNames` passes every mention key in a message to three member lookups. Two of them filter plain `String` columns. The third filters `ChatRoomSokoBotMember.sokoBotId`, which is a `uuid` column. A human mention key can be a legacy 32-character Better Auth id, and Postgres rejects that comparison outright rather than matching nothing.

That read sits in `fanOutChatNotifications` above the per-recipient loop, so the rejection escapes before any recipient has been written a row. The caller is a bare `waitUntil(...)`, so nothing caught it and the fan-out's own Sentry capture never ran.

Users created before 2026-04-15 carry the 32-character ids; `generateId: "uuid"` landed that day in #2851. A message with no mention token produces no keys and returns early, which is why direct messages were unaffected.

Introduced by #4406, which widened the mention token regex to accept those legacy ids. Before that, every key was a UUID or `all`, and `all` was already filtered out.

## The fix

Filter the soko bot lookup to the keys that column accepts, and skip the query when none are left.

The predicate is a regex rather than a schema validator. `z.uuid()` rejects hyphenless UUIDs and off-spec version or variant nibbles, all of which Postgres accepts, so it would have silently dropped mentions the column would have matched.

## Verification

Reproduced against a migrated local database through the real Prisma client:

```
chatRoomUserMember (userId String): OK, 0 rows
chatRoomCoworkerMember (coworkerId String): OK, 0 rows
chatRoomSokoBotMember (sokoBotId @db.Uuid): THREW PrismaClientKnownRequestError code=P2007
Invalid input value: invalid input syntax for type uuid: "Xk3mQp7RvT2yLb9Nc4Wd8Hf6Jg1Zs5Aq"
```

Every shape the predicate admits was then checked against live Postgres through the same adapter: canonical, hyphenless, uppercase hyphenless, and off-spec nibbles all query cleanly; only the legacy auth id throws.

- `pnpm --filter core test` — `5232 passed | 11 skipped (5243)`
- `pnpm typecheck` — clean
- `pnpm check` — clean

Mutation tested: with the filter removed, two of the new tests fail. With the pattern tightened to mandatory hyphens, an RFC version class, or an RFC variant class, the off-spec test fails in each case.

## Not in this PR

`fanOutChatNotifications` still awaits `loadChatMentionNames` outside the per-recipient `try/catch`. A pool error or a `P2028` on that same query reproduces this outage exactly, with no invalid id involved. The preview is decorative and should degrade to an empty name map instead of costing everyone their notification. Left alone to keep this PR to the regression.

Separately, push subscriptions are never re-activated on app open, so a subscription that dies for any reason stays dead until the reader opens Account and presses the cell. That is an acceptance criterion of SOK-876, which is marked Done, but the code is not there.
