### PR TITLE
chore(web): unexport unused action/schema/gtm/auth leftovers

### DIFF
--- a/apps/web/src/lib/actions/agent/create-agent-rating.ts
+++ b/apps/web/src/lib/actions/agent/create-agent-rating.ts
@@ -10,7 +10,7 @@ import {
 import { getSession } from "@/lib/auth/auth.server";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 
-export interface AgentRatingError {
+interface AgentRatingError {
   code:
     | "UNAUTHORIZED"
     | "INVALID_RATING"

--- a/apps/web/src/lib/actions/enterprise-contract/action.ts
+++ b/apps/web/src/lib/actions/enterprise-contract/action.ts
@@ -29,7 +29,7 @@ import {
   withSession,
 } from "@/middleware/auth-middleware";
 
-export type EnterpriseContractActionError =
+type EnterpriseContractActionError =
   | ActionError
   | EnterpriseContractActivationBlockedError;
 

--- a/apps/web/src/lib/actions/job/core-job-input.ts
+++ b/apps/web/src/lib/actions/job/core-job-input.ts
@@ -2,7 +2,7 @@ import * as z from "zod";
 import type { PostAgentsByIdJobsData } from "@/lib/clients/generated/core";
 import type { ProvideJobInputSchemaType } from "@/lib/schemas";
 
-export type CoreJobInputData = NonNullable<
+type CoreJobInputData = NonNullable<
   PostAgentsByIdJobsData["body"]
 >["inputData"];
 

--- a/apps/web/src/lib/actions/subscription/action.ts
+++ b/apps/web/src/lib/actions/subscription/action.ts
@@ -21,8 +21,6 @@ import {
   withSession,
 } from "@/middleware/auth-middleware";
 
-export type { SubscriptionChangeResult } from "@/lib/auth/subscription.server";
-
 export async function upgradePersonalSubscription({
   plan,
   returnPath,

--- a/apps/web/src/lib/auth/admin-access.ts
+++ b/apps/web/src/lib/auth/admin-access.ts
@@ -6,8 +6,6 @@ import { getSessionOrRedirect } from "@/lib/auth/auth.server";
 import { AdminAccessRequiredError } from "@/lib/auth/errors";
 import { hasAdminRole } from "@/lib/auth/has-admin-role";
 
-export { hasAdminRole } from "@/lib/auth/has-admin-role";
-
 function getSessionUserRole(session: Session): string | null | undefined {
   const user = session.user as Session["user"] & { role?: string | null };
   return user.role ?? undefined;

--- a/apps/web/src/lib/gtm-events/index.ts
+++ b/apps/web/src/lib/gtm-events/index.ts
@@ -1,6 +1,12 @@
+import { sendGTMEvent } from "@next/third-parties/google";
 import type { AuthMethodId } from "@/lib/schemas/auth";
+import type { GTMEvent } from "./types";
 
-import { fireEvent } from "./utils";
+function fireEvent(event: GTMEvent) {
+  if (typeof window !== "undefined") {
+    sendGTMEvent(event);
+  }
+}
 
 export const fireGTMEvent = {
   viewRegisterArea() {

--- a/apps/web/src/lib/gtm-events/utils.ts
+++ b/apps/web/src/lib/gtm-events/utils.ts
@@ -1,9 +1,0 @@
-import { sendGTMEvent } from "@next/third-parties/google";
-
-import type { GTMEvent } from "./types";
-
-export function fireEvent(event: GTMEvent) {
-  if (typeof window !== "undefined") {
-    sendGTMEvent(event);
-  }
-}

--- a/apps/web/src/lib/helpers/agent.ts
+++ b/apps/web/src/lib/helpers/agent.ts
@@ -127,9 +127,7 @@ interface AgentAuthorSource {
   };
 }
 
-export function getAgentAuthorOrganization(
-  agent: AgentAuthorSource,
-): string | null {
+function getAgentAuthorOrganization(agent: AgentAuthorSource): string | null {
   return agent.author.organization ?? null;
 }
 

--- a/apps/web/src/lib/schemas/category.ts
+++ b/apps/web/src/lib/schemas/category.ts
@@ -1,12 +1,12 @@
 import * as z from "zod";
 
-export const categoryGradientStopSchema = z.object({
+const categoryGradientStopSchema = z.object({
   color: z.string(),
   offset: z.number().min(0).max(1),
   opacity: z.number().min(0).max(1).optional(),
 });
 
-export const categoryGradientSchema = z.object({
+const categoryGradientSchema = z.object({
   type: z.string(),
   angle: z.number().optional(),
   shape: z.string().optional(),
@@ -20,7 +20,7 @@ export const categoryGradientSchema = z.object({
   stops: z.array(categoryGradientStopSchema).min(1),
 });
 
-export const categoryStyleThemeSchema = z.object({
+const categoryStyleThemeSchema = z.object({
   color: z.string().optional(),
   border: z
     .object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Drop unused public exports and re-export lines in `apps/web`. Callers that already import the real module are unchanged. `actions/index.ts` is not expanded.

## What changed

- Unexport same-file leftovers: `EnterpriseContractActionError`, `AgentRatingError`, `CoreJobInputData`, `categoryGradientStopSchema` / `categoryGradientSchema` / `categoryStyleThemeSchema`, `getAgentAuthorOrganization`
- Delete re-export lines: `hasAdminRole` from `admin-access.ts` (callers already use `@/lib/auth/has-admin-role`); `SubscriptionChangeResult` from the subscription action (canonical type stays on `subscription.server`)
- Make GTM `fireEvent` module-private (colocated next to `fireGTMEvent`) and keep every `fireGTMEvent.*` export

## Verification

- Grep: none of the named symbols remain on a public/re-export surface; no cross-module importer needed the old export path
- `pnpm check` and `pnpm typecheck` (pre-commit, turbo 19/19)
- Targeted web tests: `core-job-input`, `admin-access`, `agent` helpers — 4 files, 11 passed

No user-facing behavior change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-839329f8-d702-4b39-9c32-f2790a6a24cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-839329f8-d702-4b39-9c32-f2790a6a24cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

