### PR TITLE
feat(web): show a search input and hotkey in the chat room header

### DIFF
--- a/apps/web/src/app/(app)/chat/components/room-search-panel.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.test.tsx
@@ -18,6 +18,16 @@ vi.mock("@/lib/utils/datetime.client", () => ({
   }),
 }));
 
+const platform = { isApple: true, isMobile: false };
+
+vi.mock("@/hooks/use-is-apple-platform", () => ({
+  default: () => platform.isApple,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => platform.isMobile,
+}));
+
 const labels = {
   open: "Search in this chat",
   placeholder: "Search messages…",
@@ -53,40 +63,57 @@ function message(overrides: Partial<ChatRoomMessage> = {}): ChatRoomMessage {
   } as ChatRoomMessage;
 }
 
+function renderPanel(onJumpToMessage = vi.fn()) {
+  render(
+    <RoomSearchPanel
+      roomId="550e8400-e29b-41d4-a716-446655440000"
+      labels={labels}
+      onJumpToMessage={onJumpToMessage}
+    />,
+  );
+  return onJumpToMessage;
+}
+
+/** Opens the results surface the way the current viewport exposes it. */
+function openSearch() {
+  if (platform.isMobile) {
+    fireEvent.click(screen.getByTestId("room-search-trigger"));
+    return;
+  }
+  fireEvent.click(screen.getByTestId("room-search-input"));
+}
+
+function typeQuery(value: string) {
+  fireEvent.change(screen.getByTestId("room-search-input"), {
+    target: { value },
+  });
+}
+
 describe("RoomSearchPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    platform.isApple = true;
+    platform.isMobile = false;
     getChatRoomMessagesMock.mockResolvedValue({ data: [message()] });
   });
 
-  it("opens search surface from the header control", async () => {
-    render(
-      <RoomSearchPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onJumpToMessage={vi.fn()}
-      />,
-    );
+  it("shows the search field in the header before the results open", () => {
+    renderPanel();
 
+    expect(screen.getByTestId("room-search-input")).toBeInTheDocument();
     expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("room-search-trigger"));
+
+    openSearch();
+
     expect(screen.getByTestId("room-search-panel")).toBeInTheDocument();
     expect(screen.getByText(labels.idle)).toBeInTheDocument();
   });
 
   it("shows results after a debounced query", async () => {
-    render(
-      <RoomSearchPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onJumpToMessage={vi.fn()}
-      />,
-    );
+    renderPanel();
 
-    fireEvent.click(screen.getByTestId("room-search-trigger"));
-    fireEvent.change(screen.getByTestId("room-search-input"), {
-      target: { value: "budget" },
-    });
+    openSearch();
+    typeQuery("budget");
 
     await waitFor(() => {
       expect(getChatRoomMessagesMock).toHaveBeenCalledWith(
@@ -103,18 +130,9 @@ describe("RoomSearchPanel", () => {
   it("shows empty state when there are no matches", async () => {
     getChatRoomMessagesMock.mockResolvedValue({ data: [] });
 
-    render(
-      <RoomSearchPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onJumpToMessage={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("room-search-trigger"));
-    fireEvent.change(screen.getByTestId("room-search-input"), {
-      target: { value: "zzzz" },
-    });
+    renderPanel();
+    openSearch();
+    typeQuery("zzzz");
 
     expect(await screen.findByTestId("room-search-empty")).toHaveTextContent(
       labels.empty,
@@ -122,28 +140,22 @@ describe("RoomSearchPanel", () => {
   });
 
   it("lists search hits in API order, newest first", async () => {
-    const newer = message({
-      id: "550e8400-e29b-41d4-a716-446655440002",
-      content: "Newer budget",
+    getChatRoomMessagesMock.mockResolvedValue({
+      data: [
+        message({
+          id: "550e8400-e29b-41d4-a716-446655440002",
+          content: "Newer budget",
+        }),
+        message({
+          id: "550e8400-e29b-41d4-a716-446655440001",
+          content: "Older budget",
+        }),
+      ],
     });
-    const older = message({
-      id: "550e8400-e29b-41d4-a716-446655440001",
-      content: "Older budget",
-    });
-    getChatRoomMessagesMock.mockResolvedValue({ data: [newer, older] });
 
-    render(
-      <RoomSearchPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onJumpToMessage={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("room-search-trigger"));
-    fireEvent.change(screen.getByTestId("room-search-input"), {
-      target: { value: "budget" },
-    });
+    renderPanel();
+    openSearch();
+    typeQuery("budget");
 
     const results = await screen.findAllByTestId("room-search-result");
     expect(results).toHaveLength(2);
@@ -153,25 +165,299 @@ describe("RoomSearchPanel", () => {
 
   it("closes the popover and jumps to the selected hit", async () => {
     const hit = message();
-    const onJumpToMessage = vi.fn();
     getChatRoomMessagesMock.mockResolvedValue({ data: [hit] });
+    const onJumpToMessage = renderPanel();
 
-    render(
-      <RoomSearchPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onJumpToMessage={onJumpToMessage}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("room-search-trigger"));
-    fireEvent.change(screen.getByTestId("room-search-input"), {
-      target: { value: "budget" },
-    });
-
+    openSearch();
+    typeQuery("budget");
     fireEvent.click(await screen.findByTestId("room-search-result"));
 
     expect(onJumpToMessage).toHaveBeenCalledWith(hit);
     expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
+  });
+
+  describe("keyboard", () => {
+    it("labels the shortcut per platform", () => {
+      const { unmount } = render(
+        <RoomSearchPanel
+          roomId="550e8400-e29b-41d4-a716-446655440000"
+          labels={labels}
+          onJumpToMessage={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("⌘F")).toBeInTheDocument();
+      expect(screen.getByTestId("room-search-input")).toHaveAttribute(
+        "aria-keyshortcuts",
+        "Meta+F",
+      );
+
+      unmount();
+      platform.isApple = false;
+      renderPanel();
+
+      expect(screen.getByText("Ctrl+F")).toBeInTheDocument();
+      expect(screen.getByTestId("room-search-input")).toHaveAttribute(
+        "aria-keyshortcuts",
+        "Control+F",
+      );
+    });
+
+    it("focuses the field from the host shortcut", async () => {
+      renderPanel();
+
+      fireEvent.keyDown(window, { key: "f", metaKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("room-search-input")).toHaveFocus();
+      });
+      expect(screen.getByTestId("room-search-panel")).toBeInTheDocument();
+    });
+
+    it("ignores the foreign modifier for the platform", () => {
+      renderPanel();
+
+      fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+
+      expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
+    });
+
+    it("uses Ctrl on Windows and Linux", async () => {
+      platform.isApple = false;
+      renderPanel();
+
+      fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("room-search-panel")).toBeInTheDocument();
+      });
+    });
+
+    it("leaves find-in-page alone on a second press inside the field", async () => {
+      renderPanel();
+
+      fireEvent.keyDown(window, { key: "f", metaKey: true });
+      await waitFor(() => {
+        expect(screen.getByTestId("room-search-input")).toHaveFocus();
+      });
+
+      const secondPress = new KeyboardEvent("keydown", {
+        key: "f",
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      window.dispatchEvent(secondPress);
+
+      expect(secondPress.defaultPrevented).toBe(false);
+    });
+
+    it("moves through results and jumps with Enter", async () => {
+      const newer = message({
+        id: "550e8400-e29b-41d4-a716-446655440002",
+        content: "Newer budget",
+      });
+      const older = message({
+        id: "550e8400-e29b-41d4-a716-446655440001",
+        content: "Older budget",
+      });
+      getChatRoomMessagesMock.mockResolvedValue({ data: [newer, older] });
+      const onJumpToMessage = renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      await screen.findAllByTestId("room-search-result");
+
+      const input = screen.getByTestId("room-search-input");
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onJumpToMessage).toHaveBeenCalledWith(older);
+    });
+
+    it("closes on Escape and keeps focus on the field", async () => {
+      renderPanel();
+
+      fireEvent.keyDown(window, { key: "f", metaKey: true });
+      await waitFor(() => {
+        expect(screen.getByTestId("room-search-panel")).toBeInTheDocument();
+      });
+
+      fireEvent.keyDown(screen.getByTestId("room-search-input"), {
+        key: "Escape",
+      });
+
+      expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
+      expect(screen.getByTestId("room-search-input")).toHaveFocus();
+    });
+
+    it("reopens from the shortcut after Escape, with the field still focused", async () => {
+      renderPanel();
+
+      fireEvent.keyDown(window, { key: "f", metaKey: true });
+      await waitFor(() => {
+        expect(screen.getByTestId("room-search-input")).toHaveFocus();
+      });
+
+      fireEvent.keyDown(screen.getByTestId("room-search-input"), {
+        key: "Escape",
+      });
+      expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
+      expect(screen.getByTestId("room-search-input")).toHaveFocus();
+
+      const reopen = new KeyboardEvent("keydown", {
+        key: "f",
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      window.dispatchEvent(reopen);
+
+      expect(reopen.defaultPrevented).toBe(true);
+      await waitFor(() => {
+        expect(screen.getByTestId("room-search-panel")).toBeInTheDocument();
+      });
+    });
+
+    it("ignores an auto-repeating shortcut press", () => {
+      renderPanel();
+
+      fireEvent.keyDown(window, { key: "f", metaKey: true, repeat: true });
+
+      expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
+    });
+
+    it("clears the query on Escape, wherever focus is", async () => {
+      renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      await screen.findByTestId("room-search-result");
+
+      // Radix handles Escape on the layer, so focus placement must not matter.
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("room-search-panel"),
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("room-search-input")).toHaveValue("");
+    });
+
+    it("keeps the query but drops the hits when a result closes it", async () => {
+      renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      fireEvent.click(await screen.findByTestId("room-search-result"));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("room-search-panel"),
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("room-search-input")).toHaveValue("budget");
+      expect(screen.queryAllByTestId("room-search-result")).toHaveLength(0);
+    });
+
+    it("does not paint the previous hits when it reopens", async () => {
+      renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      fireEvent.click(await screen.findByTestId("room-search-result"));
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("room-search-panel"),
+        ).not.toBeInTheDocument();
+      });
+
+      openSearch();
+
+      // Synchronous on purpose: the refetch has not landed yet, and the stale
+      // list must not flash in the gap.
+      expect(screen.queryAllByTestId("room-search-result")).toHaveLength(0);
+    });
+
+    it("does not jump from Enter while the surface is closed", async () => {
+      const onJumpToMessage = renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      fireEvent.click(await screen.findByTestId("room-search-result"));
+      onJumpToMessage.mockClear();
+
+      fireEvent.keyDown(screen.getByTestId("room-search-input"), {
+        key: "Enter",
+      });
+
+      expect(onJumpToMessage).not.toHaveBeenCalled();
+    });
+
+    it("reopens with ArrowDown after a close", async () => {
+      renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      fireEvent.click(await screen.findByTestId("room-search-result"));
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("room-search-panel"),
+        ).not.toBeInTheDocument();
+      });
+
+      fireEvent.keyDown(screen.getByTestId("room-search-input"), {
+        key: "ArrowDown",
+      });
+
+      expect(screen.getByTestId("room-search-panel")).toBeInTheDocument();
+    });
+
+    it("returns focus to the field after a hit is selected", async () => {
+      getChatRoomMessagesMock.mockResolvedValue({ data: [message()] });
+      renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      fireEvent.click(await screen.findByTestId("room-search-result"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("room-search-input")).toHaveFocus();
+      });
+    });
+  });
+
+  describe("mobile", () => {
+    beforeEach(() => {
+      platform.isMobile = true;
+    });
+
+    it("collapses to the icon trigger and hides the shortcut", () => {
+      renderPanel();
+
+      expect(screen.getByTestId("room-search-trigger")).toBeInTheDocument();
+      expect(screen.queryByTestId("room-search-input")).not.toBeInTheDocument();
+      expect(screen.queryByText("⌘F")).not.toBeInTheDocument();
+    });
+
+    it("does not bind the host shortcut", () => {
+      renderPanel();
+
+      fireEvent.keyDown(window, { key: "f", metaKey: true });
+
+      expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
+    });
+
+    it("searches from the field inside the popover", async () => {
+      renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+
+      expect(await screen.findByTestId("room-search-result")).toHaveTextContent(
+        "Hello budget review",
+      );
+    });
   });
 });

--- a/apps/web/src/app/(app)/chat/components/room-search-panel.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.test.tsx
@@ -375,9 +375,54 @@ describe("RoomSearchPanel", () => {
 
       openSearch();
 
-      // Synchronous on purpose: the refetch has not landed yet, and the stale
-      // list must not flash in the gap.
+      // Assert the surface is actually back, or the "no results" check below
+      // would pass simply because the whole subtree is unmounted.
+      expect(screen.getByTestId("room-search-panel")).toBeInTheDocument();
       expect(screen.queryAllByTestId("room-search-result")).toHaveLength(0);
+      expect(screen.queryByTestId("room-search-empty")).not.toBeInTheDocument();
+    });
+
+    it("clears the query with Escape after the surface has closed", async () => {
+      renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      fireEvent.click(await screen.findByTestId("room-search-result"));
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("room-search-panel"),
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("room-search-input")).toHaveValue("budget");
+
+      // The dismissable layer is gone with the surface, so the field has to
+      // answer Escape itself.
+      fireEvent.keyDown(screen.getByTestId("room-search-input"), {
+        key: "Escape",
+      });
+
+      expect(screen.getByTestId("room-search-input")).toHaveValue("");
+    });
+
+    it("leaves focus where the user clicked after an outside dismissal", async () => {
+      renderPanel();
+
+      openSearch();
+      typeQuery("budget");
+      await screen.findByTestId("room-search-result");
+
+      const elsewhere = document.createElement("input");
+      document.body.append(elsewhere);
+      elsewhere.focus();
+      fireEvent.focusIn(elsewhere);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("room-search-panel"),
+        ).not.toBeInTheDocument();
+      });
+      expect(elsewhere).toHaveFocus();
+      elsewhere.remove();
     });
 
     it("does not jump from Enter while the surface is closed", async () => {

--- a/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { Loader2, Search } from "lucide-react";
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useId, useRef, useState } from "react";
 import { messageSender } from "@/app/chat/components/room-helpers";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
-  PopoverTrigger,
 } from "@/components/ui/popover";
+import useIsApplePlatform from "@/hooks/use-is-apple-platform";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { coreClient } from "@/lib/clients/core.browser.client";
 import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
@@ -17,6 +19,7 @@ import { useLocalizedDateTime } from "@/lib/utils/datetime.client";
 
 const SEARCH_PAGE_SIZE = 50;
 const SEARCH_DEBOUNCE_MS = 250;
+const SEARCH_HOTKEY = "f";
 
 export interface RoomSearchPanelLabels {
   open: string;
@@ -43,10 +46,24 @@ export function RoomSearchPanel({
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [results, setResults] = useState<ChatRoomMessage[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const requestIdRef = useRef(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const fieldRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const interactedOutsideRef = useRef(false);
+  const listboxId = useId();
+  const optionIdPrefix = useId();
   const { formatTimeAgo } = useLocalizedDateTime();
+
+  // Below the mobile breakpoint there is no physical keyboard, so the field
+  // collapses into the header icon and the hotkey stays unbound.
+  const isMobile = useIsMobile();
+  const isApplePlatform = useIsApplePlatform();
+  const shortcutLabel = isApplePlatform ? "⌘F" : "Ctrl+F";
+  const shortcutKeys = isApplePlatform ? "Meta+F" : "Control+F";
 
   const searchMessages = useEffectEvent(async (searchQuery: string) => {
     const requestId = ++requestIdRef.current;
@@ -69,6 +86,7 @@ export function RoomSearchPanel({
         return;
       }
       setResults(response.data);
+      setActiveIndex(0);
     } catch {
       if (requestId !== requestIdRef.current) {
         return;
@@ -96,57 +114,258 @@ export function RoomSearchPanel({
     void searchMessages(debouncedQuery);
   }, [debouncedQuery, open, roomId]);
 
-  function handleOpenChange(nextOpen: boolean) {
-    if (!nextOpen) {
-      setQuery("");
-      setDebouncedQuery("");
-      setResults([]);
-      setError(null);
-      setIsLoading(false);
-      requestIdRef.current += 1;
+  function focusField() {
+    // On mobile the field only mounts with the popover, so wait a frame.
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+  }
+
+  /** Returns false when the press belongs to find-in-page instead. */
+  const openFromHotkey = useEffectEvent(() => {
+    // A press while the surface is already open and focused falls through to
+    // find-in-page, so the browser shortcut stays reachable. Once the surface
+    // is closed the shortcut belongs to search again, even though the field
+    // below it kept focus.
+    if (open && document.activeElement === inputRef.current) {
+      return false;
     }
-    setOpen(nextOpen);
+
+    setOpen(true);
+    focusField();
+    return true;
+  });
+
+  useEffect(() => {
+    if (isMobile) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key?.toLowerCase() !== SEARCH_HOTKEY || event.repeat) {
+        return;
+      }
+
+      const hostModifier = isApplePlatform ? event.metaKey : event.ctrlKey;
+      if (!hostModifier || event.altKey || event.shiftKey) {
+        return;
+      }
+
+      if (openFromHotkey()) {
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isApplePlatform, isMobile]);
+
+  function isEventInsideField(target: EventTarget | null) {
+    return (
+      target instanceof Node && fieldRef.current?.contains(target) === true
+    );
+  }
+
+  function closeSearch() {
+    // Hits never outlive the surface that showed them. Keeping them would
+    // leave Enter and the arrow keys acting on a list nobody can see. The
+    // query itself does survive, because the field stays on screen and
+    // emptying it under the user would look like data loss; reopening
+    // re-runs the search from that query.
+    setResults([]);
+    setActiveIndex(0);
+    setError(null);
+    setIsLoading(false);
+    requestIdRef.current += 1;
+    setOpen(false);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (nextOpen) {
+      setOpen(true);
+      return;
+    }
+    closeSearch();
   }
 
   function handleSelect(hit: ChatRoomMessage) {
     onJumpToMessage(hit);
-    handleOpenChange(false);
+    closeSearch();
+  }
+
+  /** Escape means "clear", wherever focus happens to be when it is pressed. */
+  function clearQuery() {
+    setQuery("");
+    setDebouncedQuery("");
+  }
+
+  function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    // Escape is handled once, by the dismissable layer, so that the key means
+    // the same thing whether or not focus sits in the field.
+    if (!open) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setOpen(true);
+      }
+      return;
+    }
+
+    if (results.length === 0) {
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % results.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => (index - 1 + results.length) % results.length);
+      return;
+    }
+
+    if (event.key === "Enter") {
+      const hit = results[activeIndex];
+      if (hit) {
+        event.preventDefault();
+        handleSelect(hit);
+      }
+    }
   }
 
   const showIdle = !debouncedQuery && !isLoading && !error;
   const showEmpty =
     Boolean(debouncedQuery) && !isLoading && !error && results.length === 0;
+  const activeOptionId =
+    open && results[activeIndex]
+      ? `${optionIdPrefix}-${results[activeIndex].id}`
+      : undefined;
+
+  const searchField = (
+    <div
+      ref={fieldRef}
+      className={cn("relative", isMobile ? "w-full" : "w-56 xl:w-64")}
+    >
+      <Search
+        aria-hidden
+        className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2"
+        strokeWidth={1.5}
+      />
+      <Input
+        ref={inputRef}
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setOpen(true);
+        }}
+        onClick={() => setOpen(true)}
+        onKeyDown={handleInputKeyDown}
+        placeholder={labels.placeholder}
+        aria-label={labels.open}
+        aria-keyshortcuts={isMobile ? undefined : shortcutKeys}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-autocomplete="list"
+        aria-activedescendant={activeOptionId}
+        data-testid="room-search-input"
+        className={cn(
+          "peer h-8 pl-8",
+          // The gutter has to clear the hint without clipping the placeholder,
+          // and "Ctrl+F" is far wider than "⌘F".
+          isMobile ? "pr-3" : isApplePlatform ? "pr-12" : "pr-16",
+        )}
+      />
+      {isMobile ? null : (
+        <kbd
+          aria-hidden
+          className={cn(
+            "text-muted-foreground pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 font-sans text-xs tracking-widest whitespace-nowrap",
+            "transition-[opacity] duration-150 ease-[cubic-bezier(0.2,0,0,1)] peer-focus:opacity-0",
+            query && "opacity-0",
+          )}
+        >
+          {shortcutLabel}
+        </kbd>
+      )}
+    </div>
+  );
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label={labels.open}
-          data-testid="room-search-trigger"
-          className="size-8"
-        >
-          <Search className="size-4" />
-        </Button>
-      </PopoverTrigger>
+      <PopoverAnchor asChild>
+        {isMobile ? (
+          <Button
+            ref={triggerRef}
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={labels.open}
+            data-testid="room-search-trigger"
+            className="size-8"
+            onClick={() => {
+              setOpen(true);
+              focusField();
+            }}
+          >
+            <Search className="size-4" strokeWidth={1.5} />
+          </Button>
+        ) : (
+          searchField
+        )}
+      </PopoverAnchor>
       <PopoverContent
         align="end"
         className="w-[min(100vw-2rem,24rem)] p-0"
         data-testid="room-search-panel"
+        // The header field is the anchor, not part of the content, so Radix
+        // reads focusing or clicking it as an outside interaction and would
+        // close the surface the hotkey just opened.
+        onFocusOutside={(event) => {
+          if (isEventInsideField(event.detail.originalEvent.target)) {
+            event.preventDefault();
+            return;
+          }
+          interactedOutsideRef.current = true;
+        }}
+        onPointerDownOutside={(event) => {
+          if (isEventInsideField(event.detail.originalEvent.target)) {
+            event.preventDefault();
+            return;
+          }
+          interactedOutsideRef.current = true;
+        }}
+        onEscapeKeyDown={clearQuery}
+        // There is no PopoverTrigger any more, so Radix has no element to
+        // return focus to and would drop it on the body. It also no longer
+        // withholds that restore after an outside interaction, so match what
+        // a trigger would have done and leave the user where they clicked.
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          if (interactedOutsideRef.current) {
+            interactedOutsideRef.current = false;
+            return;
+          }
+          (isMobile ? triggerRef : inputRef).current?.focus();
+        }}
+        onOpenAutoFocus={(event) => {
+          // Desktop keeps focus in the header field; mobile focuses the field
+          // that mounts inside this popover.
+          if (!isMobile) {
+            event.preventDefault();
+          }
+        }}
       >
-        <div className="border-b p-2">
-          <Input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder={labels.placeholder}
-            aria-label={labels.placeholder}
-            data-testid="room-search-input"
-            autoFocus
-          />
-        </div>
-        <div className="max-h-80 overflow-y-auto p-1">
+        {isMobile ? <div className="border-b p-2">{searchField}</div> : null}
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label={labels.open}
+          className="max-h-80 overflow-y-auto p-1"
+        >
           {isLoading && results.length === 0 ? (
             <div className="text-muted-foreground flex items-center justify-center gap-2 px-2 py-6 text-sm">
               <Loader2 className="size-4 animate-spin" />
@@ -171,17 +390,23 @@ export function RoomSearchPanel({
               {labels.empty}
             </p>
           ) : null}
-          {results.map((message) => {
+          {results.map((message, index) => {
             const sender = messageSender(message);
             const isReply = message.parentMessageId != null;
+            const isActive = index === activeIndex;
             return (
-              <button
+              <div
                 key={message.id}
-                type="button"
+                id={`${optionIdPrefix}-${message.id}`}
+                role="option"
+                aria-selected={isActive}
+                tabIndex={-1}
                 className={cn(
-                  "hover:bg-accent flex w-full flex-col gap-0.5 rounded-md px-2 py-2 text-left text-sm",
+                  "flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-2 text-left text-sm",
+                  isActive && "bg-accent",
                 )}
                 onClick={() => handleSelect(message)}
+                onMouseEnter={() => setActiveIndex(index)}
                 data-testid="room-search-result"
               >
                 <div className="flex items-center gap-2">
@@ -198,7 +423,7 @@ export function RoomSearchPanel({
                 <p className="text-muted-foreground line-clamp-2 text-xs">
                   {message.content}
                 </p>
-              </button>
+              </div>
             );
           })}
         </div>

--- a/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
@@ -176,13 +176,19 @@ export function RoomSearchPanel({
     setResults([]);
     setActiveIndex(0);
     setError(null);
-    setIsLoading(false);
+    // A surviving query means the next open starts a fetch, so hand the
+    // reopen a loading state. Without it the first frame reads "no matches"
+    // for a query that has hits.
+    setIsLoading(Boolean(debouncedQuery));
     requestIdRef.current += 1;
     setOpen(false);
   }
 
   function handleOpenChange(nextOpen: boolean) {
     if (nextOpen) {
+      // The exit animation can cancel an unmount before onCloseAutoFocus
+      // consumes this, which would leave the next close without its restore.
+      interactedOutsideRef.current = false;
       setOpen(true);
       return;
     }
@@ -201,10 +207,17 @@ export function RoomSearchPanel({
   }
 
   function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
-    // Escape is handled once, by the dismissable layer, so that the key means
-    // the same thing whether or not focus sits in the field.
+    // While the surface is open, Escape belongs to the dismissable layer, so
+    // the key means the same thing wherever focus sits. Once it is closed
+    // that layer is gone, and the field is still holding the query Escape is
+    // meant to clear.
     if (!open) {
-      if (event.key === "ArrowDown") {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        clearQuery();
+        return;
+      }
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         event.preventDefault();
         setOpen(true);
       }


### PR DESCRIPTION
## What changed

The chat room header exposed search as a bare magnifier icon. Neither the search field nor any shortcut was discoverable until you clicked it.

Desktop now renders the field in the header: search icon, placeholder, and the shortcut printed inside the field, fading out over 150ms on focus or input. The popover anchors to that field and keeps focus in it, so there is one input rather than a second copy inside the popover.

## Shortcut

| Platform | Opens search | Printed hint | Reaches find-in-page |
| --- | --- | --- | --- |
| macOS, iOS | `Cmd+F` | `⌘F` | press again while focused, or `Ctrl+F` |
| Windows, Linux | `Ctrl+F` | `Ctrl+F` | press again while focused |
| Below 768px | not bound | hidden | always |

It stays context-aware in three ways. It is bound per open room. It ignores the foreign modifier, so `Ctrl+F` on a Mac still reaches the browser's own find. And a press while the surface is already open and focused falls through to find-in-page instead of being swallowed; once the surface is closed the shortcut belongs to search again, even though the field below it kept focus.

## Mobile

Below the mobile breakpoint the field collapses back to the icon, the hint is hidden, and the shortcut stays unbound, since there is no physical keyboard. The field then mounts inside the popover, so the header and the popover never both hold an input.

## Keyboard and ARIA

Results are a combobox listbox. `ArrowUp` / `ArrowDown` walk the hits while focus stays in the field, `Enter` jumps to the active one, `Escape` clears the query and closes. Dismissing by clicking away only closes: the field stays on screen, so emptying it under the user would read as data loss.

## Two Radix details

Both follow from anchoring the popover rather than triggering it.

1. The header field counts as outside the popover, which closed the surface in the same frame the hotkey opened it. `onFocusOutside` and `onPointerDownOutside` are now prevented for events originating inside the field.
2. With no trigger element, Radix had nothing to restore focus to and dropped it on the body after a hit was selected. `onCloseAutoFocus` now returns focus to the field, or to the icon on mobile.

## Verification

- `pnpm --filter web test "src/app/(app)/chat/components"` → 62 files, 563 tests passed.
- `pnpm --filter web typecheck` → clean.
- `biome check` → clean.
- The four regressions above are pinned by new tests. Mutating either of the two behavioural fixes back out fails exactly one test each, so the tests are not vacuous.

## Not verified

**No browser proof.** Another worktree holds ports 3000 and 8787, so this branch needs the portless HTTPS proxy on 443, which requires a password. The field width (`w-56`, `xl:w-64`) and the per-platform right gutter are derived from the text metrics, not measured in a running header. Worth a look on a narrow desktop window before this leaves draft.

**Known first-frame jump on phones.** `useIsMobile()` reports false until its media query resolves after mount, so a phone paints the desktop field for one frame before collapsing it to the icon. Fixing it properly means moving the collapse into CSS, which needs a change to the header layout in `room-header-chrome.tsx` that cannot be verified without a browser.

No new translation keys: the existing `App.Channels.RoomSearch.*` strings cover it, and the shortcut label is generated per platform the same way `history-search-dialog-provider.tsx` already does.