### PR TITLE
chore(database): delete unused unpublished credit splitter helper

### DIFF
--- a/packages/database/src/helpers/credit.test.ts
+++ b/packages/database/src/helpers/credit.test.ts
@@ -8,7 +8,6 @@ import {
   creditBucketActivatesAtOrBefore,
   creditBucketActivatesAtOrBeforeSql,
   getCreditExpiryDate,
-  splitAmountEvenlyWithRemainderRotation,
 } from "./credit.js";
 
 describe("creditBucketActivatesAtOrBefore", () => {
@@ -30,84 +29,6 @@ describe("creditBucketActivatesAtOrBeforeSql", () => {
     assert.ok(sqlText.includes("activatesAt"));
     assert.ok(sqlText.includes("IS NULL"));
     assert.ok(sqlText.includes(now.toISOString()));
-  });
-});
-
-describe("splitAmountEvenlyWithRemainderRotation", () => {
-  it("returns empty allocations for non-positive amounts or empty members", () => {
-    assert.deepEqual(
-      splitAmountEvenlyWithRemainderRotation({
-        memberIds: [],
-        totalAmount: 10n,
-      }),
-      {
-        allocations: [],
-        nextRemainderOffset: 0,
-      },
-    );
-
-    assert.deepEqual(
-      splitAmountEvenlyWithRemainderRotation({
-        memberIds: ["user-a", "user-b"],
-        totalAmount: 0n,
-      }),
-      {
-        allocations: [],
-        nextRemainderOffset: 0,
-      },
-    );
-  });
-
-  it("splits evenly when total is divisible by member count", () => {
-    const result = splitAmountEvenlyWithRemainderRotation({
-      memberIds: ["user-a", "user-b", "user-c"],
-      totalAmount: 12n,
-    });
-
-    assert.deepEqual(result.allocations, [
-      { memberId: "user-a", amount: 4n },
-      { memberId: "user-b", amount: 4n },
-      { memberId: "user-c", amount: 4n },
-    ]);
-    assert.equal(result.nextRemainderOffset, 0);
-  });
-
-  it("rotates remainder allocation across sequential buckets", () => {
-    const members = ["user-a", "user-b"];
-
-    const firstBucket = splitAmountEvenlyWithRemainderRotation({
-      memberIds: members,
-      totalAmount: 1n,
-      remainderOffset: 0,
-    });
-    const secondBucket = splitAmountEvenlyWithRemainderRotation({
-      memberIds: members,
-      totalAmount: 1n,
-      remainderOffset: firstBucket.nextRemainderOffset,
-    });
-
-    assert.deepEqual(firstBucket.allocations, [
-      { memberId: "user-a", amount: 1n },
-    ]);
-    assert.equal(firstBucket.nextRemainderOffset, 1);
-    assert.deepEqual(secondBucket.allocations, [
-      { memberId: "user-b", amount: 1n },
-    ]);
-    assert.equal(secondBucket.nextRemainderOffset, 0);
-  });
-
-  it("normalizes negative remainder offsets", () => {
-    const result = splitAmountEvenlyWithRemainderRotation({
-      memberIds: ["user-a", "user-b", "user-c"],
-      totalAmount: 2n,
-      remainderOffset: -1,
-    });
-
-    assert.deepEqual(result.allocations, [
-      { memberId: "user-a", amount: 1n },
-      { memberId: "user-c", amount: 1n },
-    ]);
-    assert.equal(result.nextRemainderOffset, 1);
   });
 });
 

--- a/packages/database/src/helpers/credit.ts
+++ b/packages/database/src/helpers/credit.ts
@@ -25,17 +25,6 @@ export const USER_CREDIT_REFERENCE_PREFIX = "user:";
 export const ORGANIZATION_CREDIT_REFERENCE_PREFIX = "org:";
 export const FREE_CREDIT_REFERENCE_SEGMENT = "free";
 
-interface SplitAmountEvenlyWithRemainderRotationParams {
-  memberIds: string[];
-  remainderOffset?: number;
-  totalAmount: bigint;
-}
-
-interface SplitAmountEvenlyWithRemainderRotationResult {
-  allocations: Array<{ amount: bigint; memberId: string }>;
-  nextRemainderOffset: number;
-}
-
 export function getCreditExpiryDate(baseDate: Date, days: number): Date {
   if (!Number.isFinite(days) || !Number.isInteger(days) || days < 0) {
     throw new Error("Expiry days must be a non-negative integer");
@@ -58,46 +47,6 @@ export function buildOrganizationMemberSubscriptionReferenceId(
   validateReferenceSegment(referenceSuffix, "referenceSuffix");
 
   return `${getOrganizationMemberSubscriptionReferencePrefix(userId)}${referenceSuffix}`;
-}
-
-export function splitAmountEvenlyWithRemainderRotation(
-  params: SplitAmountEvenlyWithRemainderRotationParams,
-): SplitAmountEvenlyWithRemainderRotationResult {
-  if (params.memberIds.length === 0 || params.totalAmount <= 0n) {
-    return {
-      allocations: [],
-      nextRemainderOffset: 0,
-    };
-  }
-
-  const memberCount = params.memberIds.length;
-  const memberCountBigInt = BigInt(memberCount);
-  const rawRemainderOffset = params.remainderOffset ?? 0;
-  const requestedOffset = Number.isFinite(rawRemainderOffset)
-    ? Math.trunc(rawRemainderOffset)
-    : 0;
-  const normalizedOffset =
-    ((requestedOffset % memberCount) + memberCount) % memberCount;
-  const baseAmount = params.totalAmount / memberCountBigInt;
-  const remainder = Number(params.totalAmount % memberCountBigInt);
-
-  const allocationAmounts = Array<bigint>(memberCount).fill(baseAmount);
-  for (let index = 0; index < remainder; index += 1) {
-    const targetIndex = (normalizedOffset + index) % memberCount;
-    allocationAmounts[targetIndex] += 1n;
-  }
-
-  const allocations = params.memberIds
-    .map((memberId, index) => ({
-      memberId,
-      amount: allocationAmounts[index] ?? 0n,
-    }))
-    .filter((allocation) => allocation.amount > 0n);
-
-  return {
-    allocations,
-    nextRemainderOffset: (normalizedOffset + remainder) % memberCount,
-  };
 }
 
 function validateReferenceSegment(segment: string, name: string): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pure dead-code delete. No product behavior change.

`splitAmountEvenlyWithRemainderRotation` was already unpublished from the named helpers barrel after #4405 and has no remaining callers.

## Deleted

- `splitAmountEvenlyWithRemainderRotation` plus its param/result types in `packages/database/src/helpers/credit.ts`
- Tests for that helper in `packages/database/src/helpers/credit.test.ts`

## Kept

- Named helpers barrel (`packages/database/src/helpers/index.ts`) — no #4405 re-export churn
- Subscription / credit-grant production paths

## Verification

- Repo grep: no remaining callers of the helper or its types
- `pnpm check` and `pnpm typecheck` (pre-commit) — pass
- `pnpm --filter @sokosumi/database test src/helpers/credit.test.ts` — 7 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e006a805-868d-44d5-b95d-400d17403656?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e006a805-868d-44d5-b95d-400d17403656&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

