### PR TITLE
fix(web): keep the collapsed chat search icon inside its 32px box

### DIFF
--- a/apps/web/src/app/(app)/chat/components/room-search-panel.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.test.tsx
@@ -128,6 +128,19 @@ describe("RoomSearchPanel", () => {
       expect(fieldState()).toBe("expanded");
     });
 
+    it("drops its padding while collapsed so it stays inside the icon box", () => {
+      renderPanel();
+      const input = screen.getByTestId("room-search-input");
+
+      expect(input).toHaveClass("px-0");
+      expect(input).not.toHaveClass("pl-8");
+
+      fireEvent.focus(input);
+
+      expect(input).toHaveClass("pl-8");
+      expect(input).not.toHaveClass("px-0");
+    });
+
     it("shrinks back on blur when there is no query", () => {
       renderPanel();
       const input = screen.getByTestId("room-search-input");

--- a/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
@@ -343,13 +343,17 @@ export function RoomSearchPanel({
         aria-activedescendant={activeOptionId}
         data-testid="room-search-input"
         className={cn(
-          "peer h-8 pl-8 placeholder:transition-opacity placeholder:duration-200",
+          "peer h-8 placeholder:transition-opacity placeholder:duration-200",
           // The gutter has to clear the hint without clipping the placeholder,
           // and "Ctrl+F" is far wider than "⌘F".
-          isMobile ? "pr-3" : isApplePlatform ? "pr-12" : "pr-16",
+          isExpanded && "pl-8",
+          isExpanded &&
+            (isMobile ? "pr-3" : isApplePlatform ? "pr-12" : "pr-16"),
           // Collapsed, the field passes for the ghost icon button next to it.
+          // It must drop its padding too: border-box cannot shrink below the
+          // padding, so the 32px box would otherwise grow over the next button.
           !isExpanded &&
-            "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 cursor-pointer border-transparent dark:bg-transparent placeholder:opacity-0",
+            "px-0 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 cursor-pointer border-transparent dark:bg-transparent placeholder:opacity-0",
         )}
       />
       {isMobile ? null : (


### PR DESCRIPTION
## Summary

Follow-up to #4471. The collapsed search field in the chat room header kept its expanded padding (32px left, 48 to 64px right). With border-box sizing the input cannot shrink below its padding, so the 32px wrapper held an ~80px input that overlapped the pin button and swallowed its clicks. The hover background looked oversized for the same reason.

The fix drops the padding while the field is collapsed, so it is exactly the 32px ghost icon box it is meant to pass for.

## User-facing impact

- The search icon hover state is the same size as the neighbouring icon buttons.
- The pin button in the chat room header is clickable again.

## Verification

- `pnpm --filter web test src/app/(app)/chat/components/room-search-panel.test.tsx` (36 pass, one new regression test)
- `pnpm check`
- `pnpm --filter web typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)