### PR TITLE
chore(web): delete unused aurora-orb candidate picker helpers

### DIFF
--- a/apps/web/src/lib/aurora-orb.ts
+++ b/apps/web/src/lib/aurora-orb.ts
@@ -53,7 +53,7 @@ const HUES: Array<[string, number]> = [
  * tier, then the jewel tier. ~28 colours = plenty of variety between
  * coworkers while one shading recipe keeps them a family.
  */
-export const ORB_PALETTE: OrbPaletteEntry[] = [
+const ORB_PALETTE: OrbPaletteEntry[] = [
   { id: "porcelain", name: "Porcelain", tier: "anchor", hue: null },
   { id: "ink", name: "Ink", tier: "anchor", hue: null },
   ...HUES.map(
@@ -247,7 +247,7 @@ function paletteEntryForSeed(seed: string): OrbPaletteEntry {
   return TINTED[Math.floor(r() * TINTED.length)] ?? TINTED[0]!;
 }
 
-export function params(seed: string): OrbParams {
+function params(seed: string): OrbParams {
   const entry = paletteEntryForSeed(seed);
   const r = mulberry32(xmur3(`${seed}:paint`)());
   return {
@@ -258,7 +258,7 @@ export function params(seed: string): OrbParams {
   };
 }
 
-export function draw(
+function draw(
   ctx: CanvasRenderingContext2D,
   S: number,
   p: OrbParams,
@@ -330,7 +330,7 @@ const PLACEHOLDER_PARAMS: OrbParams = {
  *
  * Pure function of (ctx, S, t) — no seed, no module state.
  */
-export function drawPlaceholder(
+function drawPlaceholder(
   ctx: CanvasRenderingContext2D,
   S: number,
   t: number,
@@ -406,7 +406,7 @@ interface EyeFrame {
  *   happy                        upward "^ ^" arcs — a smile in the eyes
  *   sleeping                     closed lines
  */
-export function drawEyes(
+function drawEyes(
   ctx: CanvasRenderingContext2D,
   S: number,
   expr: OrbExpression,
@@ -796,7 +796,7 @@ export function toDataURL(
 // unique, so two coworkers with the same colour still don't look the same.
 
 /** Seed for a specific palette colour, salted for per-user face traits. */
-export function orbSeedFor(paletteId: string, salt?: string): string {
+function orbSeedFor(paletteId: string, salt?: string): string {
   return salt ? `orb:${paletteId}:${salt}` : `orb:${paletteId}`;
 }
 
@@ -805,18 +805,4 @@ export function defaultOrbSeed(userId: string): string {
   const r = mulberry32(xmur3(`${userId}:default`)());
   const entry = TINTED[Math.floor(r() * TINTED.length)] ?? TINTED[0]!;
   return orbSeedFor(entry.id, userId);
-}
-
-/**
- * Candidate seeds for the "pick your colour" selector — a tight, curated
- * set: the ink anchor plus the jewel tier (porcelain is offered separately
- * by the picker as the "standard" placeholder option), salted per user.
- * The pastel tier stays in the palette for variety elsewhere without
- * overwhelming the picker.
- */
-export function orbCandidateSeeds(userId: string, count?: number): string[] {
-  const pool = ORB_PALETTE.filter((e) => e.id === "ink" || e.tier === "jewel");
-  return pool
-    .slice(0, count ?? pool.length)
-    .map((e) => orbSeedFor(e.id, userId));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly cleanup for dead aurora-orb candidate-picker surface (`web-dead-aurora-orb-helpers`).

## Change

`apps/web/src/lib/aurora-orb.ts` only:

- Delete `orbCandidateSeeds` (unused picker seed list).
- Unexport `orbSeedFor` (still used privately by `defaultOrbSeed`).
- Unexport same-file-only helpers: `ORB_PALETTE`, `params`, `draw`, `drawPlaceholder`, `drawEyes`.

Public surface kept: `mount`, `toDataURL`, `OrbExpression`, `defaultOrbSeed` (plus existing mount types).

No replacement picker/API. Does not touch #4062.

## Verification

- `rg orbCandidateSeeds|orbSeedFor` — no external importers
- `pnpm check` + `pnpm typecheck` (precommit)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f68e32a5-e8f9-458b-93fe-8198d80931af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f68e32a5-e8f9-458b-93fe-8198d80931af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

