### PR TITLE
fix(web): close the gap above and below notification rows

### DIFF
--- a/apps/web/src/app/(app)/components/header/notification-dropdown-content.tsx
+++ b/apps/web/src/app/(app)/components/header/notification-dropdown-content.tsx
@@ -195,7 +195,8 @@ export function NotificationDropdownContent({
         className="mx-2 my-2"
         onNavigate={onClose}
       />
-      <div className="-mx-1 max-h-96 overflow-y-auto">
+      {/* Pulled onto the separators, so the first and last row tint edge to edge. */}
+      <div className="-mx-1 -my-1 max-h-96 overflow-y-auto">
         {notifications.map((notification) => (
           <NotificationItem
             key={notification.id}


### PR DESCRIPTION
## Summary

Follow-up to #4426. In the bell dropdown, the separators above and below the list carry a 4px vertical margin, so the first row's tint started 4px under the header line and the last row's stopped 4px above the footer line. The list now sits on both separators, so the first and last row tint edge to edge like the rows between them.

One class change: `-my-1` on the list container.

## Verification

- `pnpm --filter web test src/app/(app)/components/header`
- `pnpm check`, `pnpm typecheck` (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)