### PR TITLE
chore(web): delete useModal Host wrappers and rename invite modal props

### DIFF
--- a/apps/web/src/app/(app)/organizations/[organizationSlug]/components/organization-invite-button.tsx
+++ b/apps/web/src/app/(app)/organizations/[organizationSlug]/components/organization-invite-button.tsx
@@ -14,49 +14,15 @@ interface OrganizationInviteButtonProps {
   className?: string | undefined;
 }
 
-interface OrganizationMemberInviteModalHostProps {
-  open: boolean;
-  onOpenChange: React.Dispatch<React.SetStateAction<boolean>>;
-  organizationId: string;
-}
-
-function OrganizationMemberInviteModalHost({
-  open,
-  onOpenChange,
-  organizationId,
-}: OrganizationMemberInviteModalHostProps) {
-  return (
-    <OrganizationMemberInviteModal
-      open={open}
-      onOpenChange={onOpenChange}
-      organizationId={organizationId}
-    />
-  );
-}
-
-function OrganizationBulkInviteModalHost({
-  open,
-  onOpenChange,
-  organizationId,
-}: OrganizationMemberInviteModalHostProps) {
-  return (
-    <OrganizationBulkInviteModal
-      open={open}
-      onOpenChange={onOpenChange}
-      organizationId={organizationId}
-    />
-  );
-}
-
 export default function OrganizationInviteButton({
   organizationId,
   className,
 }: OrganizationInviteButtonProps) {
   const t = useTranslations("App.Organizations.OrganizationDetail");
   const { Component: InviteMemberModal, showModal: showInviteMemberModal } =
-    useModal(OrganizationMemberInviteModalHost, { organizationId });
+    useModal(OrganizationMemberInviteModal, { organizationId });
   const { Component: BulkInviteModal, showModal: showBulkInviteModal } =
-    useModal(OrganizationBulkInviteModalHost, { organizationId });
+    useModal(OrganizationBulkInviteModal, { organizationId });
 
   return (
     <>

--- a/apps/web/src/app/(app)/organizations/[organizationSlug]/components/organization-remove-button.tsx
+++ b/apps/web/src/app/(app)/organizations/[organizationSlug]/components/organization-remove-button.tsx
@@ -17,32 +17,6 @@ interface OrganizationRemoveButtonProps {
   preflightFailed?: boolean;
 }
 
-interface OrganizationRemoveModalHostProps {
-  open: boolean;
-  onOpenChange: React.Dispatch<React.SetStateAction<boolean>>;
-  organization: OrganizationRecord;
-  blockers?: OrganizationDeletionEvaluation["blockers"];
-  preflightFailed?: boolean;
-}
-
-function OrganizationRemoveModalHost({
-  open,
-  onOpenChange,
-  organization,
-  blockers = [],
-  preflightFailed = false,
-}: OrganizationRemoveModalHostProps) {
-  return (
-    <OrganizationRemoveModal
-      open={open}
-      onOpenChange={onOpenChange}
-      organization={organization}
-      blockers={blockers}
-      preflightFailed={preflightFailed}
-    />
-  );
-}
-
 export default function OrganizationRemoveButton({
   organization,
   className,
@@ -50,7 +24,7 @@ export default function OrganizationRemoveButton({
   preflightFailed = false,
 }: OrganizationRemoveButtonProps) {
   const t = useTranslations("App.Organizations.OrganizationDetail");
-  const { Component, showModal } = useModal(OrganizationRemoveModalHost, {
+  const { Component, showModal } = useModal(OrganizationRemoveModal, {
     organization,
     blockers,
     preflightFailed,

--- a/apps/web/src/app/(app)/tasks/components/task-share-button.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-share-button.tsx
@@ -4,40 +4,9 @@ import { Share } from "lucide-react";
 import type { TaskWithCoworker } from "@/app/tasks/types/task-board";
 import { Button } from "@/components/ui/button";
 import useModal from "@/hooks/use-modal";
-import type { TaskShare } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 
 import { TaskShareModal } from "./task-share-modal";
-
-interface TaskShareModalHostProps {
-  open: boolean;
-  onOpenChange: React.Dispatch<React.SetStateAction<boolean>>;
-  taskId: string;
-  share: TaskShare | null;
-}
-
-/**
- * useModal renders its first argument as the modal component type. Passing an
- * inline render prop there creates a fresh component type every render, so
- * React remounts TaskShareModal and re-runs useState(share) from a potentially
- * stale RSC prop before router.refresh() finishes. Keep the host component
- * stable and pass changing task props separately through the hook.
- */
-function TaskShareModalHost({
-  open,
-  onOpenChange,
-  taskId,
-  share,
-}: TaskShareModalHostProps) {
-  return (
-    <TaskShareModal
-      open={open}
-      onOpenChange={onOpenChange}
-      taskId={taskId}
-      share={share}
-    />
-  );
-}
 
 interface TaskShareButtonProps {
   task: Pick<TaskWithCoworker, "id" | "share">;
@@ -54,7 +23,7 @@ export function TaskShareButton({
   variant = "ghost",
   size = "icon",
 }: TaskShareButtonProps) {
-  const { showModal, Component } = useModal(TaskShareModalHost, {
+  const { showModal, Component } = useModal(TaskShareModal, {
     taskId: task.id,
     share: task.share ?? null,
   });

--- a/apps/web/src/components/jobs/job-details/job-share-button.tsx
+++ b/apps/web/src/components/jobs/job-details/job-share-button.tsx
@@ -10,20 +10,6 @@ import { cn } from "@/lib/utils";
 
 import JobShareModal from "./job-share-modal";
 
-interface JobShareModalHostProps {
-  open: boolean;
-  onOpenChange: React.Dispatch<React.SetStateAction<boolean>>;
-  job: Job;
-}
-
-function JobShareModalHost({
-  open,
-  onOpenChange,
-  job,
-}: JobShareModalHostProps) {
-  return <JobShareModal open={open} onOpenChange={onOpenChange} job={job} />;
-}
-
 interface JobShareButtonProps {
   job: Job;
   label?: string;
@@ -41,7 +27,7 @@ export default function JobShareButton({
 }: JobShareButtonProps) {
   const t = useTranslations("Components.Jobs.JobDetails.JobShare");
   const resolvedLabel = label ?? t("share");
-  const { showModal, Component } = useModal(JobShareModalHost, { job });
+  const { showModal, Component } = useModal(JobShareModal, { job });
 
   return (
     <>

--- a/apps/web/src/components/organizations/organization-member-invite/modal.tsx
+++ b/apps/web/src/components/organizations/organization-member-invite/modal.tsx
@@ -12,7 +12,7 @@ import {
 
 import OrganizationMemberInviteForm from "./form";
 
-interface OrganizationInformationEditModalProps {
+interface OrganizationMemberInviteModalProps {
   open: boolean;
   onOpenChange: Dispatch<SetStateAction<boolean>>;
   organizationId: string;
@@ -22,7 +22,7 @@ export default function OrganizationMemberInviteModal({
   open,
   onOpenChange,
   organizationId,
-}: OrganizationInformationEditModalProps) {
+}: OrganizationMemberInviteModalProps) {
   const t = useTranslations("Components.Organizations.InviteMemberModal");
   const [isLoading, setIsLoading] = useState(false);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Passthrough `useModal` Host wrappers around org invite/bulk-invite/remove and job/task share added no behavior. Callers now pass the real modal plus extra props, matching `CreateOrganizationWizard`. Also rename copy-pasted `OrganizationInformationEditModalProps` to `OrganizationMemberInviteModalProps`.

No UX change.

## Verification

- `pnpm --filter web exec biome check` on the five touched files
- `pnpm --filter web typecheck`
- `pnpm --filter web test src/hooks/use-modal.test.tsx`
- Husky `pnpm check` + `pnpm typecheck` on commit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9da1b980-a506-4fba-8dc1-968f745d8942?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9da1b980-a506-4fba-8dc1-968f745d8942&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

