### PR TITLE
perf(chat): memoize transcript rows with stable callbacks

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-row-render-isolation.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-row-render-isolation.test.tsx
@@ -25,8 +25,9 @@ import type {
  * prop with a new identity or value.
  */
 
-const { rowRenders } = vi.hoisted(() => ({
+const { rowRenders, fetchRoomMessagesMock } = vi.hoisted(() => ({
   rowRenders: new Map<string, number>(),
+  fetchRoomMessagesMock: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -139,8 +140,9 @@ vi.mock("@/app/chat/actions", () => ({
   unpinRoomMessageAction: vi.fn(),
 }));
 
+// Scheduled room recovery reads go over GET; the poll is the refresh merge.
 vi.mock("@/components/chat/fetch-room-messages", () => ({
-  fetchRoomMessages: vi.fn(async () => ({ messages: [], nextCursor: null })),
+  fetchRoomMessages: fetchRoomMessagesMock,
 }));
 
 vi.mock("@/components/chat/organization-chat-list.actions", () => ({
@@ -375,12 +377,52 @@ describe("RoomsClient transcript row render isolation", () => {
     clearMembershipVisibleRoomsSnapshot();
     rowRenders.clear();
     vi.clearAllMocks();
+    fetchRoomMessagesMock
+      .mockReset()
+      .mockResolvedValue({ messages: [], nextCursor: null });
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
   });
 
   afterEach(() => {
     clearMembershipVisibleRoomsSnapshot();
     vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("renders no row when a refresh merge re-sends the same messages", async () => {
+    vi.useFakeTimers();
+    fetchRoomMessagesMock.mockImplementation(async () => ({
+      messages: [message("m1", 1), message("m2", 2), message("m3", 3)],
+      nextCursor: null,
+    }));
+    const before = await mountRoom();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+
+    expect(fetchRoomMessagesMock).toHaveBeenCalled();
+    expect(rendersSince(before)).toEqual({ m1: 0, m2: 0, m3: 0 });
+  });
+
+  it("renders only the changed row when a refresh merge differs", async () => {
+    vi.useFakeTimers();
+    fetchRoomMessagesMock.mockImplementation(async () => ({
+      messages: [
+        message("m1", 1),
+        { ...message("m2", 2), content: "edited elsewhere" },
+        message("m3", 3),
+      ],
+      nextCursor: null,
+    }));
+    const before = await mountRoom();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+
+    expect(screen.getByText("edited elsewhere")).toBeTruthy();
+    expect(rendersSince(before)).toEqual({ m1: 0, m2: 1, m3: 0 });
   });
 
   it("renders only the new row when a realtime message arrives", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-row-render-isolation.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-row-render-isolation.test.tsx
@@ -1,0 +1,527 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { memo, type ReactNode, type Ref, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  editRoomMessageAction,
+  pinRoomMessageAction,
+  toggleMessageReactionAction,
+  unpinRoomMessageAction,
+} from "@/app/chat/actions";
+import type { RoomComposerHandle } from "@/app/chat/components/room-composer";
+import { RoomsClient } from "@/app/chat/components/rooms-client";
+import { clearMembershipVisibleRoomsSnapshot } from "@/components/chat/membership-visible-rooms-store";
+import { clearRoomReadOverlays } from "@/components/chat/room-read-overlay";
+import { chatRoomMessageEventDataSchema } from "@/lib/ably";
+import { useChatRoomRealtime } from "@/lib/ably/use-chat-room-realtime";
+import type {
+  ChatRoom,
+  ChatRoomMessage,
+  Organization,
+} from "@/lib/clients/generated/core";
+
+/**
+ * A change that touches one message must re-render that row only. The row
+ * stub is memoized, so a row re-renders exactly when RoomsClient hands it a
+ * prop with a new identity or value.
+ */
+
+const { rowRenders } = vi.hoisted(() => ({
+  rowRenders: new Map<string, number>(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/chat/rooms/room-channel",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// next-intl memoizes its translator; a fresh function per render would
+// churn every memoized input that lists `t`.
+const translate = (key: string) => key;
+vi.mock("next-intl", () => ({
+  useTranslations: () => translate,
+  useLocale: () => "en",
+}));
+
+vi.mock("@/app/chat/components/room-search-panel", () => ({
+  RoomSearchPanel: () => null,
+}));
+
+vi.mock("@/app/chat/components/unread-threads-panel", () => ({
+  UnreadThreadsPanel: () => null,
+}));
+
+vi.mock("@/app/chat/components/day-separator", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/hooks/use-is-apple-platform", () => ({
+  default: () => false,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobileMedia: () => false,
+}));
+
+vi.mock("@/app/components/header/use-header-room-slot-host", () => ({
+  useHeaderRoomSlotHost: () => null,
+}));
+
+vi.mock("@/contexts/breadcrumb-override-context", () => ({
+  useRegisterBreadcrumbOverride: () => undefined,
+}));
+
+vi.mock("@/contexts/lazy-ably-provider", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/ably/use-chat-room-realtime", () => ({
+  useChatRoomRealtime: vi.fn(),
+}));
+
+vi.mock("@/lib/ably/use-selected-room-channel-health", () => ({
+  useSelectedRoomChannelHealth: () => undefined,
+}));
+
+vi.mock("@/app/chat/hooks/use-client-local-calendar-ready", () => ({
+  useClientLocalCalendarReady: () => true,
+}));
+
+vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
+  useStickToBottom: () => ({
+    scrollerRef: { current: null },
+    contentRef: { current: null },
+    contentMinHeight: undefined,
+    scrollToBottom: vi.fn(),
+    pinToBottomAfterOwnSend: vi.fn(),
+    scrollToBottomIfPinned: vi.fn(),
+    suppressStickToBottom: vi.fn(),
+    releaseStickToBottomSuppress: vi.fn(),
+  }),
+}));
+
+vi.mock("@/app/chat/hooks/use-coworker-direct-room-stream", () => ({
+  readStoredStreamParentMessageId: () => null,
+  useCoworkerDirectRoomStream: () => ({
+    streamOverlayMessages: [],
+    isStreaming: false,
+    activeStreamParentMessageId: null,
+    sendStreamMessage: vi.fn(),
+    consumePendingStreamMessage: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/chat/use-show-room-unread-count", () => ({
+  useShowRoomUnreadCount: () => false,
+}));
+
+vi.mock("@/app/chat/actions", () => ({
+  countUnreadThreadsAction: vi.fn(async () => ({
+    ok: true as const,
+    value: 0,
+  })),
+  deleteRoomMessageAction: vi.fn(),
+  editRoomMessageAction: vi.fn(),
+  listRoomMessagesAction: vi.fn(async () => ({
+    ok: true,
+    value: { messages: [], nextCursor: null },
+  })),
+  listThreadMessagesAction: vi.fn(),
+  markThreadReadAction: vi.fn(),
+  pinRoomMessageAction: vi.fn(),
+  retryRoomMentionAction: vi.fn(),
+  sendRoomMessageAction: vi.fn(),
+  toggleMessageReactionAction: vi.fn(),
+  unpinRoomMessageAction: vi.fn(),
+}));
+
+vi.mock("@/components/chat/fetch-room-messages", () => ({
+  fetchRoomMessages: vi.fn(async () => ({ messages: [], nextCursor: null })),
+}));
+
+vi.mock("@/components/chat/organization-chat-list.actions", () => ({
+  markOrganizationChatRoomReadAction: vi.fn(async (roomId: string) => ({
+    ok: true as const,
+    value: {
+      id: roomId,
+      unreadCount: 0,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    },
+  })),
+}));
+
+vi.mock("../room-file-drop-zone", () => ({
+  RoomFileDropZone: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("../room-session-composer", () => ({
+  RoomSessionComposer: ({ ref }: { ref?: Ref<RoomComposerHandle> }) => {
+    useImperativeHandle(ref, () => ({
+      attachFiles: () => undefined,
+      focus: () => undefined,
+    }));
+    return <div data-testid="room-session-composer" />;
+  },
+}));
+
+vi.mock("../room-message-row", () => ({
+  ChatMessageRow: memo(function ChatMessageRowStub({
+    message,
+    isPinned,
+    isEditing,
+    editDraft,
+    onToggleReaction,
+    onPin,
+    onStartEdit,
+    onEditDraftChange,
+    onSaveEdit,
+  }: {
+    message: ChatRoomMessage;
+    isPinned?: boolean;
+    isEditing?: boolean;
+    editDraft?: string;
+    onToggleReaction: (message: ChatRoomMessage, emoji: string) => void;
+    onPin?: (message: ChatRoomMessage) => void;
+    onStartEdit?: (message: ChatRoomMessage) => void;
+    onEditDraftChange?: (value: string) => void;
+    onSaveEdit?: (content?: string) => void;
+  }) {
+    rowRenders.set(message.id, (rowRenders.get(message.id) ?? 0) + 1);
+    return (
+      <div
+        data-testid="chat-message-row"
+        data-message-id={message.id}
+        data-pinned={String(Boolean(isPinned))}
+        data-editing={String(Boolean(isEditing))}
+        data-edit-draft={editDraft ?? ""}
+      >
+        {message.content}
+        <button type="button" onClick={() => onToggleReaction(message, "👍")}>
+          {`React ${message.id}`}
+        </button>
+        <button type="button" onClick={() => onPin?.(message)}>
+          {`Pin ${message.id}`}
+        </button>
+        <button type="button" onClick={() => onStartEdit?.(message)}>
+          {`Edit ${message.id}`}
+        </button>
+        <button
+          type="button"
+          onClick={() => onEditDraftChange?.("typed draft")}
+        >
+          {`Type ${message.id}`}
+        </button>
+        <button type="button" onClick={() => onSaveEdit?.()}>
+          {`Save ${message.id}`}
+        </button>
+      </div>
+    );
+  }),
+}));
+
+vi.mock("../thread-panel", () => ({
+  ThreadPanel: () => null,
+}));
+
+vi.mock("../edit-channel-dialog", () => ({
+  EditChannelDialog: ({ children }: { children?: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("../chat-participant-hover-card", () => ({
+  ChatParticipantHoverCard: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@/components/chat/channel-discoverability-icon", () => ({
+  ChannelDiscoverabilityIcon: () => null,
+}));
+
+vi.mock("@/components/chat/live-member-presence-dot", () => ({
+  LiveMemberPresenceDot: () => null,
+  LiveMemberPresenceText: () => null,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+function channelRoom(): ChatRoom {
+  return {
+    id: "room-channel",
+    organizationId: "org-1",
+    organizationName: "Acme",
+    name: "general",
+    slug: "general",
+    kind: "channel",
+    directKey: null,
+    topic: null,
+    discoverability: "public",
+    createdByUserId: "user-1",
+    createdAt: new Date("2026-07-01T12:00:00.000Z"),
+    updatedAt: new Date("2026-07-01T12:00:00.000Z"),
+    unreadCount: 0,
+    unreadMentionCount: 0,
+    starredAt: null,
+    mutedAt: null,
+    markedUnread: false,
+    myAccess: "member",
+    userMembers: [
+      {
+        id: "user-1",
+        name: "Ada",
+        email: "user-1@example.com",
+        image: null,
+        presence: "offline",
+      },
+    ],
+    coworkerMembers: [],
+    sokoBotMembers: [],
+  };
+}
+
+function message(id: string, minute: number): ChatRoomMessage {
+  return {
+    id,
+    roomId: "room-channel",
+    parentMessageId: null,
+    content: `body ${id}`,
+    createdAt: new Date(
+      `2026-07-01T12:${String(minute).padStart(2, "0")}:00.000Z`,
+    ),
+    editedAt: null,
+    deletedAt: null,
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: null,
+    quote: null,
+    membership: null,
+    unfurls: null,
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+  };
+}
+
+const organization = {
+  id: "org-1",
+  name: "Acme",
+  slug: "acme",
+} as Organization;
+
+const messages = [message("m1", 1), message("m2", 2), message("m3", 3)];
+
+const baseProps = {
+  activeOrganization: organization,
+  rooms: [channelRoom()],
+  organizationMembers: [] as [],
+  currentUserId: "user-1",
+  coworkers: [] as [],
+  selectedRoomId: "room-channel",
+  messageLoadFailed: false,
+  membersLoadFailed: false,
+  messages,
+  messagesNextCursor: null as string | null,
+};
+
+function realtimeOptions() {
+  const options = vi.mocked(useChatRoomRealtime).mock.calls.at(-1)?.[0];
+  if (!options) {
+    throw new Error("useChatRoomRealtime was not called");
+  }
+  return options;
+}
+
+function snapshotRenders() {
+  return new Map(rowRenders);
+}
+
+function rendersSince(before: Map<string, number>) {
+  const delta: Record<string, number> = {};
+  for (const [id, count] of rowRenders) {
+    delta[id] = count - (before.get(id) ?? 0);
+  }
+  return delta;
+}
+
+async function mountRoom() {
+  render(<RoomsClient {...baseProps} />);
+  await act(async () => {});
+  expect(screen.getAllByTestId("chat-message-row")).toHaveLength(3);
+  return snapshotRenders();
+}
+
+describe("RoomsClient transcript row render isolation", () => {
+  beforeEach(() => {
+    clearRoomReadOverlays();
+    clearMembershipVisibleRoomsSnapshot();
+    rowRenders.clear();
+    vi.clearAllMocks();
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+  });
+
+  afterEach(() => {
+    clearMembershipVisibleRoomsSnapshot();
+    vi.restoreAllMocks();
+  });
+
+  it("renders only the new row when a realtime message arrives", async () => {
+    const before = await mountRoom();
+
+    const event = chatRoomMessageEventDataSchema.parse(
+      JSON.parse(
+        JSON.stringify({ eventType: "create", message: message("m4", 4) }),
+      ),
+    );
+    await act(async () => {
+      realtimeOptions().onMessage?.(event);
+    });
+
+    expect(screen.getByText("body m4")).toBeTruthy();
+    expect(rendersSince(before)).toEqual({ m1: 0, m2: 0, m3: 0, m4: 1 });
+  });
+
+  it("re-renders only the reacted row", async () => {
+    vi.mocked(toggleMessageReactionAction).mockImplementation(
+      async (_roomId, messageId, emoji) => ({
+        ok: true as const,
+        value: {
+          ...message(messageId, 2),
+          reactions: [
+            { emoji, count: 1, reactedByCurrentUser: true, reactors: [] },
+          ],
+        },
+      }),
+    );
+    const before = await mountRoom();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "React m2" }));
+    });
+
+    expect(toggleMessageReactionAction).toHaveBeenCalledWith(
+      "room-channel",
+      "m2",
+      "👍",
+    );
+    expect(rendersSince(before)).toEqual({ m1: 0, m2: 1, m3: 0 });
+  });
+
+  it("re-renders only the row entering edit mode", async () => {
+    const before = await mountRoom();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Edit m2" }));
+    });
+
+    expect(
+      screen
+        .getAllByTestId("chat-message-row")
+        .map((row) => row.getAttribute("data-editing")),
+    ).toEqual(["false", "true", "false"]);
+    expect(rendersSince(before)).toEqual({ m1: 0, m2: 1, m3: 0 });
+  });
+
+  it("re-renders only the edited row while its draft changes", async () => {
+    await mountRoom();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Edit m2" }));
+    });
+    const before = snapshotRenders();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Type m2" }));
+    });
+
+    expect(
+      screen
+        .getAllByTestId("chat-message-row")
+        .map((row) => row.getAttribute("data-edit-draft")),
+    ).toEqual(["", "typed draft", ""]);
+    expect(rendersSince(before)).toEqual({ m1: 0, m2: 1, m3: 0 });
+  });
+
+  it("unpins a row that was pinned over realtime after mount", async () => {
+    vi.mocked(unpinRoomMessageAction).mockResolvedValue({
+      ok: true as const,
+      value: undefined as never,
+    });
+    await mountRoom();
+
+    await act(async () => {
+      realtimeOptions().onPinnedMessage?.({
+        action: "pin",
+        roomId: "room-channel",
+        messageId: "m2",
+        pinnedMessageCount: 1,
+      });
+    });
+    expect(
+      screen
+        .getAllByTestId("chat-message-row")
+        .map((row) => row.getAttribute("data-pinned")),
+    ).toEqual(["false", "true", "false"]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Pin m2" }));
+    });
+
+    expect(unpinRoomMessageAction).toHaveBeenCalledWith("room-channel", "m2");
+    expect(pinRoomMessageAction).not.toHaveBeenCalled();
+  });
+
+  it("saves the current draft after a realtime update to the edited row", async () => {
+    vi.mocked(editRoomMessageAction).mockImplementation(
+      async (_roomId, messageId, content) => ({
+        ok: true as const,
+        value: { ...message(messageId, 2), content },
+      }),
+    );
+    await mountRoom();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Edit m2" }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Type m2" }));
+    });
+    const event = chatRoomMessageEventDataSchema.parse(
+      JSON.parse(
+        JSON.stringify({
+          eventType: "update",
+          message: { ...message("m2", 2), reactions: [] },
+        }),
+      ),
+    );
+    await act(async () => {
+      realtimeOptions().onMessage?.(event);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save m2" }));
+    });
+
+    expect(editRoomMessageAction).toHaveBeenCalledWith(
+      "room-channel",
+      "m2",
+      "typed draft",
+    );
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.test.tsx
@@ -82,8 +82,15 @@ vi.mock("next-intl", () => ({
   },
 }));
 
+const { markdownRenders } = vi.hoisted(() => ({
+  markdownRenders: { count: 0 },
+}));
+
 vi.mock("@/components/markdown", () => ({
-  default: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  default: ({ children }: { children: ReactNode }) => {
+    markdownRenders.count += 1;
+    return <span>{children}</span>;
+  },
 }));
 
 vi.mock("@/components/ui/file-chip-mini-preview", () => ({
@@ -261,6 +268,28 @@ function renderContinuation(message: ChatRoomMessage = userMessage()) {
 }
 
 describe("ChatMessageRow", () => {
+  it("skips re-rendering for an identical prop set", () => {
+    const message = userMessage();
+    const coworkersById = new Map<string, ChatRoomCoworkerParticipant>();
+    const coworkersBySlug = new Map<string, ChatRoomCoworkerParticipant>();
+    const onToggleReaction = vi.fn();
+    const row = () => (
+      <ChatMessageRow
+        message={message}
+        coworkersById={coworkersById}
+        coworkersBySlug={coworkersBySlug}
+        onToggleReaction={onToggleReaction}
+      />
+    );
+    const { rerender } = render(row());
+    const rendersAfterMount = markdownRenders.count;
+    expect(rendersAfterMount).toBeGreaterThan(0);
+
+    rerender(row());
+
+    expect(markdownRenders.count).toBe(rendersAfterMount);
+  });
+
   it("shows coworker bot badge on avatar, not beside name", () => {
     renderRow({ message: coworkerMessage() });
 

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 import {
+  memo,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
   type PointerEvent as ReactPointerEvent,
@@ -2003,7 +2004,7 @@ function MessageMetaFooter({
   );
 }
 
-export function ChatMessageRow({
+export const ChatMessageRow = memo(function ChatMessageRow({
   message,
   coworkersById,
   coworkersBySlug,
@@ -2537,4 +2538,4 @@ export function ChatMessageRow({
       ) : null}
     </article>
   );
-}
+});

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2077,32 +2077,29 @@ export function RoomsClient({
     });
   }
 
-  const handleRetryOutbound = useCallback(
-    (message: ChatRoomMessage) => {
-      const clientTurnId = readClientTurnId(message);
-      if (!clientTurnId || !selectedRoom) {
-        return;
-      }
-      const isThread = message.parentMessageId != null;
-      const jobsRef = isThread ? classicThreadJobsRef : classicChannelJobsRef;
-      const job = jobsRef.current.get(clientTurnId);
-      if (!job) {
-        return;
-      }
-      if (isThread) {
-        setThreadMessages((current) =>
-          markOutboundMessagePending(current, clientTurnId),
-        );
-        enqueueClassicThreadJob(job);
-        return;
-      }
-      setMessagesState((current) =>
+  function handleRetryOutbound(message: ChatRoomMessage) {
+    const clientTurnId = readClientTurnId(message);
+    if (!clientTurnId || !selectedRoom) {
+      return;
+    }
+    const isThread = message.parentMessageId != null;
+    const jobsRef = isThread ? classicThreadJobsRef : classicChannelJobsRef;
+    const job = jobsRef.current.get(clientTurnId);
+    if (!job) {
+      return;
+    }
+    if (isThread) {
+      setThreadMessages((current) =>
         markOutboundMessagePending(current, clientTurnId),
       );
-      enqueueClassicChannelJob(job);
-    },
-    [selectedRoom],
-  );
+      enqueueClassicThreadJob(job);
+      return;
+    }
+    setMessagesState((current) =>
+      markOutboundMessagePending(current, clientTurnId),
+    );
+    enqueueClassicChannelJob(job);
+  }
 
   const handleRemoveOutbound = useCallback((message: ChatRoomMessage) => {
     const clientTurnId = readClientTurnId(message);
@@ -2126,6 +2123,57 @@ export function RoomsClient({
     );
     setMessagesState((current) => removeOutboundMessage(current, clientTurnId));
   }, []);
+
+  // Transcript rows are memoized. Hand them callbacks whose identity never
+  // changes; each call reads the handler from the latest render, so nothing
+  // here closes over stale room state.
+  const latestMessageHandlers = {
+    handleOpenDirectMessage,
+    handleToggleReaction,
+    handleOpenThreadFromMessage,
+    handleQuoteMessage,
+    handlePinMessage,
+    handleStartEdit,
+    handleDeleteMessage,
+    handleRemoveUnfurl,
+    handleRetryMention,
+    handleRetryOutbound,
+    handleEditDraftChange,
+    handleCancelEdit,
+    handleSaveEdit,
+  };
+  const latestMessageHandlersRef = useRef(latestMessageHandlers);
+  latestMessageHandlersRef.current = latestMessageHandlers;
+  const stableMessageHandlers = useMemo(
+    () => ({
+      onOpenDirectMessage: (profile: ChatParticipantHoverProfile) =>
+        latestMessageHandlersRef.current.handleOpenDirectMessage(profile),
+      onToggleReaction: (message: ChatRoomMessage, emoji: string) =>
+        latestMessageHandlersRef.current.handleToggleReaction(message, emoji),
+      onOpenThread: (message: ChatRoomMessage) =>
+        latestMessageHandlersRef.current.handleOpenThreadFromMessage(message),
+      onQuote: (message: ChatRoomMessage) =>
+        latestMessageHandlersRef.current.handleQuoteMessage(message),
+      onPin: (message: ChatRoomMessage) =>
+        latestMessageHandlersRef.current.handlePinMessage(message),
+      onStartEdit: (message: ChatRoomMessage) =>
+        latestMessageHandlersRef.current.handleStartEdit(message),
+      onDelete: (message: ChatRoomMessage) =>
+        latestMessageHandlersRef.current.handleDeleteMessage(message),
+      onRemoveUnfurl: (message: ChatRoomMessage, url: string) =>
+        latestMessageHandlersRef.current.handleRemoveUnfurl(message, url),
+      onRetryMention: (message: ChatRoomMessage) =>
+        latestMessageHandlersRef.current.handleRetryMention(message),
+      onRetryOutbound: (message: ChatRoomMessage) =>
+        latestMessageHandlersRef.current.handleRetryOutbound(message),
+      onEditDraftChange: (draft: string) =>
+        latestMessageHandlersRef.current.handleEditDraftChange(draft),
+      onCancelEdit: () => latestMessageHandlersRef.current.handleCancelEdit(),
+      onSaveEdit: (contentOverride?: string) =>
+        latestMessageHandlersRef.current.handleSaveEdit(contentOverride),
+    }),
+    [],
+  );
 
   const handleChannelBeforeSend = useCallback(
     (_clientMessageId: string) => {
@@ -2469,9 +2517,11 @@ export function RoomsClient({
                       channelLinks={channelLinks}
                       currentUserId={currentUserId}
                       canOpenHumanDirect={canOpenHumanDirect}
-                      onOpenDirectMessage={handleOpenDirectMessage}
+                      onOpenDirectMessage={
+                        stableMessageHandlers.onOpenDirectMessage
+                      }
                       openingDirectParticipantKey={openingDirectKey}
-                      onToggleReaction={handleToggleReaction}
+                      onToggleReaction={stableMessageHandlers.onToggleReaction}
                       onOpenThread={
                         !isOutboundLocal &&
                         shouldShowChatRoomThreadButton({
@@ -2479,34 +2529,44 @@ export function RoomsClient({
                           isStreamOverlay,
                           isThinkingShell,
                         })
-                          ? handleOpenThreadFromMessage
+                          ? stableMessageHandlers.onOpenThread
                           : undefined
                       }
-                      onQuote={isOutboundLocal ? undefined : handleQuoteMessage}
+                      onQuote={
+                        isOutboundLocal
+                          ? undefined
+                          : stableMessageHandlers.onQuote
+                      }
                       onPin={
                         !isDirectRoom && !isOutboundLocal
-                          ? handlePinMessage
+                          ? stableMessageHandlers.onPin
                           : undefined
                       }
                       showPinButton={!isDirectRoom && !isOutboundLocal}
                       isPinned={pinnedMessageIds.has(message.id)}
                       onStartEdit={
-                        isOutboundLocal ? undefined : handleStartEdit
+                        isOutboundLocal
+                          ? undefined
+                          : stableMessageHandlers.onStartEdit
                       }
                       onDelete={
-                        isOutboundLocal ? undefined : handleDeleteMessage
+                        isOutboundLocal
+                          ? undefined
+                          : stableMessageHandlers.onDelete
                       }
                       onRemoveUnfurl={
-                        isOutboundLocal ? undefined : handleRemoveUnfurl
+                        isOutboundLocal
+                          ? undefined
+                          : stableMessageHandlers.onRemoveUnfurl
                       }
-                      onRetryOutbound={handleRetryOutbound}
+                      onRetryOutbound={stableMessageHandlers.onRetryOutbound}
                       onRetryMention={
                         isCurrentUserMentionerOfFailedShell({
                           shell: message,
                           currentUserId,
                           sourceMessages: mentionRetrySourceMessages,
                         })
-                          ? handleRetryMention
+                          ? stableMessageHandlers.onRetryMention
                           : undefined
                       }
                       onRemoveOutbound={handleRemoveOutbound}
@@ -2517,9 +2577,11 @@ export function RoomsClient({
                           ? editSession.draft
                           : ""
                       }
-                      onEditDraftChange={handleEditDraftChange}
-                      onCancelEdit={handleCancelEdit}
-                      onSaveEdit={handleSaveEdit}
+                      onEditDraftChange={
+                        stableMessageHandlers.onEditDraftChange
+                      }
+                      onCancelEdit={stableMessageHandlers.onCancelEdit}
+                      onSaveEdit={stableMessageHandlers.onSaveEdit}
                       isSavingEdit={
                         isSavingEdit && editSession?.messageId === message.id
                       }
@@ -2631,7 +2693,7 @@ export function RoomsClient({
               onSend={handleChannelSend}
               currentUserId={currentUserId}
               canOpenHumanDirect={canOpenHumanDirect}
-              onOpenDirectMessage={handleOpenDirectMessage}
+              onOpenDirectMessage={stableMessageHandlers.onOpenDirectMessage}
               openingDirectParticipantKey={openingDirectKey}
             />
           }
@@ -2663,25 +2725,25 @@ export function RoomsClient({
                 isSendingReply={
                   isCoworkerStreaming && threadStreamOverlayMessages.length > 0
                 }
-                onRetryOutbound={handleRetryOutbound}
-                onRetryMention={handleRetryMention}
+                onRetryOutbound={stableMessageHandlers.onRetryOutbound}
+                onRetryMention={stableMessageHandlers.onRetryMention}
                 onRemoveOutbound={handleRemoveOutbound}
                 outboundSentTickIds={outboundSentTickIds}
                 onBack={threadOpenedFromList ? backToThreadList : undefined}
                 onClose={closeThreadSidePanel}
-                onToggleReaction={handleToggleReaction}
+                onToggleReaction={stableMessageHandlers.onToggleReaction}
                 onQuote={handleQuoteThreadMessage}
                 currentUserId={currentUserId}
                 canOpenHumanDirect={canOpenHumanDirect}
-                onOpenDirectMessage={handleOpenDirectMessage}
+                onOpenDirectMessage={stableMessageHandlers.onOpenDirectMessage}
                 openingDirectParticipantKey={openingDirectKey}
-                onStartEdit={handleStartEdit}
-                onDelete={handleDeleteMessage}
-                onRemoveUnfurl={handleRemoveUnfurl}
+                onStartEdit={stableMessageHandlers.onStartEdit}
+                onDelete={stableMessageHandlers.onDelete}
+                onRemoveUnfurl={stableMessageHandlers.onRemoveUnfurl}
                 editSession={editSession}
-                onEditDraftChange={handleEditDraftChange}
-                onCancelEdit={handleCancelEdit}
-                onSaveEdit={handleSaveEdit}
+                onEditDraftChange={stableMessageHandlers.onEditDraftChange}
+                onCancelEdit={stableMessageHandlers.onCancelEdit}
+                onSaveEdit={stableMessageHandlers.onSaveEdit}
                 isSavingEdit={isSavingEdit}
                 pendingQuote={pendingThreadQuote}
                 onClearPendingQuote={() => setPendingThreadQuote(null)}
@@ -2732,7 +2794,7 @@ export function RoomsClient({
                 channelLinks={channelLinks}
                 currentUserId={currentUserId}
                 canOpenHumanDirect={canOpenHumanDirect}
-                onOpenDirectMessage={handleOpenDirectMessage}
+                onOpenDirectMessage={stableMessageHandlers.onOpenDirectMessage}
                 openingDirectParticipantKey={openingDirectKey}
                 onIdsLoaded={handlePinnedIdsLoaded}
                 onClose={() => {
@@ -2768,7 +2830,7 @@ export function RoomsClient({
                 participants={getRoomParticipantPreviews(selectedRoom)}
                 currentUserId={currentUserId}
                 canOpenHumanDirect={canOpenHumanDirect}
-                onOpenDirect={handleOpenDirectMessage}
+                onOpenDirect={stableMessageHandlers.onOpenDirectMessage}
                 openingDirectKey={openingDirectKey}
                 onClose={() => {
                   setRosterOpen(false);

--- a/apps/web/src/app/(app)/chat/utils/merge-room-messages.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/merge-room-messages.test.ts
@@ -98,6 +98,20 @@ describe("applyFullChatRoomMessageEvent", () => {
 });
 
 describe("mergeRoomMessages", () => {
+  it("keeps the existing object for an unchanged incoming message", () => {
+    const first = message("m1", "2026-07-01T10:00:00.000Z");
+    const second = message("m2", "2026-07-01T11:00:00.000Z");
+    const changedSecond = { ...second, content: "edited" };
+
+    const merged = mergeRoomMessages(
+      [first, second],
+      [message("m1", "2026-07-01T10:00:00.000Z"), changedSecond],
+    );
+
+    expect(merged[0]).toBe(first);
+    expect(merged[1]).toBe(changedSecond);
+  });
+
   it("keeps pending shells after confirmed rows when peers merge", () => {
     const older = message("m1", "2026-07-01T10:00:00.000Z");
     const pending = createPendingRoomMessage({

--- a/apps/web/src/app/(app)/chat/utils/merge-room-messages.ts
+++ b/apps/web/src/app/(app)/chat/utils/merge-room-messages.ts
@@ -81,6 +81,12 @@ export function mergeRoomMessages(
     if (isOutboundLocalMessage(message)) {
       continue;
     }
+    // Memoized rows key on object identity; a refresh page re-sends every
+    // message, so keep the existing object when nothing in it changed.
+    const existingById = byId.get(message.id);
+    if (existingById != null && isSameMessage(existingById, message)) {
+      continue;
+    }
     byId.set(message.id, message);
   }
 
@@ -111,6 +117,15 @@ export function mergeRoomMessages(
   }
 
   return [...mergedConfirmed, ...unresolvedOutbound];
+}
+
+/**
+ * Structural equality by JSON text. Page and realtime rows are built in the
+ * same DTO key order, so equal messages serialize identically (Dates as ISO).
+ * A key-order mismatch only costs one extra row render, never wrong data.
+ */
+function isSameMessage(left: ChatRoomMessage, right: ChatRoomMessage): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function streamSenderSortRank(message: ChatRoomMessage): number {


### PR DESCRIPTION
## Summary

Opening a busy room loads 100 to 200 transcript rows, and every room state change re-rendered all of them: a realtime message from another member, a reaction, an edit session opening, a refresh merge after a coworker stream settled. On a phone the transcript stuttered after each of those events even though one row changed.

A change that touches one message now re-renders that row only. The transcript looks and behaves as before.

- **`ChatMessageRow` is memoized** with the default shallow comparison. Its DOM, props contract, and callback signatures are unchanged; the existing row tests pass without edits.
- **Row callbacks from the room screen are referentially stable.** `RoomsClient` keeps its handlers as they are and exposes one stable wrapper per callback. Each wrapper reads the handler from the latest render through a ref, so no wrapper closes over stale room state. This is a "latest handlers" ref rather than the "latest values" ref the spec sketched; it reaches the same goal with no handler rewrite and no dependency-array audit.
- **Message identity survives a refresh merge.** `mergeRoomMessages` keeps the existing object when a re-sent message is structurally equal, so a refresh page after a stream settles re-renders only rows that actually changed.
- **`handleRetryOutbound`** was already a `useCallback` keyed on the room object; it now goes through the same wrapper so its guard is unchanged.

Per-row lookups already reached the row as primitives (`isPinned`, `showOutboundSentTick`, `isEditing`, `editDraft`), so that stays.

Closes [SOK-1054](https://linear.app/masumi/issue/SOK-1054/memoize-transcript-rows-with-stable-callbacks). Builds on #4472.

## Tests

- New `rooms-client-row-render-isolation.test.tsx`: the room-screen harness with a memoized row stub that counts renders per message. Realtime create, reaction toggle, edit start, and draft typing each re-render only the touched row. Two stale-closure guards: pin after a realtime pin calls unpin, and save after a realtime update sends the current draft.
- Row test: re-render with an identical prop set does not re-run the row body.
- Merge helper: unchanged incoming messages keep their object identity; changed ones get the new object.

## Verification

- `pnpm --filter web exec vitest run` — 5486 passed, 1 skipped
- `pnpm --filter web typecheck` — clean
- `pnpm check` — clean

Not changed: virtualization, the thread panel's own per-row prop construction, and Core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)