### PR TITLE
chore(database): drop unused pg-pool dependency

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -70,7 +70,6 @@
     "@sokosumi/utils": "workspace:*",
     "neverthrow": "8.2.0",
     "pg": "8.23.0",
-    "pg-pool": "3.14.0",
     "uuid": "14.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,9 +674,6 @@ importers:
       pg:
         specifier: 8.23.0
         version: 8.23.0
-      pg-pool:
-        specifier: 3.14.0
-        version: 3.14.0(pg@8.23.0)
       uuid:
         specifier: 14.0.2
         version: 14.0.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Leftover direct `pg-pool` dependency after #4399 (that PR dropped unused names but left this one). Nothing in the monorepo imports `pg-pool`; `pg@8.23.0` already depends on it.

**What changed**
- Removed the direct `"pg-pool"` dependency from `packages/database/package.json`.
- Dropped the matching importer from `pnpm-lock.yaml`.
- Left `pg` and `uuid` as they are.

**Catalog**
There is no pnpm `catalog:` entry for `pg-pool`. The only `pnpm-workspace.yaml` mention is `publicHoistPattern` (alongside `pg` and the Prisma adapter). That is hoist config, not a catalog/direct dep, so it was left in place.

**Verification**
- `pnpm install --frozen-lockfile` succeeds.
- `pnpm why pg-pool` shows `pg-pool@3.14.0` only as a transitive of `pg@8.23.0`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdbfb104-9d05-4700-8b27-51f6d5a7b235?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdbfb104-9d05-4700-8b27-51f6d5a7b235&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

