### PR TITLE
fix(web): release this browser's push device after account deletion

### DIFF
--- a/apps/web/src/app/(app)/account/components/delete-account-form.test.tsx
+++ b/apps/web/src/app/(app)/account/components/delete-account-form.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeleteAccountForm } from "./delete-account-form";
 
 const deleteUserMock = vi.fn();
+const releasePushDeviceMock = vi.fn();
 const mockRouterPush = vi.fn();
 const mockRouterRefresh = vi.fn();
 
@@ -86,6 +87,10 @@ vi.mock("@/lib/auth/auth.client", () => ({
   deleteUser: (...args: unknown[]) => deleteUserMock(...args),
 }));
 
+vi.mock("@/lib/ably/release-push-device.client", () => ({
+  dropBrowserPushSubscriptionOnAccountDeletion: () => releasePushDeviceMock(),
+}));
+
 async function openDialog() {
   const user = userEvent.setup();
   await user.click(screen.getByRole("button", { name: "Delete account" }));
@@ -95,6 +100,7 @@ async function openDialog() {
 describe("DeleteAccountForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    releasePushDeviceMock.mockResolvedValue(undefined);
   });
 
   it("lists mapped blockers and disables confirm while any remain", async () => {
@@ -302,5 +308,67 @@ describe("DeleteAccountForm", () => {
     expect(toast.error).toHaveBeenCalledWith(
       "A task payment is still pending; contact support to have it resolved, then delete your account again.",
     );
+  });
+  /**
+   * Web Push needs no session, so the deleted account's subscription would go
+   * on rendering banners on this browser, and the next reader to sign in here
+   * would find the Push cell on over it.
+   */
+  it("releases this browser's push device once the account is gone", async () => {
+    deleteUserMock.mockResolvedValue({ error: null });
+    let finishRelease: () => void = () => {};
+    releasePushDeviceMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishRelease = resolve;
+      }),
+    );
+
+    render(<DeleteAccountForm blockers={[]} />);
+
+    const user = await openDialog();
+    await user.type(screen.getByLabelText("Current password"), "Password123!");
+    await user.click(
+      screen.getByRole("button", { name: "Yes, delete my account" }),
+    );
+
+    await waitFor(() => {
+      expect(releasePushDeviceMock).toHaveBeenCalledTimes(1);
+    });
+    // Finished, not merely started. A release still in flight across
+    // `router.push` is one the unmounting page no longer holds.
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    finishRelease();
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith("/");
+    });
+  });
+
+  /**
+   * The password check can refuse the deletion. Releasing first would turn
+   * push off for an account that still exists.
+   */
+  it("keeps push on when the delete is refused", async () => {
+    deleteUserMock.mockResolvedValue({
+      error: {
+        code: "TASK_PAYMENT_CLAIM_PENDING",
+        message: "Backend fallback",
+        status: 400,
+        statusText: "Bad Request",
+      },
+    });
+
+    render(<DeleteAccountForm blockers={[]} />);
+
+    const user = await openDialog();
+    await user.type(screen.getByLabelText("Current password"), "Password123!");
+    await user.click(
+      screen.getByRole("button", { name: "Yes, delete my account" }),
+    );
+
+    await waitFor(() => {
+      expect(deleteUserMock).toHaveBeenCalledOnce();
+    });
+    expect(releasePushDeviceMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/account/components/delete-account-form.tsx
+++ b/apps/web/src/app/(app)/account/components/delete-account-form.tsx
@@ -34,6 +34,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { dropBrowserPushSubscriptionOnAccountDeletion } from "@/lib/ably/release-push-device.client";
 import {
   IN_FLIGHT_JOB_ERROR_CODE,
   IN_FLIGHT_TASK_ERROR_CODE,
@@ -162,6 +163,9 @@ export function DeleteAccountForm({
         userDeletionBlockerMessage(deleteUserResult.error.code ?? "", t),
       );
     } else {
+      // After the delete, not before it: a deletion the password check blocks
+      // would otherwise turn push off for an account that still exists.
+      await dropBrowserPushSubscriptionOnAccountDeletion();
       toast.success(t("success"));
       router.push("/");
     }

--- a/apps/web/src/lib/ably/push-activation.client.ts
+++ b/apps/web/src/lib/ably/push-activation.client.ts
@@ -198,7 +198,15 @@ async function attempt(
   }
 }
 
-async function dropBrowserPushSubscription(): Promise<void> {
+/**
+ * Drop this browser's Web Push subscription.
+ *
+ * Exported because the account-deletion path needs this half on its own: the
+ * session is gone by the time it runs, so Ably's deactivation cannot mint the
+ * token it needs, while the browser unsubscribe needs no session and is the
+ * step that stops delivery.
+ */
+export async function dropBrowserPushSubscription(): Promise<void> {
   // Read the registration rather than create one: turning push off must not
   // install a worker. A browser that never had one has nothing to drop.
   const registration = await getExistingNotificationServiceWorker();

--- a/apps/web/src/lib/ably/release-push-device.client.test.ts
+++ b/apps/web/src/lib/ably/release-push-device.client.test.ts
@@ -1,13 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { releasePushDeviceOnSignOut } from "./release-push-device.client";
+import {
+  dropBrowserPushSubscriptionOnAccountDeletion,
+  releasePushDeviceOnSignOut,
+} from "./release-push-device.client";
 
 const deactivatePushMock = vi.fn();
+const dropBrowserPushSubscriptionMock = vi.fn();
 const hasWebPushSubscriptionMock = vi.fn();
 const isPushSupportedMock = vi.fn();
 
 vi.mock("./push-activation.client", () => ({
   deactivatePush: (...args: unknown[]) => deactivatePushMock(...args),
+  dropBrowserPushSubscription: () => dropBrowserPushSubscriptionMock(),
 }));
 
 vi.mock("@/lib/utils/notification-service-worker", () => ({
@@ -167,6 +172,123 @@ describe("releasePushDeviceOnSignOut", () => {
 
     expect(logged).toHaveBeenCalledWith(
       "Failed to release the push device on sign out",
+      reason,
+    );
+  });
+});
+
+describe("dropBrowserPushSubscriptionOnAccountDeletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isPushSupportedMock.mockReturnValue(true);
+    hasWebPushSubscriptionMock.mockResolvedValue(true);
+    dropBrowserPushSubscriptionMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  /**
+   * The account row is gone, but the browser keeps the subscription the
+   * account page reads. The next reader to sign in here would find the Push
+   * cell on over a subscription that belongs to a deleted account.
+   */
+  it("drops the subscription this browser holds", async () => {
+    await dropBrowserPushSubscriptionOnAccountDeletion();
+
+    expect(dropBrowserPushSubscriptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Deactivation mints an Ably token, and the session died with the account.
+   * Only the half that needs no session is left, and that is the half that
+   * stops delivery.
+   */
+  it("does not try the Ably half, which has no session left", async () => {
+    await dropBrowserPushSubscriptionOnAccountDeletion();
+
+    expect(deactivatePushMock).not.toHaveBeenCalled();
+  });
+
+  it("loads nothing for a browser that never subscribed", async () => {
+    hasWebPushSubscriptionMock.mockResolvedValue(false);
+
+    await dropBrowserPushSubscriptionOnAccountDeletion();
+
+    expect(dropBrowserPushSubscriptionMock).not.toHaveBeenCalled();
+  });
+
+  it("reads nothing on a browser that cannot push at all", async () => {
+    isPushSupportedMock.mockReturnValue(false);
+
+    await dropBrowserPushSubscriptionOnAccountDeletion();
+
+    expect(hasWebPushSubscriptionMock).not.toHaveBeenCalled();
+    expect(dropBrowserPushSubscriptionMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The dynamic import has to fetch the chunk that carries the Ably SDK. The
+   * account is already deleted, so a reader held on that fetch would sit on
+   * the account page of an account that no longer exists.
+   */
+  it("lets the reader go when the release hangs", async () => {
+    vi.useFakeTimers();
+    dropBrowserPushSubscriptionMock.mockReturnValue(new Promise(() => {}));
+
+    const released = dropBrowserPushSubscriptionOnAccountDeletion();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(released).resolves.toBeUndefined();
+  });
+
+  /**
+   * The cap lets the reader go first, so the rejection lands with the outer
+   * `try` already over. Without a handler on the release itself it would be
+   * unhandled. A chunk fetch that 404s after a deploy rotated its hash is the
+   * way to get one.
+   */
+  it("logs a rejection that lands after the cap", async () => {
+    vi.useFakeTimers();
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const reason = new Error("the chunk is gone");
+    let failRelease: (error: unknown) => void = () => {};
+    dropBrowserPushSubscriptionMock.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        failRelease = reject;
+      }),
+    );
+
+    const released = dropBrowserPushSubscriptionOnAccountDeletion();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(released).resolves.toBeUndefined();
+
+    failRelease(reason);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(logged).toHaveBeenCalledWith(
+      "Failed to release the push device after account deletion",
+      reason,
+    );
+  });
+
+  /**
+   * The account is already deleted, so there is nothing to fail back to. The
+   * reader still has to reach the success toast and leave the page.
+   */
+  it("returns when the unsubscribe fails", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const reason = new Error("the browser said no");
+    dropBrowserPushSubscriptionMock.mockRejectedValue(reason);
+
+    await expect(
+      dropBrowserPushSubscriptionOnAccountDeletion(),
+    ).resolves.toBeUndefined();
+
+    expect(logged).toHaveBeenCalledWith(
+      "Failed to release the push device after account deletion",
       reason,
     );
   });

--- a/apps/web/src/lib/ably/release-push-device.client.ts
+++ b/apps/web/src/lib/ably/release-push-device.client.ts
@@ -41,7 +41,7 @@ function hasAblyPushRegistration(): boolean {
 }
 
 /**
- * How long the sign-out waits for the release before it goes anyway.
+ * How long a release is waited on before the caller goes anyway.
  *
  * The browser unsubscribe leads and does not wait on the network, so this
  * only ever sheds the Ably half. `PushSubscription.unsubscribe()` deactivates
@@ -64,6 +64,28 @@ function hasAblyPushRegistration(): boolean {
  * minute. Signing out is the more urgent of the two.
  */
 const RELEASE_TIMEOUT_MS = 5_000;
+
+/**
+ * Waits for a release, and lets the caller go when the cap runs out.
+ *
+ * Shared by both paths, because both have a step that leaves the machine: the
+ * sign-out has Ably's two REST calls, and the deletion has the chunk fetch its
+ * dynamic import needs. A caller held on either has already done the part that
+ * stops delivery.
+ *
+ * The release must carry its own rejection handler. The cap can let the caller
+ * go first, and a rejection that lands after that has no one left to catch it.
+ */
+async function waitForRelease(release: Promise<void>): Promise<void> {
+  let capTimer: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    release,
+    new Promise<void>((resolve) => {
+      capTimer = setTimeout(resolve, RELEASE_TIMEOUT_MS);
+    }),
+  ]);
+  clearTimeout(capTimer);
+}
 
 /**
  * Drop this browser's push registration before an explicit sign-out.
@@ -104,18 +126,11 @@ export async function releasePushDeviceOnSignOut(
     // Caught here rather than by the `catch` below, because the cap can let
     // the sign-out go before this settles. The alternative for a late
     // rejection is no handler at all.
-    const release = deactivatePush(userId).catch((error) => {
-      console.error("Failed to release the push device on sign out", error);
-    });
-
-    let capTimer: ReturnType<typeof setTimeout> | undefined;
-    await Promise.race([
-      release,
-      new Promise<void>((resolve) => {
-        capTimer = setTimeout(resolve, RELEASE_TIMEOUT_MS);
+    await waitForRelease(
+      deactivatePush(userId).catch((error) => {
+        console.error("Failed to release the push device on sign out", error);
       }),
-    ]);
-    clearTimeout(capTimer);
+    );
   } catch (error) {
     // Signing out must not fail because Ably did. The registration is then
     // still live, and the reader can clear it from the browser's own site
@@ -123,4 +138,69 @@ export async function releasePushDeviceOnSignOut(
     // browser, which replaces the registration rather than adding one.
     console.error("Failed to release the push device on sign out", error);
   }
+}
+
+/**
+ * Drop this browser's push subscription once an account deletion has gone
+ * through.
+ *
+ * Deleting the account takes the publish gate with it, so no banner can reach
+ * the wrong reader. What stays behind is the browser's own subscription, which
+ * the account page reads: the next reader to sign in on this browser would
+ * find the Push cell on over a subscription that belongs to a deleted account.
+ *
+ * Runs after the deletion, not before it. Deletion asks for a password and can
+ * be blocked, and releasing first would turn push off for an account that
+ * still exists.
+ *
+ * That order gives up the Ably half, which mints a token and needs the session
+ * the deletion just ended. Only the browser unsubscribe is left, and that is
+ * the step that stops delivery and clears the cell, which is why the name says
+ * so. Ably prunes a device whose endpoint stops answering.
+ *
+ * Capped like the sign-out, for a different step. `unsubscribe()` resolves
+ * before its own request to the push service, so that one cannot hang; the
+ * dynamic import below can, because the chunk it names carries the Ably SDK
+ * and has to be fetched. The account is already deleted by then, so a reader
+ * left waiting on it would sit on the account page of an account that no
+ * longer exists, with the button still disabled, until they reloaded.
+ *
+ * What stays is Ably's own identity token in this browser's storage. The next
+ * reader heals it either way: a sign-out reads it and releases the device with
+ * their own session, and an activation that finds no subscription deactivates
+ * and goes round again (`activatePush`).
+ */
+export async function dropBrowserPushSubscriptionOnAccountDeletion(): Promise<void> {
+  try {
+    // Both reads are local, so a reader who never enabled push pays nothing
+    // and never loads the Ably SDK on their way out.
+    if (!isPushSupported() || !(await hasWebPushSubscription())) {
+      return;
+    }
+
+    await waitForRelease(
+      dropSubscription().catch((error) => {
+        console.error(
+          "Failed to release the push device after account deletion",
+          error,
+        );
+      }),
+    );
+  } catch (error) {
+    // The account is already gone, so there is nothing to fail back to. The
+    // subscription is then still live, and the reader can clear it from the
+    // browser's own site data.
+    console.error(
+      "Failed to release the push device after account deletion",
+      error,
+    );
+  }
+}
+
+/** The drop, with the chunk fetch its import needs folded into one promise. */
+async function dropSubscription(): Promise<void> {
+  const { dropBrowserPushSubscription } = await import(
+    "./push-activation.client"
+  );
+  await dropBrowserPushSubscription();
 }


### PR DESCRIPTION
Closes SOK-911.

## What

Deleting an account left this browser holding a Web Push subscription for an account that no longer exists. The account page reads that subscription, so the next reader to sign in on the browser found the Push cell switched on over it.

The success branch of the delete form now releases the browser's push device.

## Why this shape

Sign-out already releases, through `releasePushDeviceOnSignOut`. That helper cannot be reused as it stands: it must run *before* the session ends, because Ably's deactivation mints a token.

Deletion asks for a password and can be refused, so the release has to run *after* the delete succeeds. That order gives up the Ably half, which needs the session the deletion just ended. What is left is the browser unsubscribe, which needs no session and is the step that stops delivery and clears the cell. Ably prunes a device whose endpoint stops answering.

## Changes

- `push-activation.client.ts`: `dropBrowserPushSubscription` is now exported. No behaviour change.
- `release-push-device.client.ts`: new `releasePushDeviceOnAccountDeletion()`. Guards on `isPushSupported` and `hasWebPushSubscription`, so a reader who never enabled push loads no Ably SDK on their way out. Swallows its own failures: the account is already gone, so there is nothing to fail back to.
- `delete-account-form.tsx`: calls it in the success branch only.

## Verification

- `pnpm --filter web test src/lib/ably/release-push-device.client.test.ts src/lib/ably/push-activation.client.test.ts 'src/app/(app)/account/components/delete-account-form.test.tsx'` → `Tests 43 passed (43)`, exit 0
- `pnpm --filter web typecheck` → exit 0
- Mutation checked: removing the call in the form fails `releases this browser's push device once the account is gone`; removing the drop in the helper fails 2 tests.

## Out of scope

Sessions that expire on their own, and clearing other browsers. Both are excluded by the ticket.
