### PR TITLE
fix(web): enable Queued in status dropdown when a schedule exists

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.test.tsx
@@ -795,7 +795,7 @@ describe("TaskForm", () => {
     );
   });
 
-  it("disables Queued for a human assignee even with a schedule (SOK-1033)", async () => {
+  it("enables Queued whenever a schedule is set, including for human assignees", async () => {
     const user = userEvent.setup();
 
     render(
@@ -821,7 +821,51 @@ describe("TaskForm", () => {
     await user.click(screen.getByRole("button", { name: "save" }));
 
     await user.click(screen.getByRole("combobox", { name: "Status" }));
-    expect(screen.getByRole("option", { name: "Queued" })).toHaveAttribute(
+    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
+      "data-disabled",
+    );
+  });
+
+  it("enables Queued on edit when Ready with an active schedule", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskForm
+        mode="edit"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={[
+          ...coworkerOptions,
+          mockCoworkerOption({
+            id: "user-1",
+            slug: "bob",
+            name: "Bob",
+            kind: "user",
+          }),
+        ]}
+        taskId="task-1"
+        initialValues={{
+          name: "Daily sync",
+          description: "Run the sync",
+          assigneeUserId: "user-1",
+          status: TaskStatus.READY,
+          metadata: JSON.stringify({
+            version: 1,
+            mode: "once",
+            scheduledAt: "2026-06-26T09:00:00.000Z",
+            runAt: "2026-06-26T09:00:00.000Z",
+          }),
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "Status" })).toHaveTextContent(
+      "Ready",
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Status" }));
+    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
       "data-disabled",
     );
   });

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -189,6 +189,10 @@ function resolveCelebrationStatus(options: {
   if (options.desiredStatus === TaskStatus.DRAFT) {
     return "DRAFT";
   }
+  // Honor an explicit Queued create when the action succeeded (Core accepted).
+  if (options.desiredStatus === TaskStatus.QUEUED) {
+    return "QUEUED";
+  }
   if (options.hasSchedule) {
     return options.isAgent ? "QUEUED" : "READY";
   }

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -167,11 +167,8 @@ function isAgentAssigneeFields(fields: {
   return fields.assigneeId !== null || fields.assigneeSokoBotId !== null;
 }
 
-function canSelectQueued(options: {
-  isAgent: boolean;
-  hasSchedule: boolean;
-}): boolean {
-  return options.hasSchedule && options.isAgent;
+function canSelectQueued(options: { hasSchedule: boolean }): boolean {
+  return options.hasSchedule;
 }
 
 function resolveStatusForAssigneeAndSchedule(options: {
@@ -490,7 +487,7 @@ export function TaskForm({
         !statusTouchedRef.current ||
         assigneeKindChanged ||
         (status === TaskStatus.QUEUED &&
-          !canSelectQueued({ isAgent, hasSchedule: nextHasSchedule }));
+          !canSelectQueued({ hasSchedule: nextHasSchedule }));
       if (shouldResolveStatus) {
         setStatus(
           resolveStatusForAssigneeAndSchedule({
@@ -892,7 +889,6 @@ export function TaskForm({
     selectedAssigneeFields.assigneeId !== null ||
     selectedAssigneeFields.assigneeSokoBotId !== null;
   const isQueuedSelectable = canSelectQueued({
-    isAgent: isAgentAssignee,
     hasSchedule,
   });
   const isSchedulableAssignee =

--- a/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata-status-field.tsx
@@ -31,22 +31,17 @@ interface TaskMetadataStatusFieldProps {
   taskId: string;
   status: TaskStatus;
   hasSchedule: boolean;
-  isAgentAssignee: boolean;
   labels: TaskMetadataStatusFieldLabels;
 }
 
-function canSelectQueued(options: {
-  hasSchedule: boolean;
-  isAgentAssignee: boolean;
-}): boolean {
-  return options.hasSchedule && options.isAgentAssignee;
+function canSelectQueued(options: { hasSchedule: boolean }): boolean {
+  return options.hasSchedule;
 }
 
 export function TaskMetadataStatusField({
   taskId,
   status,
   hasSchedule,
-  isAgentAssignee,
   labels,
 }: TaskMetadataStatusFieldProps) {
   const router = useRouter();
@@ -56,7 +51,7 @@ export function TaskMetadataStatusField({
   const [pendingStatus, setPendingStatus] = useState<TaskStatus | null>(null);
   const [isReopenDialogOpen, setIsReopenDialogOpen] = useState(false);
   const [reopenComment, setReopenComment] = useState("");
-  const isQueuedSelectable = canSelectQueued({ hasSchedule, isAgentAssignee });
+  const isQueuedSelectable = canSelectQueued({ hasSchedule });
 
   function applyStatusChange(desiredStatus: TaskStatus, comment?: string) {
     const previousStatus = currentStatus;

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.test.tsx
@@ -24,6 +24,10 @@ vi.mock("@/components/modals/global-modals-context", () => ({
   }),
 }));
 
+vi.mock("@/components/task-schedule-display", () => ({
+  TaskScheduleDisplay: () => <span>Daily (1:47 PM)</span>,
+}));
+
 vi.mock("@/components/aurora-orb", () => ({
   AssistantOrb: ({ seed, alt }: { seed: string | null; alt?: string }) => (
     <div data-testid="assistant-orb" data-seed={seed ?? ""} aria-label={alt} />
@@ -451,6 +455,54 @@ describe("TaskMetadata", () => {
 
     await user.click(screen.getByRole("combobox", { name: "Draft" }));
     expect(screen.getByRole("option", { name: "Queued" })).toHaveAttribute(
+      "data-disabled",
+    );
+  });
+
+  it("enables Queued when the task has an active schedule", async () => {
+    const user = userEvent.setup();
+    const statusLabels = Object.fromEntries(
+      TASK_STATUS_DISPLAY_ORDER.map((status) => [
+        status,
+        status === TaskStatus.DRAFT
+          ? "Draft"
+          : status === TaskStatus.QUEUED
+            ? "Queued"
+            : status === TaskStatus.READY
+              ? "Ready"
+              : status,
+      ]),
+    ) as Record<(typeof TaskStatus)[keyof typeof TaskStatus], string>;
+
+    renderTaskMetadata({
+      task: {
+        ...createTask({
+          status: TaskStatus.READY,
+          assignee: {
+            type: "user",
+            id: "user-1",
+            user: {
+              id: "user-1",
+              name: "Bob",
+              image: null,
+            },
+          },
+        }),
+        metadata: JSON.stringify({
+          version: 1,
+          mode: "recurring",
+          expr: "47 13 * * *",
+          timezone: "UTC",
+          endsMode: "never",
+        }),
+      },
+      editable: true,
+      labels: { ...baseLabels, statusLabels },
+      statusFieldLabels: { ...baseStatusFieldLabels, statusLabels },
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Ready" }));
+    expect(screen.getByRole("option", { name: "Queued" })).not.toHaveAttribute(
       "data-disabled",
     );
   });

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -193,8 +193,6 @@ export function TaskMetadata({
   );
   const creator = resolveTaskCreatorDisplay(task, labels);
   const hasSchedule = hasActiveTaskSchedule(task.metadata, task.nextRunAt);
-  const isAgentAssignee =
-    task.assignee?.type === "coworker" || task.assignee?.type === "sokoBot";
 
   return (
     <section className="space-y-3">
@@ -207,7 +205,6 @@ export function TaskMetadata({
             taskId={taskId}
             status={task.status}
             hasSchedule={hasSchedule}
-            isAgentAssignee={isAgentAssignee}
             labels={statusFieldLabels}
           />
         ) : (

--- a/apps/web/src/lib/actions/task/action.test.ts
+++ b/apps/web/src/lib/actions/task/action.test.ts
@@ -774,6 +774,34 @@ describe("updateTask schedule status", () => {
     expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
   });
 
+  it("emits Queued after adding a schedule when Queued was requested but schedule left Ready", async () => {
+    taskScheduleServiceMock.setSchedule.mockResolvedValue({
+      id: "task-1",
+      status: TaskStatus.READY,
+    });
+
+    const { updateTask } = await import("./action");
+
+    await updateTask({
+      taskId: "task-1",
+      name: "Task",
+      description: "Do work",
+      assigneeId: null,
+      assigneeSokoBotId: null,
+      assigneeUserId: "user-1",
+      currentStatus: TaskStatus.READY,
+      desiredStatus: TaskStatus.QUEUED,
+      hadSchedule: false,
+      originalSchedule: { mode: "none", timezone: "UTC" },
+      schedule: recurringSchedule,
+    });
+
+    expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).toHaveBeenCalledWith("task-1", {
+      status: TaskStatus.QUEUED,
+    });
+  });
+
   it("applies an explicit draft/ready toggle when the schedule is unchanged", async () => {
     const { updateTask } = await import("./action");
 
@@ -1003,8 +1031,11 @@ describe("createTask schedule", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     taskServiceMock.createTask.mockReset();
+    taskServiceMock.createTaskEvent.mockReset();
+    taskServiceMock.deleteTask.mockReset();
     taskScheduleServiceMock.clearSchedule.mockReset();
     taskScheduleServiceMock.setSchedule.mockReset();
+    taskServiceMock.createTaskEvent.mockResolvedValue({});
   });
 
   it("does not apply a schedule when saving as draft", async () => {
@@ -1074,6 +1105,62 @@ describe("createTask schedule", () => {
       expect.objectContaining({ status: TaskStatus.DRAFT }),
     );
     expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
+  });
+
+  it("emits Queued after schedule apply when create requested Queued but schedule left Ready", async () => {
+    taskServiceMock.createTask.mockResolvedValue(
+      buildTask({ status: TaskStatus.DRAFT }),
+    );
+    taskScheduleServiceMock.setSchedule.mockResolvedValue({
+      id: "task-created",
+      status: TaskStatus.READY,
+    });
+
+    const { createTask } = await import("./action");
+
+    await createTask({
+      description: "Human scheduled queued task",
+      assigneeId: null,
+      assigneeSokoBotId: null,
+      assigneeUserId: "user-1",
+      status: TaskStatus.QUEUED,
+      schedule: recurringSchedule,
+    });
+
+    expect(taskScheduleServiceMock.setSchedule).toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).toHaveBeenCalledWith(
+      "task-created",
+      { status: TaskStatus.QUEUED },
+    );
+  });
+
+  it("archives the created task when the post-schedule Queued event fails", async () => {
+    taskServiceMock.createTask.mockResolvedValue(
+      buildTask({ status: TaskStatus.DRAFT }),
+    );
+    taskScheduleServiceMock.setSchedule.mockResolvedValue({
+      id: "task-created",
+      status: TaskStatus.READY,
+    });
+    taskServiceMock.createTaskEvent.mockRejectedValue(
+      new Error("Queued requires an agent assignee"),
+    );
+
+    const { createTask } = await import("./action");
+
+    await expect(
+      createTask({
+        description: "Human scheduled queued task",
+        assigneeId: null,
+        assigneeSokoBotId: null,
+        assigneeUserId: "user-1",
+        status: TaskStatus.QUEUED,
+        schedule: recurringSchedule,
+      }),
+    ).rejects.toThrow(/Queued requires an agent assignee|Failed to create/);
+
+    expect(taskServiceMock.deleteTask).toHaveBeenCalledWith("task-created");
   });
 
   it("returns a client-upgrade outcome for the exact Calendar 426 error", async () => {

--- a/apps/web/src/lib/actions/task/action.ts
+++ b/apps/web/src/lib/actions/task/action.ts
@@ -254,6 +254,14 @@ function resolveUpdateTargetStatus(
 ): TaskStatus {
   if (scheduleWasMutated) {
     if (scheduleActiveOnServer) {
+      // Schedule apply may land Ready (e.g. human assignee). Honor an
+      // explicit Queued choice so Core can accept or reject it.
+      if (
+        desiredStatus === TaskStatus.QUEUED &&
+        statusAfterSchedule !== TaskStatus.QUEUED
+      ) {
+        return desiredStatus;
+      }
       return statusAfterSchedule;
     }
 
@@ -458,7 +466,24 @@ async function createTaskFromDescription(input: {
       input.schedule &&
       input.schedule.mode !== "none"
     ) {
-      await applyTaskSchedule(task.id, input.schedule, false);
+      const statusAfterSchedule = await applyTaskSchedule(
+        task.id,
+        input.schedule,
+        false,
+      );
+      // Create always goes Draft → schedule. Schedule apply may leave the
+      // task Ready (human assignee). Carry an explicit Queued choice through
+      // so Core accepts it for agents or rejects it for humans instead of
+      // silently succeeding as Ready.
+      if (
+        input.status === TaskStatus.QUEUED &&
+        statusAfterSchedule != null &&
+        statusAfterSchedule !== TaskStatus.QUEUED
+      ) {
+        await taskService.createTaskEvent(task.id, {
+          status: TaskStatus.QUEUED,
+        });
+      }
     }
     return task;
   } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

With a schedule already set, the create/edit footer status pill and the task details status dropdown left Queued disabled unless the assignee was a Coworker or Soko Bot. That blocked the manual Ready → Queued path when schedule data was present (SOK-1033 stories 8 and 12).

Manual Queued selectability now follows schedule presence only. Auto-status still lands humans on Ready and agents on Queued. Core still rejects Queued without an agent assignee.

## Scope

- `canSelectQueued` in `task-form.tsx` and `task-metadata-status-field.tsx`
- Drop unused `isAgentAssignee` prop from `TaskMetadataStatusField`
- Form and metadata tests for scheduled Queued enablement
- Carry explicit Queued through scheduled create/update after schedule apply (Codex CR): emit Queued when schedule left the task non-Queued so Core accepts or rejects instead of silently celebrating Ready

## Tradeoffs

Rejected keeping the agent conjunct in the dropdown gate. It matched Core, but it made Queued look broken next to a visible schedule. Core remains the enforcement boundary for agent-only Queued.

## Blast Radius

Web status dropdowns on create/edit and task details. Humans can select Queued when a schedule exists; save/status update still fails in Core without an agent assignee. Failed post-schedule Queued events archive the created task.

## Verification

```bash
pnpm --filter web test src/lib/actions/task/action.test.ts src/app/(app)/tasks/components/task-form.test.tsx src/app/(app)/tasks/components/task-metadata.test.tsx -t 'Queued|schedule|celebration|Ready celebration|enables Queued|disables Queued'
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0ae4bc9-eaab-4865-b151-061277e67b92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0ae4bc9-eaab-4865-b151-061277e67b92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

