### PR TITLE
chore(core): delete unused OpenAPI array/query schema wrappers and fix stale /v1/chat comments

### DIFF
--- a/apps/core/src/schemas/agent.schema.ts
+++ b/apps/core/src/schemas/agent.schema.ts
@@ -334,8 +334,6 @@ export type AgentMyReview = z.infer<typeof agentMyReviewSchema>;
 
 export const agentMyReviewResponseSchema = agentMyReviewSchema.nullable();
 
-export const agentsSummarySchema = z.array(agentSummarySchema);
-
 export const agentRatingRequestSchema = z
   .object({
     rating: z

--- a/apps/core/src/schemas/chat-ui-message.schema.ts
+++ b/apps/core/src/schemas/chat-ui-message.schema.ts
@@ -62,9 +62,10 @@ export const chatUiFilePartSchema = z.object({
 });
 
 /**
- * Shared union for typed chat body parts: POST `/v1/chat` requests, persisted
- * conversation messages, and GET `/v1/chat` UI payloads. Extend here only once
- * when adding a new part type.
+ * Shared union for typed chat body parts: POST `/v1/chats/rooms/{id}/stream`
+ * requests, persisted conversation messages, and GET
+ * `/v1/chats/rooms/{id}/stream` UI payloads. Extend here only once when adding a
+ * new part type.
  */
 export const chatMessageContentPartSchema = z.union([
   chatUiFilePartSchema,
@@ -73,9 +74,6 @@ export const chatMessageContentPartSchema = z.union([
   chatUiOutputTextPartSchema,
   chatUiReasoningPartSchema,
 ]);
-
-/** Alias for GET `/v1/chat` and OpenAPI; identical to `chatMessageContentPartSchema`. */
-export const chatUiMessagePartSchema = chatMessageContentPartSchema;
 
 export const chatUiThoughtTimingMetadataSchema = z.object({
   thoughtStartedAtMs: z.number(),
@@ -89,19 +87,20 @@ export const chatUiMessageMetadataSchema = chatUiThoughtTimingMetadataSchema
   });
 
 /**
- * AI SDK `UIMessage`-compatible object returned by GET /v1/chat (`data.messages`).
- * Aligns with OpenAI-style roles and text-shaped content parts.
+ * AI SDK `UIMessage`-compatible object returned by GET
+ * `/v1/chats/rooms/{id}/stream` (`data.messages`). Aligns with OpenAI-style
+ * roles and text-shaped content parts.
  */
 export const chatUiMessageSchema = z
   .object({
     id: z.string(),
     role: z.enum(["user", "assistant", "system"]),
-    parts: z.array(chatUiMessagePartSchema),
+    parts: z.array(chatMessageContentPartSchema),
     metadata: chatUiMessageMetadataSchema.optional(),
   })
   .openapi("ChatUiMessage");
 
-/** `data` payload for GET /v1/chat success responses. */
+/** `data` payload for GET `/v1/chats/rooms/{id}/stream` success responses. */
 export const getChatUiMessagesResponseDataSchema = z
   .object({
     messages: z.array(chatUiMessageSchema),
@@ -131,35 +130,3 @@ export const getRoomChatUiMessagesQuerySchema = z
       }),
   })
   .openapi("GetRoomChatUiMessagesQuery");
-
-export const getChatUiMessagesQuerySchema = z
-  .object({
-    conversationId: z
-      .string()
-      .uuid()
-      .openapi({
-        param: { name: "conversationId", in: "query" },
-        description: "Internal conversation id",
-        example: "550e8400-e29b-41d4-a716-446655440000",
-      }),
-    cursor: z
-      .string()
-      .optional()
-      .openapi({
-        param: { name: "cursor", in: "query" },
-        description:
-          "Cursor for pagination (id of the last message from the previous page).",
-      }),
-    limit: z.coerce
-      .number()
-      .int()
-      .min(1)
-      .max(LIMITS.CHAT_UI_MESSAGES_MAX_LIMIT)
-      .default(LIMITS.CHAT_UI_MESSAGES_DEFAULT_LIMIT)
-      .openapi({
-        param: { name: "limit", in: "query" },
-        description: `Page size (max ${LIMITS.CHAT_UI_MESSAGES_MAX_LIMIT}). Cursor pagination metadata is always returned for forward compatibility.`,
-        example: LIMITS.CHAT_UI_MESSAGES_DEFAULT_LIMIT,
-      }),
-  })
-  .openapi("GetChatUiMessagesQuery");

--- a/apps/core/src/schemas/drive-file.schema.ts
+++ b/apps/core/src/schemas/drive-file.schema.ts
@@ -157,11 +157,6 @@ export const driveFileSchema = z
 export type DriveFile = z.infer<typeof driveFileSchema>;
 
 /**
- * List of drive files.
- */
-export const driveFilesSchema = z.array(driveFileSchema).openapi("DriveFiles");
-
-/**
  * Rename drive file request.
  */
 export const renameDriveFileRequestSchema = z

--- a/apps/core/src/schemas/task.schema.ts
+++ b/apps/core/src/schemas/task.schema.ts
@@ -160,17 +160,6 @@ export const taskEventSchema = z
   })
   .openapi("TaskEvent");
 
-export const taskCommentSchema = z
-  .object({
-    id: z.string().openapi({ example: "com_123" }),
-    createdAt: dateTimeSchema,
-    updatedAt: dateTimeSchema,
-    text: z.string().openapi({ example: "Looks good." }),
-    userId: z.string().nullish().openapi({ example: "user_123" }),
-    coworkerId: z.string().nullish().openapi({ example: "cow_123" }),
-  })
-  .openapi("TaskComment");
-
 const taskCreatorUserSchema = z
   .object({
     type: z.literal("user"),
@@ -375,8 +364,6 @@ export const taskSchema = taskBaseSchema
   .openapi("Task");
 
 export const taskListSchema = z.array(taskListItemSchema);
-
-export const tasksSchema = z.array(taskSchema);
 
 export const createTaskJobRequestSchema = createJobRequestSchema.extend({
   agentId: z.string().openapi({ example: "agent_123" }),

--- a/apps/core/src/schemas/x402-agent.schema.ts
+++ b/apps/core/src/schemas/x402-agent.schema.ts
@@ -152,5 +152,3 @@ export const x402AgentSchema = z
   .openapi("X402Agent");
 
 export type X402Agent = z.infer<typeof x402AgentSchema>;
-
-export const x402AgentsSchema = z.array(x402AgentSchema);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Dead OpenAPI wrappers with no remaining callers. Chat UI message comments now name the live room stream GET.

## Change

Delete six unused Zod/OpenAPI wrappers:

- `agentsSummarySchema`
- `getChatUiMessagesQuerySchema`
- `driveFilesSchema`
- `tasksSchema`
- `taskCommentSchema` (Prisma `taskComment` table already gone; comments are task events)
- `x402AgentsSchema`

Also rewrite leftover `/v1/chat` comments in `chat-ui-message.schema.ts` to `GET /v1/chats/rooms/{id}/stream`, and inline the in-file `chatUiMessagePartSchema` alias.

Left live list schemas in place (`agentListSchema`, `driveItemsSchema`, `taskListSchema`, `x402AgentSchema`). Did not touch `requireTaskCommentAccess`.

## rg proof (export-only before delete)

Monorepo `rg` for each name hit only the defining export:

```
agentsSummarySchema          apps/core/src/schemas/agent.schema.ts:337
getChatUiMessagesQuerySchema apps/core/src/schemas/chat-ui-message.schema.ts:135
driveFilesSchema             apps/core/src/schemas/drive-file.schema.ts:162
tasksSchema                  apps/core/src/schemas/task.schema.ts:379
taskCommentSchema            apps/core/src/schemas/task.schema.ts:163
x402AgentsSchema             apps/core/src/schemas/x402-agent.schema.ts:156
```

`chatUiMessagePartSchema` was an in-file alias only (`chat-ui-message.schema.ts` lines 78 and 99). After delete, the same names have zero matches.

## Out of scope

- `GET /agents/{id}` interactive `$transaction` (standing skip `core-agents-get-batch-tx`)
- `#4466` `config/constants.ts` and other open product/security PRs
- Other nightly cleanup areas

## Verification

- [x] `pnpm check` / `pnpm typecheck` (pre-commit; 19 turbo tasks)
- [x] Targeted Core tests: 5 files, 34 passed (`chat-ui-message`, `agent`, `task`, `x402-agent` schema tests + `GET .../stream/get.test.ts`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8d163a7-19dd-4a7a-9306-0a1664840ad2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8d163a7-19dd-4a7a-9306-0a1664840ad2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

