### PR TITLE
chore(web): drop unused siteConfig marketing fields

### DIFF
--- a/apps/web/src/config/site.ts
+++ b/apps/web/src/config/site.ts
@@ -1,15 +1,9 @@
 export const siteConfig = {
-  name: "Sokosumi",
   url: "https://app.sokosumi.com",
-  description: "Use AI coworkers to finish your most time-consuming tasks",
   links: {
-    twitter: "https://twitter.com/sokosumi",
-    github: "https://github.com/masumi-network/sokosumi",
     decisionLoggingDocs:
       "https://www.masumi.network/dev/masumi/core-concepts/decision-logging",
     jobTransactionMainnet: "https://cardanoscan.io/transaction/",
     jobTransactionPreprod: "https://preprod.cardanoscan.io/transaction/",
   },
 };
-
-export type SiteConfig = typeof siteConfig;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Drop unused marketing fields from `apps/web/src/config/site.ts`. Subtraction only — no new metadata wiring.

**Deleted (no live importers):** `name`, `description`, `links.twitter`, `links.github`, and the exported `SiteConfig` type.

**Kept:** `url`, `links.jobTransactionMainnet`, `links.jobTransactionPreprod`, `links.decisionLoggingDocs`.

Live callers remain:
- `siteConfig.url` — share page Open Graph URLs
- `siteConfig.links.jobTransactionMainnet` / `jobTransactionPreprod` — `buildJobTransactionUrl`
- `siteConfig.links.decisionLoggingDocs` — job verification badge

## Verification

- Grep: no remaining `siteConfig.name`, `siteConfig.description`, `siteConfig.links.twitter`, `siteConfig.links.github`, or `SiteConfig` importers
- `pnpm check` + `pnpm typecheck` (pre-commit hook): 19 typecheck tasks successful
- `pnpm --filter web test src/lib/utils/url.test.ts`: 1 file, 3 tests passed

Nightly cleanup area 5 from the 2026-09-12 audit. Does not invent replacements for deleted fields.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1239622-484e-499c-af01-1071702f7082?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1239622-484e-499c-af01-1071702f7082&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

