### PR TITLE
chore(database): delete unused internal types and fix stale tx JSDoc

### DIFF
--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -138,7 +138,7 @@ import {
   MemberRole,
   workspaceRelationInclude,
 } from "@sokosumi/database";
-import type { JobWithStatus } from "@sokosumi/database";
+import type { JobWithSokosumiStatus } from "@sokosumi/database";
 ```
 
 Agent query shapes used by Core:

--- a/packages/database/src/repositories/invitation.repository.ts
+++ b/packages/database/src/repositories/invitation.repository.ts
@@ -14,7 +14,7 @@ export const invitationRepository = {
    * Retrieves a pending invitation by its ID, regardless of expiration.
    *
    * @param id - The invitation ID.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns Promise resolving to the invitation with relations, or null if not found.
    */
   async getPendingInvitationById(

--- a/packages/database/src/repositories/member.repository.ts
+++ b/packages/database/src/repositories/member.repository.ts
@@ -24,7 +24,7 @@ export const memberRepository = (() => {
    * @param userId - The ID of the user to add as a member.
    * @param organizationId - The ID of the organization.
    * @param role - The role to assign to the member (e.g., ADMIN, MEMBER).
-   * @param tx - Optional Prisma transaction client for transactional operations.
+   * @param tx - The Prisma transaction client to use.
    * @returns The created Member object.
    */
   async function createMember(
@@ -54,7 +54,7 @@ export const memberRepository = (() => {
    * Retrieves all memberships for a user, including organization details.
    *
    * @param userId - The ID of the user.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns An array of MemberWithOrganization objects.
    */
   async function getMembersWithOrganizationByUserId(
@@ -74,7 +74,7 @@ export const memberRepository = (() => {
    * Retrieves all organization IDs for which the user is a member.
    *
    * @param userId - The ID of the user.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns An array of organization IDs.
    */
   async function getMembersOrganizationIdsByUserId(
@@ -93,7 +93,7 @@ export const memberRepository = (() => {
    *
    * @param userId - The ID of the user.
    * @param organizationId - The ID of the organization.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns The Member object if found, otherwise null.
    */
   async function getMemberByUserIdAndOrganizationId(
@@ -164,7 +164,7 @@ export const memberRepository = (() => {
    * Retrieves all members of a given organization.
    *
    * @param organizationId - The ID of the organization.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns An array of Member objects.
    */
   async function getMembersByOrganizationId(

--- a/packages/database/src/repositories/organization.repository.ts
+++ b/packages/database/src/repositories/organization.repository.ts
@@ -16,7 +16,7 @@ export const organizationRepository = {
    * Retrieves a unique organization with its relations based on a unique identifier.
    *
    * @param where - Unique input to identify the organization (e.g., id or slug).
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns The OrganizationWithRelations object if found, otherwise null.
    */
   async getUniqueOrganizationWithRelations(
@@ -33,7 +33,7 @@ export const organizationRepository = {
    * Retrieves an organization with its relations by organization ID.
    *
    * @param id - The ID of the organization.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns The OrganizationWithRelations object if found, otherwise null.
    */
   async getOrganizationWithRelationsById(
@@ -48,7 +48,7 @@ export const organizationRepository = {
    *
    * @param organizationId - The ID of the organization to update.
    * @param data - The update data for the organization.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns The updated OrganizationWithRelations object.
    */
   async updateOrganizationById(
@@ -119,7 +119,7 @@ export const organizationRepository = {
    * Get an organization by its Stripe customer ID.
    *
    * @param stripeCustomerId - The Stripe customer ID.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns The organization if found, null otherwise.
    */
   async getOrganizationByStripeCustomerId(

--- a/packages/database/src/repositories/user.repository.ts
+++ b/packages/database/src/repositories/user.repository.ts
@@ -22,7 +22,7 @@ export const userRepository = {
    * Retrieves a user by their unique ID.
    *
    * @param id - The unique identifier of the user.
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
+   * @param tx - The Prisma transaction client to use.
    * @returns A promise that resolves to the User object if found, or null otherwise.
    */
   getUserById: async (
@@ -36,7 +36,7 @@ export const userRepository = {
    * Get a user by their Stripe customer ID.
    *
    * @param stripeCustomerId - The Stripe customer ID.
-   * @param tx - Optional Prisma transaction client.
+   * @param tx - The Prisma transaction client to use.
    * @returns The user if found, null otherwise.
    */
   getUserByStripeCustomerId: async (
@@ -120,7 +120,7 @@ export const userRepository = {
    *
    * @param userId - The unique identifier of the user.
    * @param preferredOrganizationId - The preferred organization ID, or null for the personal workspace.
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
+   * @param tx - The Prisma transaction client to use.
    * @returns A promise that resolves to the updated User object.
    */
   updatePreferredOrganizationId: async (

--- a/packages/database/src/types/invitation.ts
+++ b/packages/database/src/types/invitation.ts
@@ -22,14 +22,6 @@ export const invitationInclude = {
   ...invitationInviterInclude,
 } as const;
 
-export type InvitationWithOrganization = Prisma.InvitationGetPayload<{
-  include: typeof invitationOrganizationInclude;
-}>;
-
-export type InvitationWithInviter = Prisma.InvitationGetPayload<{
-  include: typeof invitationInviterInclude;
-}>;
-
 export type InvitationWithRelations = Prisma.InvitationGetPayload<{
   include: typeof invitationInclude;
 }>;

--- a/packages/database/src/types/member.ts
+++ b/packages/database/src/types/member.ts
@@ -23,11 +23,6 @@ export const memberOrderBy = [
   { ...memberUserNameOrderBy },
 ] as const;
 
-export const memberInclude = {
-  ...memberOrganizationInclude,
-  ...memberUserInclude,
-} as const;
-
 export type MemberWithOrganization = Prisma.MemberGetPayload<{
   include: typeof memberOrganizationInclude;
 }>;
@@ -44,7 +39,3 @@ export type MemberWithUser = Prisma.MemberGetPayload<{
 export type MemberWithUserAndLastSeen = MemberWithUser & {
   lastSeenAt: Date | null;
 };
-
-export type MemberWithRelations = Prisma.MemberGetPayload<{
-  include: typeof memberInclude;
-}>;

--- a/packages/database/src/types/organization.ts
+++ b/packages/database/src/types/organization.ts
@@ -14,12 +14,6 @@ export const organizationMembersCountInclude = {
   },
 } as const;
 
-export const organizationOrderBy = {
-  members: {
-    _count: "desc",
-  },
-} as const;
-
 export const organizationInclude = {
   ...organizationMembersCountInclude,
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pure dead-code/docs cleanup. No product behavior change. No migrations. These types were never on the public `@sokosumi/database` index.

## Deleted

- `organizationOrderBy` in `packages/database/src/types/organization.ts`
- `MemberWithRelations` and `memberInclude` in `packages/database/src/types/member.ts`
- `InvitationWithOrganization` and `InvitationWithInviter` in `packages/database/src/types/invitation.ts`

## Fixed

- README named export example: `JobWithStatus` → `JobWithSokosumiStatus` (helper stays `mapJobWithStatus`)
- Lying optional `@param tx` JSDoc on user/member/organization/invitation repositories — `tx` is required `Prisma.TransactionClient`

## Kept

- `organizationInclude`
- `MemberWithOrganization` / `MemberWithUser` / `MemberWithUserAndLastSeen`
- `InvitationWithRelations`, `invitationInclude`, and include fragments
- `InvitationStatus.EXPIRED`

## Verification

- Repo grep: no remaining callers of the deleted symbols
- `pnpm check` and `pnpm typecheck` (pre-commit) — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08c2ef14-0e5b-4259-8485-00de3d033b80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08c2ef14-0e5b-4259-8485-00de3d033b80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

