### PR TITLE
feat(web): move create/edit task status to footer pill (SOK-1047)

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
@@ -795,7 +795,7 @@ describe("TaskForm", () => {
     );
   });
 
-  it("enables Queued whenever a schedule is set, including for human assignees", async () => {
+  it("disables Queued for human assignees even when a schedule is set (SOK-1033)", async () => {
     const user = userEvent.setup();
 
     render(
@@ -820,13 +820,53 @@ describe("TaskForm", () => {
     await user.click(screen.getByRole("button", { name: "Set schedule" }));
     await user.click(screen.getByRole("button", { name: "save" }));
 
+    expect(screen.getByRole("combobox", { name: "Status" })).toHaveTextContent(
+      "Ready",
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Status" }));
+    expect(screen.getByRole("option", { name: "Queued" })).toHaveAttribute(
+      "data-disabled",
+    );
+  });
+
+  it("enables Queued on edit for an agent Ready task with an active schedule", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskForm
+        mode="edit"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={coworkerOptions}
+        taskId="task-1"
+        initialValues={{
+          name: "Daily sync",
+          description: "Run the sync",
+          assigneeId: "coworker-2",
+          status: TaskStatus.READY,
+          metadata: JSON.stringify({
+            version: 1,
+            mode: "once",
+            scheduledAt: "2026-06-26T09:00:00.000Z",
+            runAt: "2026-06-26T09:00:00.000Z",
+          }),
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "Status" })).toHaveTextContent(
+      "Ready",
+    );
+
     await user.click(screen.getByRole("combobox", { name: "Status" }));
     expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
       "data-disabled",
     );
   });
 
-  it("enables Queued on edit when Ready with an active schedule", async () => {
+  it("disables Queued on edit for a human Ready task with an active schedule", async () => {
     const user = userEvent.setup();
 
     render(
@@ -860,12 +900,8 @@ describe("TaskForm", () => {
       />,
     );
 
-    expect(screen.getByRole("combobox", { name: "Status" })).toHaveTextContent(
-      "Ready",
-    );
-
     await user.click(screen.getByRole("combobox", { name: "Status" }));
-    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
+    expect(screen.getByRole("option", { name: "Queued" })).toHaveAttribute(
       "data-disabled",
     );
   });

--- a/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
@@ -488,12 +488,17 @@ describe("TaskForm", () => {
     );
 
     expect(screen.queryByText("Pick status")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("label", { name: "Status" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryAllByText("Status", { selector: "label" })).toHaveLength(
+      0,
+    );
 
     const statusControl = screen.getByRole("combobox", { name: "Status" });
     expect(statusControl).toHaveTextContent("Draft");
+    expect(
+      screen.getByTestId("markdown-editor").compareDocumentPosition(
+        statusControl,
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(
       statusControl.compareDocumentPosition(
         screen.getByRole("button", { name: "Set schedule" }),
@@ -530,6 +535,23 @@ describe("TaskForm", () => {
       statusControl.compareDocumentPosition(scheduleLabel) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("hides status on the assignee wizard step", () => {
+    render(
+      <TaskForm
+        mode="create"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={coworkerOptions}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("markdown-editor")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: "Status" }),
+    ).not.toBeInTheDocument();
   });
 
   it("defaults status to Ready when selecting a coworker", async () => {

--- a/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
@@ -475,7 +475,7 @@ describe("TaskForm", () => {
     expect(createTaskMock).not.toHaveBeenCalled();
   });
 
-  it("shows the status dropdown defaulting to Draft on create", () => {
+  it("shows the footer status pill defaulting to Draft on create", () => {
     render(
       <TaskForm
         mode="create"
@@ -487,15 +487,49 @@ describe("TaskForm", () => {
       />,
     );
 
-    expect(screen.getByRole("combobox", { name: "Status" })).toHaveTextContent(
-      "Draft",
-    );
+    expect(screen.queryByText("Pick status")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("label", { name: "Status" }),
+    ).not.toBeInTheDocument();
+
+    const statusControl = screen.getByRole("combobox", { name: "Status" });
+    expect(statusControl).toHaveTextContent("Draft");
+    expect(
+      statusControl.compareDocumentPosition(
+        screen.getByRole("button", { name: "Set schedule" }),
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: "Save as Draft" }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Mark as Ready" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("places the status pill before the schedule label in the footer", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskForm
+        mode="create"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={coworkerOptions}
+        initialValues={{ assigneeId: "coworker-2" }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Set schedule" }));
+    await user.click(screen.getByRole("button", { name: "save" }));
+
+    const statusControl = screen.getByRole("combobox", { name: "Status" });
+    const scheduleLabel = screen.getByText("footer.oneTimeAt");
+    expect(
+      statusControl.compareDocumentPosition(scheduleLabel) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("defaults status to Ready when selecting a coworker", async () => {

--- a/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
@@ -495,9 +495,10 @@ describe("TaskForm", () => {
     const statusControl = screen.getByRole("combobox", { name: "Status" });
     expect(statusControl).toHaveTextContent("Draft");
     expect(
-      screen.getByTestId("markdown-editor").compareDocumentPosition(
-        statusControl,
-      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+      screen
+        .getByTestId("markdown-editor")
+        .compareDocumentPosition(statusControl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
       statusControl.compareDocumentPosition(

--- a/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
@@ -795,7 +795,7 @@ describe("TaskForm", () => {
     );
   });
 
-  it("disables Queued for a human assignee even with a schedule (SOK-1033)", async () => {
+  it("enables Queued whenever a schedule is set, including for human assignees", async () => {
     const user = userEvent.setup();
 
     render(
@@ -821,7 +821,51 @@ describe("TaskForm", () => {
     await user.click(screen.getByRole("button", { name: "save" }));
 
     await user.click(screen.getByRole("combobox", { name: "Status" }));
-    expect(screen.getByRole("option", { name: "Queued" })).toHaveAttribute(
+    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
+      "data-disabled",
+    );
+  });
+
+  it("enables Queued on edit when Ready with an active schedule", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskForm
+        mode="edit"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={[
+          ...coworkerOptions,
+          mockCoworkerOption({
+            id: "user-1",
+            slug: "bob",
+            name: "Bob",
+            kind: "user",
+          }),
+        ]}
+        taskId="task-1"
+        initialValues={{
+          name: "Daily sync",
+          description: "Run the sync",
+          assigneeUserId: "user-1",
+          status: TaskStatus.READY,
+          metadata: JSON.stringify({
+            version: 1,
+            mode: "once",
+            scheduledAt: "2026-06-26T09:00:00.000Z",
+            runAt: "2026-06-26T09:00:00.000Z",
+          }),
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "Status" })).toHaveTextContent(
+      "Ready",
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Status" }));
+    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
       "data-disabled",
     );
   });

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -167,8 +167,11 @@ function isAgentAssigneeFields(fields: {
   return fields.assigneeId !== null || fields.assigneeSokoBotId !== null;
 }
 
-function canSelectQueued(options: { hasSchedule: boolean }): boolean {
-  return options.hasSchedule;
+function canSelectQueued(options: {
+  hasSchedule: boolean;
+  isAgent: boolean;
+}): boolean {
+  return options.hasSchedule && options.isAgent;
 }
 
 function resolveStatusForAssigneeAndSchedule(options: {
@@ -491,7 +494,10 @@ export function TaskForm({
         !statusTouchedRef.current ||
         assigneeKindChanged ||
         (status === TaskStatus.QUEUED &&
-          !canSelectQueued({ hasSchedule: nextHasSchedule }));
+          !canSelectQueued({
+            isAgent,
+            hasSchedule: nextHasSchedule,
+          }));
       if (shouldResolveStatus) {
         setStatus(
           resolveStatusForAssigneeAndSchedule({
@@ -893,6 +899,7 @@ export function TaskForm({
     selectedAssigneeFields.assigneeId !== null ||
     selectedAssigneeFields.assigneeSokoBotId !== null;
   const isQueuedSelectable = canSelectQueued({
+    isAgent: isAgentAssignee,
     hasSchedule,
   });
   const isSchedulableAssignee =

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -167,11 +167,8 @@ function isAgentAssigneeFields(fields: {
   return fields.assigneeId !== null || fields.assigneeSokoBotId !== null;
 }
 
-function canSelectQueued(options: {
-  isAgent: boolean;
-  hasSchedule: boolean;
-}): boolean {
-  return options.hasSchedule && options.isAgent;
+function canSelectQueued(options: { hasSchedule: boolean }): boolean {
+  return options.hasSchedule;
 }
 
 function resolveStatusForAssigneeAndSchedule(options: {
@@ -191,6 +188,10 @@ function resolveCelebrationStatus(options: {
 }): "DRAFT" | "QUEUED" | "READY" {
   if (options.desiredStatus === TaskStatus.DRAFT) {
     return "DRAFT";
+  }
+  // Honor an explicit Queued create when the action succeeded (Core accepted).
+  if (options.desiredStatus === TaskStatus.QUEUED) {
+    return "QUEUED";
   }
   if (options.hasSchedule) {
     return options.isAgent ? "QUEUED" : "READY";
@@ -490,7 +491,7 @@ export function TaskForm({
         !statusTouchedRef.current ||
         assigneeKindChanged ||
         (status === TaskStatus.QUEUED &&
-          !canSelectQueued({ isAgent, hasSchedule: nextHasSchedule }));
+          !canSelectQueued({ hasSchedule: nextHasSchedule }));
       if (shouldResolveStatus) {
         setStatus(
           resolveStatusForAssigneeAndSchedule({
@@ -892,7 +893,6 @@ export function TaskForm({
     selectedAssigneeFields.assigneeId !== null ||
     selectedAssigneeFields.assigneeSokoBotId !== null;
   const isQueuedSelectable = canSelectQueued({
-    isAgent: isAgentAssignee,
     hasSchedule,
   });
   const isSchedulableAssignee =

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -80,6 +80,7 @@ import { TaskCreatedCelebration } from "./task-created-celebration";
 import { TaskFormModalHeaderStart } from "./task-form-modal";
 import { TaskProjectSelect } from "./task-project-select";
 import { TaskScheduleModal } from "./task-schedule-modal";
+import { TaskStatusPillSelectTrigger } from "./task-status-pill-select-trigger";
 
 const EMPTY_AGENT_NAME_MAP = new Map<string, string>();
 
@@ -1193,40 +1194,6 @@ export function TaskForm({
                 </div>
               ) : null}
 
-              <div className="space-y-2">
-                <Label htmlFor="task-status">{labels.status}</Label>
-                <Select
-                  value={status}
-                  onValueChange={(value) =>
-                    handleStatusSelect(value as TaskStatus)
-                  }
-                >
-                  <SelectTrigger id="task-status" className="w-full">
-                    <SelectValue>
-                      {getTaskFormStatusLabel(status, labels)}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {statusOptions.map((option) => (
-                      <SelectItem
-                        key={option}
-                        value={option}
-                        disabled={
-                          option === TaskStatus.QUEUED && !isQueuedSelectable
-                        }
-                      >
-                        {getTaskFormStatusLabel(option, labels)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {labels.statusDescription ? (
-                  <p className="text-muted-foreground text-xs">
-                    {labels.statusDescription}
-                  </p>
-                ) : null}
-              </div>
-
               {shouldShowProjectSelect ? (
                 <div className="space-y-2">
                   <Label>{labels.projectLabel}</Label>
@@ -1362,12 +1329,39 @@ export function TaskForm({
 
         {showTaskStep ? (
           <div className="flex shrink-0 flex-col items-stretch justify-between gap-3 border-t px-6 py-3 sm:flex-row sm:items-center md:px-8">
-            {hasSchedule && scheduleLabel && ScheduleFooterIcon ? (
-              <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
-                <ScheduleFooterIcon className="size-4 shrink-0" aria-hidden />
-                <span className="truncate">{scheduleLabel}</span>
-              </div>
-            ) : null}
+            <div className="flex min-w-0 items-center gap-2">
+              <Select
+                value={status}
+                onValueChange={(value) =>
+                  handleStatusSelect(value as TaskStatus)
+                }
+              >
+                <TaskStatusPillSelectTrigger
+                  status={status}
+                  label={getTaskFormStatusLabel(status, labels)}
+                  ariaLabel={labels.status}
+                />
+                <SelectContent>
+                  {statusOptions.map((option) => (
+                    <SelectItem
+                      key={option}
+                      value={option}
+                      disabled={
+                        option === TaskStatus.QUEUED && !isQueuedSelectable
+                      }
+                    >
+                      {getTaskFormStatusLabel(option, labels)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {hasSchedule && scheduleLabel && ScheduleFooterIcon ? (
+                <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
+                  <ScheduleFooterIcon className="size-4 shrink-0" aria-hidden />
+                  <span className="truncate">{scheduleLabel}</span>
+                </div>
+              ) : null}
+            </div>
             <div className="flex items-center gap-3 sm:ml-auto">
               <Button
                 type="button"

--- a/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
@@ -1,26 +1,18 @@
 "use client";
 
 import { userTaskStatusTransitionRequiresComment } from "@sokosumi/utils";
-import { ChevronDown, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 
 import { useGlobalModalsContext } from "@/components/modals/global-modals-context";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Select, SelectContent, SelectItem } from "@/components/ui/select";
 import { setTaskStatusFromDrag } from "@/lib/actions/task/action";
 import { TaskStatus } from "@/lib/clients/generated/core";
-import { cn } from "@/lib/utils";
 import { getManualTaskStatusSelectOptions } from "@/lib/utils/task-status-order";
 
 import { TaskReopenToReadyDialog } from "./task-reopen-to-ready-dialog";
-import { getTaskStatusPillTone } from "./task-status-badge";
+import { TaskStatusPillSelectTrigger } from "./task-status-pill-select-trigger";
 
 export interface TaskMetadataStatusFieldLabels {
   statusLabels: Record<TaskStatus, string>;
@@ -122,7 +114,6 @@ export function TaskMetadataStatusField({
   const displayStatus =
     isPending && pendingStatus ? pendingStatus : currentStatus;
   const displayLabel = labels.statusLabels[displayStatus];
-  const pillTone = getTaskStatusPillTone(displayStatus);
 
   return (
     <>
@@ -131,31 +122,12 @@ export function TaskMetadataStatusField({
         onValueChange={(value) => handleStatusSelect(value as TaskStatus)}
         disabled={isPending}
       >
-        <SelectTrigger
-          aria-label={displayLabel}
-          className={cn(
-            "h-auto w-auto gap-0 rounded-sm border-0 bg-transparent p-0 shadow-none",
-            "dark:bg-transparent dark:hover:bg-transparent",
-            "data-[size=default]:h-auto",
-            "[&>svg]:hidden",
-          )}
-        >
-          <SelectValue>
-            <span
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs font-medium",
-                pillTone.bg,
-                pillTone.text,
-              )}
-            >
-              {isPending ? (
-                <Loader2 className="size-3 animate-spin" aria-hidden />
-              ) : null}
-              <span>{displayLabel}</span>
-              <ChevronDown className="size-3 opacity-70" aria-hidden />
-            </span>
-          </SelectValue>
-        </SelectTrigger>
+        <TaskStatusPillSelectTrigger
+          status={displayStatus}
+          label={displayLabel}
+          ariaLabel={displayLabel}
+          isPending={isPending}
+        />
         <SelectContent align="end">
           {getManualTaskStatusSelectOptions(displayStatus).map((option) => (
             <SelectItem

--- a/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
@@ -31,17 +31,22 @@ interface TaskMetadataStatusFieldProps {
   taskId: string;
   status: TaskStatus;
   hasSchedule: boolean;
+  isAgentAssignee: boolean;
   labels: TaskMetadataStatusFieldLabels;
 }
 
-function canSelectQueued(options: { hasSchedule: boolean }): boolean {
-  return options.hasSchedule;
+function canSelectQueued(options: {
+  hasSchedule: boolean;
+  isAgentAssignee: boolean;
+}): boolean {
+  return options.hasSchedule && options.isAgentAssignee;
 }
 
 export function TaskMetadataStatusField({
   taskId,
   status,
   hasSchedule,
+  isAgentAssignee,
   labels,
 }: TaskMetadataStatusFieldProps) {
   const router = useRouter();
@@ -51,7 +56,7 @@ export function TaskMetadataStatusField({
   const [pendingStatus, setPendingStatus] = useState<TaskStatus | null>(null);
   const [isReopenDialogOpen, setIsReopenDialogOpen] = useState(false);
   const [reopenComment, setReopenComment] = useState("");
-  const isQueuedSelectable = canSelectQueued({ hasSchedule });
+  const isQueuedSelectable = canSelectQueued({ hasSchedule, isAgentAssignee });
 
   function applyStatusChange(desiredStatus: TaskStatus, comment?: string) {
     const previousStatus = currentStatus;

--- a/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
@@ -31,22 +31,17 @@ interface TaskMetadataStatusFieldProps {
   taskId: string;
   status: TaskStatus;
   hasSchedule: boolean;
-  isAgentAssignee: boolean;
   labels: TaskMetadataStatusFieldLabels;
 }
 
-function canSelectQueued(options: {
-  hasSchedule: boolean;
-  isAgentAssignee: boolean;
-}): boolean {
-  return options.hasSchedule && options.isAgentAssignee;
+function canSelectQueued(options: { hasSchedule: boolean }): boolean {
+  return options.hasSchedule;
 }
 
 export function TaskMetadataStatusField({
   taskId,
   status,
   hasSchedule,
-  isAgentAssignee,
   labels,
 }: TaskMetadataStatusFieldProps) {
   const router = useRouter();
@@ -56,7 +51,7 @@ export function TaskMetadataStatusField({
   const [pendingStatus, setPendingStatus] = useState<TaskStatus | null>(null);
   const [isReopenDialogOpen, setIsReopenDialogOpen] = useState(false);
   const [reopenComment, setReopenComment] = useState("");
-  const isQueuedSelectable = canSelectQueued({ hasSchedule, isAgentAssignee });
+  const isQueuedSelectable = canSelectQueued({ hasSchedule });
 
   function applyStatusChange(desiredStatus: TaskStatus, comment?: string) {
     const previousStatus = currentStatus;

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
@@ -485,6 +485,7 @@ describe("TaskMetadata", () => {
               id: "coworker-1",
               name: "Elena",
               image: null,
+              slug: "elena",
             },
           },
         }),

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
@@ -24,6 +24,10 @@ vi.mock("@/components/modals/global-modals-context", () => ({
   }),
 }));
 
+vi.mock("@/components/task-schedule-display", () => ({
+  TaskScheduleDisplay: () => <span>Daily (1:47 PM)</span>,
+}));
+
 vi.mock("@/components/aurora-orb", () => ({
   AssistantOrb: ({ seed, alt }: { seed: string | null; alt?: string }) => (
     <div data-testid="assistant-orb" data-seed={seed ?? ""} aria-label={alt} />
@@ -451,6 +455,54 @@ describe("TaskMetadata", () => {
 
     await user.click(screen.getByRole("combobox", { name: "Draft" }));
     expect(screen.getByRole("option", { name: "Queued" })).toHaveAttribute(
+      "data-disabled",
+    );
+  });
+
+  it("enables Queued when the task has an active schedule", async () => {
+    const user = userEvent.setup();
+    const statusLabels = Object.fromEntries(
+      TASK_STATUS_DISPLAY_ORDER.map((status) => [
+        status,
+        status === TaskStatus.DRAFT
+          ? "Draft"
+          : status === TaskStatus.QUEUED
+            ? "Queued"
+            : status === TaskStatus.READY
+              ? "Ready"
+              : status,
+      ]),
+    ) as Record<(typeof TaskStatus)[keyof typeof TaskStatus], string>;
+
+    renderTaskMetadata({
+      task: {
+        ...createTask({
+          status: TaskStatus.READY,
+          assignee: {
+            type: "user",
+            id: "user-1",
+            user: {
+              id: "user-1",
+              name: "Bob",
+              image: null,
+            },
+          },
+        }),
+        metadata: JSON.stringify({
+          version: 1,
+          mode: "recurring",
+          expr: "47 13 * * *",
+          timezone: "UTC",
+          endsMode: "never",
+        }),
+      },
+      editable: true,
+      labels: { ...baseLabels, statusLabels },
+      statusFieldLabels: { ...baseStatusFieldLabels, statusLabels },
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Ready" }));
+    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
       "data-disabled",
     );
   });

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
@@ -459,7 +459,55 @@ describe("TaskMetadata", () => {
     );
   });
 
-  it("enables Queued when the task has an active schedule", async () => {
+  it("enables Queued when an agent task has an active schedule", async () => {
+    const user = userEvent.setup();
+    const statusLabels = Object.fromEntries(
+      TASK_STATUS_DISPLAY_ORDER.map((status) => [
+        status,
+        status === TaskStatus.DRAFT
+          ? "Draft"
+          : status === TaskStatus.QUEUED
+            ? "Queued"
+            : status === TaskStatus.READY
+              ? "Ready"
+              : status,
+      ]),
+    ) as Record<(typeof TaskStatus)[keyof typeof TaskStatus], string>;
+
+    renderTaskMetadata({
+      task: {
+        ...createTask({
+          status: TaskStatus.READY,
+          assignee: {
+            type: "coworker",
+            id: "coworker-1",
+            coworker: {
+              id: "coworker-1",
+              name: "Elena",
+              image: null,
+            },
+          },
+        }),
+        metadata: JSON.stringify({
+          version: 1,
+          mode: "recurring",
+          expr: "47 13 * * *",
+          timezone: "UTC",
+          endsMode: "never",
+        }),
+      },
+      editable: true,
+      labels: { ...baseLabels, statusLabels },
+      statusFieldLabels: { ...baseStatusFieldLabels, statusLabels },
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Ready" }));
+    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
+      "data-disabled",
+    );
+  });
+
+  it("disables Queued for a human task even with an active schedule", async () => {
     const user = userEvent.setup();
     const statusLabels = Object.fromEntries(
       TASK_STATUS_DISPLAY_ORDER.map((status) => [
@@ -502,7 +550,7 @@ describe("TaskMetadata", () => {
     });
 
     await user.click(screen.getByRole("combobox", { name: "Ready" }));
-    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
+    expect(screen.getByRole("option", { name: "Queued" })).toHaveAttribute(
       "data-disabled",
     );
   });

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -193,6 +193,8 @@ export function TaskMetadata({
   );
   const creator = resolveTaskCreatorDisplay(task, labels);
   const hasSchedule = hasActiveTaskSchedule(task.metadata, task.nextRunAt);
+  const isAgentAssignee =
+    task.assignee?.type === "coworker" || task.assignee?.type === "sokoBot";
 
   return (
     <section className="space-y-3">
@@ -205,6 +207,7 @@ export function TaskMetadata({
             taskId={taskId}
             status={task.status}
             hasSchedule={hasSchedule}
+            isAgentAssignee={isAgentAssignee}
             labels={statusFieldLabels}
           />
         ) : (

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -193,8 +193,6 @@ export function TaskMetadata({
   );
   const creator = resolveTaskCreatorDisplay(task, labels);
   const hasSchedule = hasActiveTaskSchedule(task.metadata, task.nextRunAt);
-  const isAgentAssignee =
-    task.assignee?.type === "coworker" || task.assignee?.type === "sokoBot";
 
   return (
     <section className="space-y-3">
@@ -207,7 +205,6 @@ export function TaskMetadata({
             taskId={taskId}
             status={task.status}
             hasSchedule={hasSchedule}
-            isAgentAssignee={isAgentAssignee}
             labels={statusFieldLabels}
           />
         ) : (

--- a/apps/web/src/app/(app)/tasks/components/task-status-pill-select-trigger.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-status-pill-select-trigger.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { ChevronDown, Loader2 } from "lucide-react";
+
+import { SelectTrigger, SelectValue } from "@/components/ui/select";
+import { TaskStatus } from "@/lib/clients/generated/core";
+import { cn } from "@/lib/utils";
+
+import { getTaskStatusPillTone } from "./task-status-badge";
+
+interface TaskStatusPillSelectTriggerProps {
+  status: TaskStatus;
+  label: string;
+  ariaLabel: string;
+  isPending?: boolean;
+}
+
+export function TaskStatusPillSelectTrigger({
+  status,
+  label,
+  ariaLabel,
+  isPending = false,
+}: TaskStatusPillSelectTriggerProps) {
+  const pillTone = getTaskStatusPillTone(status);
+
+  return (
+    <SelectTrigger
+      aria-label={ariaLabel}
+      className={cn(
+        "h-auto w-auto gap-0 rounded-sm border-0 bg-transparent p-0 shadow-none",
+        "dark:bg-transparent dark:hover:bg-transparent",
+        "data-[size=default]:h-auto",
+        "[&>svg]:hidden",
+      )}
+    >
+      <SelectValue>
+        <span
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs font-medium",
+            pillTone.bg,
+            pillTone.text,
+          )}
+        >
+          {isPending ? (
+            <Loader2 className="size-3 animate-spin" aria-hidden />
+          ) : null}
+          <span>{label}</span>
+          <ChevronDown className="size-3 opacity-70" aria-hidden />
+        </span>
+      </SelectValue>
+    </SelectTrigger>
+  );
+}

--- a/apps/web/src/lib/actions/task/action.test.ts
+++ b/apps/web/src/lib/actions/task/action.test.ts
@@ -774,6 +774,34 @@ describe("updateTask schedule status", () => {
     expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
   });
 
+  it("emits Queued after adding a schedule when Queued was requested but schedule left Ready", async () => {
+    taskScheduleServiceMock.setSchedule.mockResolvedValue({
+      id: "task-1",
+      status: TaskStatus.READY,
+    });
+
+    const { updateTask } = await import("./action");
+
+    await updateTask({
+      taskId: "task-1",
+      name: "Task",
+      description: "Do work",
+      assigneeId: null,
+      assigneeSokoBotId: null,
+      assigneeUserId: "user-1",
+      currentStatus: TaskStatus.READY,
+      desiredStatus: TaskStatus.QUEUED,
+      hadSchedule: false,
+      originalSchedule: { mode: "none", timezone: "UTC" },
+      schedule: recurringSchedule,
+    });
+
+    expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).toHaveBeenCalledWith("task-1", {
+      status: TaskStatus.QUEUED,
+    });
+  });
+
   it("applies an explicit draft/ready toggle when the schedule is unchanged", async () => {
     const { updateTask } = await import("./action");
 
@@ -1003,8 +1031,11 @@ describe("createTask schedule", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     taskServiceMock.createTask.mockReset();
+    taskServiceMock.createTaskEvent.mockReset();
+    taskServiceMock.deleteTask.mockReset();
     taskScheduleServiceMock.clearSchedule.mockReset();
     taskScheduleServiceMock.setSchedule.mockReset();
+    taskServiceMock.createTaskEvent.mockResolvedValue({});
   });
 
   it("does not apply a schedule when saving as draft", async () => {
@@ -1074,6 +1105,62 @@ describe("createTask schedule", () => {
       expect.objectContaining({ status: TaskStatus.DRAFT }),
     );
     expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
+  });
+
+  it("emits Queued after schedule apply when create requested Queued but schedule left Ready", async () => {
+    taskServiceMock.createTask.mockResolvedValue(
+      buildTask({ status: TaskStatus.DRAFT }),
+    );
+    taskScheduleServiceMock.setSchedule.mockResolvedValue({
+      id: "task-created",
+      status: TaskStatus.READY,
+    });
+
+    const { createTask } = await import("./action");
+
+    await createTask({
+      description: "Human scheduled queued task",
+      assigneeId: null,
+      assigneeSokoBotId: null,
+      assigneeUserId: "user-1",
+      status: TaskStatus.QUEUED,
+      schedule: recurringSchedule,
+    });
+
+    expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).toHaveBeenCalledWith(
+      "task-created",
+      { status: TaskStatus.QUEUED },
+    );
+  });
+
+  it("archives the created task when the post-schedule Queued event fails", async () => {
+    taskServiceMock.createTask.mockResolvedValue(
+      buildTask({ status: TaskStatus.DRAFT }),
+    );
+    taskScheduleServiceMock.setSchedule.mockResolvedValue({
+      id: "task-created",
+      status: TaskStatus.READY,
+    });
+    taskServiceMock.createTaskEvent.mockRejectedValue(
+      new Error("Queued requires an agent assignee"),
+    );
+
+    const { createTask } = await import("./action");
+
+    await expect(
+      createTask({
+        description: "Human scheduled queued task",
+        assigneeId: null,
+        assigneeSokoBotId: null,
+        assigneeUserId: "user-1",
+        status: TaskStatus.QUEUED,
+        schedule: recurringSchedule,
+      }),
+    ).rejects.toThrow(/Queued requires an agent assignee|Failed to create/);
+
+    expect(taskServiceMock.deleteTask).toHaveBeenCalledWith("task-created");
   });
 
   it("returns a client-upgrade outcome for the exact Calendar 426 error", async () => {

--- a/apps/web/src/lib/actions/task/action.test.ts
+++ b/apps/web/src/lib/actions/task/action.test.ts
@@ -774,7 +774,7 @@ describe("updateTask schedule status", () => {
     expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
   });
 
-  it("emits Queued after adding a schedule when Queued was requested but schedule left Ready", async () => {
+  it("does not force Queued when a human schedule lands Ready (save must succeed)", async () => {
     taskScheduleServiceMock.setSchedule.mockResolvedValue({
       id: "task-1",
       status: TaskStatus.READY,
@@ -789,6 +789,32 @@ describe("updateTask schedule status", () => {
       assigneeId: null,
       assigneeSokoBotId: null,
       assigneeUserId: "user-1",
+      currentStatus: TaskStatus.READY,
+      desiredStatus: TaskStatus.QUEUED,
+      hadSchedule: false,
+      originalSchedule: { mode: "none", timezone: "UTC" },
+      schedule: recurringSchedule,
+    });
+
+    expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
+  });
+
+  it("emits Queued after schedule when an agent requested Queued but schedule left Ready", async () => {
+    taskScheduleServiceMock.setSchedule.mockResolvedValue({
+      id: "task-1",
+      status: TaskStatus.READY,
+    });
+
+    const { updateTask } = await import("./action");
+
+    await updateTask({
+      taskId: "task-1",
+      name: "Task",
+      description: "Do work",
+      assigneeId: "coworker-1",
+      assigneeSokoBotId: null,
+      assigneeUserId: null,
       currentStatus: TaskStatus.READY,
       desiredStatus: TaskStatus.QUEUED,
       hadSchedule: false,
@@ -1108,7 +1134,7 @@ describe("createTask schedule", () => {
     expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
   });
 
-  it("emits Queued after schedule apply when create requested Queued but schedule left Ready", async () => {
+  it("saves a human Queued+schedule create without forcing a Queued event", async () => {
     taskServiceMock.createTask.mockResolvedValue(
       buildTask({ status: TaskStatus.DRAFT }),
     );
@@ -1129,13 +1155,38 @@ describe("createTask schedule", () => {
     });
 
     expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
+    expect(taskServiceMock.deleteTask).not.toHaveBeenCalled();
+  });
+
+  it("emits Queued after create schedule when an agent requested Queued but schedule left Ready", async () => {
+    taskServiceMock.createTask.mockResolvedValue(
+      buildTask({ status: TaskStatus.DRAFT }),
+    );
+    taskScheduleServiceMock.setSchedule.mockResolvedValue({
+      id: "task-created",
+      status: TaskStatus.READY,
+    });
+
+    const { createTask } = await import("./action");
+
+    await createTask({
+      description: "Agent scheduled queued task",
+      assigneeId: "coworker-1",
+      assigneeSokoBotId: null,
+      assigneeUserId: null,
+      status: TaskStatus.QUEUED,
+      schedule: recurringSchedule,
+    });
+
+    expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
     expect(taskServiceMock.createTaskEvent).toHaveBeenCalledWith(
       "task-created",
       { status: TaskStatus.QUEUED },
     );
   });
 
-  it("archives the created task when the post-schedule Queued event fails", async () => {
+  it("archives the created task when a post-schedule agent Queued event fails", async () => {
     taskServiceMock.createTask.mockResolvedValue(
       buildTask({ status: TaskStatus.DRAFT }),
     );
@@ -1144,21 +1195,21 @@ describe("createTask schedule", () => {
       status: TaskStatus.READY,
     });
     taskServiceMock.createTaskEvent.mockRejectedValue(
-      new Error("Queued requires an agent assignee"),
+      new Error("A schedule is required before moving a task to Queued"),
     );
 
     const { createTask } = await import("./action");
 
     await expect(
       createTask({
-        description: "Human scheduled queued task",
-        assigneeId: null,
+        description: "Agent scheduled queued task",
+        assigneeId: "coworker-1",
         assigneeSokoBotId: null,
-        assigneeUserId: "user-1",
+        assigneeUserId: null,
         status: TaskStatus.QUEUED,
         schedule: recurringSchedule,
       }),
-    ).rejects.toThrow(/Queued requires an agent assignee|Failed to create/);
+    ).rejects.toThrow(/schedule is required|Failed to create/);
 
     expect(taskServiceMock.deleteTask).toHaveBeenCalledWith("task-created");
   });

--- a/apps/web/src/lib/actions/task/action.ts
+++ b/apps/web/src/lib/actions/task/action.ts
@@ -251,12 +251,14 @@ function resolveUpdateTargetStatus(
   statusAfterSchedule: TaskStatus,
   scheduleWasMutated: boolean,
   scheduleActiveOnServer: boolean,
+  isAgentAssignee: boolean,
 ): TaskStatus {
   if (scheduleWasMutated) {
     if (scheduleActiveOnServer) {
-      // Schedule apply may land Ready (e.g. human assignee). Honor an
-      // explicit Queued choice so Core can accept or reject it.
+      // Schedule apply may land Ready. For agents, honor an explicit Queued
+      // choice with a follow-up event. Humans stay on the schedule result.
       if (
+        isAgentAssignee &&
         desiredStatus === TaskStatus.QUEUED &&
         statusAfterSchedule !== TaskStatus.QUEUED
       ) {
@@ -448,13 +450,17 @@ async function createTaskFromDescription(input: {
     ? toCoreTaskContext(input.context, input.userId)
     : undefined;
 
+  const assigneeWrite = resolveAssigneeWrite(
+    input.assigneeId,
+    input.assigneeSokoBotId,
+    input.assigneeUserId,
+  );
+  const isAgentAssignee =
+    assigneeWrite.assigneeId != null || assigneeWrite.assigneeSokoBotId != null;
+
   const task = await taskService.createTask({
     description: trimmedDescription,
-    ...resolveAssigneeWrite(
-      input.assigneeId,
-      input.assigneeSokoBotId,
-      input.assigneeUserId,
-    ),
+    ...assigneeWrite,
     projectId: normalizedProjectId ?? null,
     ...(context ? { context } : {}),
     status: resolveCreateStatus(input.status, input.schedule),
@@ -471,11 +477,10 @@ async function createTaskFromDescription(input: {
         input.schedule,
         false,
       );
-      // Create always goes Draft → schedule. Schedule apply may leave the
-      // task Ready (human assignee). Carry an explicit Queued choice through
-      // so Core accepts it for agents or rejects it for humans instead of
-      // silently succeeding as Ready.
+      // Create always goes Draft → schedule. Agents that asked for Queued but
+      // landed Ready need a follow-up event. Humans keep Ready and save.
       if (
+        isAgentAssignee &&
         input.status === TaskStatus.QUEUED &&
         statusAfterSchedule != null &&
         statusAfterSchedule !== TaskStatus.QUEUED
@@ -790,10 +795,15 @@ export const updateTask = withSession<UpdateTaskParameters, UpdateTaskResult>(
     try {
       const normalizedProjectId = normalizeOptionalProjectId(projectId);
 
+      const assigneeWrite = resolveAssigneeWrite(
+        assigneeId,
+        assigneeSokoBotId,
+        assigneeUserId,
+      );
       await taskService.patchTask(taskId, {
         name: trimmedName,
         description: trimmedDescription,
-        ...resolveAssigneeWrite(assigneeId, assigneeSokoBotId, assigneeUserId),
+        ...assigneeWrite,
         ...(typeof normalizedProjectId !== "undefined"
           ? { projectId: normalizedProjectId }
           : {}),
@@ -844,11 +854,15 @@ export const updateTask = withSession<UpdateTaskParameters, UpdateTaskResult>(
         scheduleActiveOnServer = schedule.mode !== "none";
       }
 
+      const isAgentAssignee =
+        assigneeWrite.assigneeId != null ||
+        assigneeWrite.assigneeSokoBotId != null;
       const targetStatus = resolveUpdateTargetStatus(
         desiredStatus,
         statusAfterSchedule,
         scheduleWasMutated,
         scheduleActiveOnServer,
+        isAgentAssignee,
       );
 
       if (targetStatus !== statusAfterSchedule) {

--- a/apps/web/src/lib/actions/task/action.ts
+++ b/apps/web/src/lib/actions/task/action.ts
@@ -254,6 +254,14 @@ function resolveUpdateTargetStatus(
 ): TaskStatus {
   if (scheduleWasMutated) {
     if (scheduleActiveOnServer) {
+      // Schedule apply may land Ready (e.g. human assignee). Honor an
+      // explicit Queued choice so Core can accept or reject it.
+      if (
+        desiredStatus === TaskStatus.QUEUED &&
+        statusAfterSchedule !== TaskStatus.QUEUED
+      ) {
+        return desiredStatus;
+      }
       return statusAfterSchedule;
     }
 
@@ -458,7 +466,24 @@ async function createTaskFromDescription(input: {
       input.schedule &&
       input.schedule.mode !== "none"
     ) {
-      await applyTaskSchedule(task.id, input.schedule, false);
+      const statusAfterSchedule = await applyTaskSchedule(
+        task.id,
+        input.schedule,
+        false,
+      );
+      // Create always goes Draft → schedule. Schedule apply may leave the
+      // task Ready (human assignee). Carry an explicit Queued choice through
+      // so Core accepts it for agents or rejects it for humans instead of
+      // silently succeeding as Ready.
+      if (
+        input.status === TaskStatus.QUEUED &&
+        statusAfterSchedule != null &&
+        statusAfterSchedule !== TaskStatus.QUEUED
+      ) {
+        await taskService.createTaskEvent(task.id, {
+          status: TaskStatus.QUEUED,
+        });
+      }
     }
     return task;
   } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves create/edit task status into the footer pill (SOK-1047), and keeps Queued available when an agent assignee already has a schedule.

## CI fix

`c77eff393` adds the missing `slug` on a `CoworkerSummary` fixture in `task-metadata.test.tsx`. That typed fixture broke Typecheck, Build, and the Vercel web preview on the previous head.

## Test plan

- [x] `pnpm --filter web exec tsc --noEmit`
- [x] `pnpm --filter web test src/app/(app)/tasks/components/task-metadata.test.tsx`
- [ ] CI Typecheck / Build / Vercel web green on `c77eff393`

Linear: SOK-1047
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ca93dc-ff11-468d-9a0e-7dc560f4b763?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ca93dc-ff11-468d-9a0e-7dc560f4b763&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Moved the task status selector to the form footer beside scheduling controls.
  - Added a consistent status pill with clear labels, status colors, dropdown indicator, and pending feedback.
  - Queued status is now preserved for explicitly queued tasks assigned to agents, including after scheduling and creation.

- **Bug Fixes**
  - Improved scheduled-task status handling so queued agent tasks remain queued when appropriate.
  - Prevented queued status from being applied to scheduled human-assigned tasks when scheduling leaves them Ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->