### PR TITLE
chore(web): dedupe keyboard and video url helpers

### DIFF
--- a/apps/web/src/app/(app)/components/notice-dialog.tsx
+++ b/apps/web/src/app/(app)/components/notice-dialog.tsx
@@ -17,7 +17,7 @@ import {
 import { acknowledgeNoticeAction } from "@/lib/actions/notice";
 import type { Notice } from "@/lib/clients/generated/core";
 import { NoticeKind } from "@/lib/clients/generated/core";
-import { isVideoUrl } from "@/lib/utils/notice-media";
+import { isVideoUrl } from "@/lib/utils/file-preview";
 import { parseNoticeTemplate } from "@/lib/utils/notice-template";
 
 const Markdown = dynamic(() => import("@/components/markdown"), {

--- a/apps/web/src/app/(app)/components/sidebar/components/announcement-cards.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/announcement-cards.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { useSidebar } from "@/components/ui/sidebar";
 import type { Notice } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
-import { isVideoUrl } from "@/lib/utils/notice-media";
+import { isVideoUrl } from "@/lib/utils/file-preview";
 import { parseNoticeTemplate } from "@/lib/utils/notice-template";
 
 const Markdown = dynamic(() => import("@/components/markdown"), {

--- a/apps/web/src/lib/utils/notice-media.ts
+++ b/apps/web/src/lib/utils/notice-media.ts
@@ -1,3 +1,0 @@
-export function isVideoUrl(url: string): boolean {
-  return /\.(mp4|webm|ogg)(\?|#|$)/i.test(url);
-}

--- a/apps/web/src/lib/utils/visual-viewport-keyboard.test.ts
+++ b/apps/web/src/lib/utils/visual-viewport-keyboard.test.ts
@@ -1,31 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  isEditableKeyboardTarget,
   isVisualViewportKeyboardOpen,
   readVisualViewportKeyboardOpen,
   resetVisualViewportKeyboardBaseline,
   VISUAL_VIEWPORT_KEYBOARD_OPEN_THRESHOLD_PX,
 } from "./visual-viewport-keyboard";
-
-describe("isEditableKeyboardTarget", () => {
-  it("accepts textarea, input, select, and contentEditable", () => {
-    const textarea = document.createElement("textarea");
-    const input = document.createElement("input");
-    const select = document.createElement("select");
-    const editable = document.createElement("div");
-    editable.contentEditable = "true";
-    expect(isEditableKeyboardTarget(textarea)).toBe(true);
-    expect(isEditableKeyboardTarget(input)).toBe(true);
-    expect(isEditableKeyboardTarget(select)).toBe(true);
-    expect(isEditableKeyboardTarget(editable)).toBe(true);
-  });
-
-  it("rejects non-editables", () => {
-    expect(isEditableKeyboardTarget(document.createElement("div"))).toBe(false);
-    expect(isEditableKeyboardTarget(null)).toBe(false);
-  });
-});
 
 describe("isVisualViewportKeyboardOpen", () => {
   it("is false when no editable is focused (autofocus / idle)", () => {
@@ -145,7 +125,6 @@ describe("readVisualViewportKeyboardOpen", () => {
     expect(readVisualViewportKeyboardOpen()).toBe(false);
     (document.activeElement as HTMLElement | null)?.blur?.();
     stubViewport(500, 500);
-    expect(isEditableKeyboardTarget(document.activeElement)).toBe(false);
     expect(readVisualViewportKeyboardOpen()).toBe(false);
   });
 

--- a/apps/web/src/lib/utils/visual-viewport-keyboard.ts
+++ b/apps/web/src/lib/utils/visual-viewport-keyboard.ts
@@ -1,3 +1,5 @@
+import { isEditableKeyboardTarget } from "./is-editable-keyboard-target";
+
 /**
  * Soft-keyboard heuristic for iOS Safari / standalone PWA and Android.
  *
@@ -21,23 +23,6 @@ let maxVisualHeightPx = 0;
 export function resetVisualViewportKeyboardBaseline(): void {
   maxLayoutHeightPx = 0;
   maxVisualHeightPx = 0;
-}
-
-export function isEditableKeyboardTarget(
-  target: EventTarget | null | undefined,
-): boolean {
-  if (target == null || typeof target !== "object") {
-    return false;
-  }
-  const el = target as {
-    tagName?: string;
-    isContentEditable?: boolean;
-  };
-  if (el.isContentEditable) {
-    return true;
-  }
-  const tag = el.tagName;
-  return tag === "TEXTAREA" || tag === "INPUT" || tag === "SELECT";
 }
 
 export interface VisualViewportKeyboardOpenOptions {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Scoped web helper cleanup only. Two duplicate pairs collapse onto existing shared helpers. No product or UX change.

## Keyboard helper
- Keep `apps/web/src/lib/utils/is-editable-keyboard-target.ts` (includes `closest('[contenteditable]')`).
- `visual-viewport-keyboard.ts` now imports that helper and no longer defines a local copy.
- Duplicate `isEditableKeyboardTarget` tests were removed from `visual-viewport-keyboard.test.ts`; coverage stays on the shared module.

## Video URL helper
- Deleted `apps/web/src/lib/utils/notice-media.ts`.
- `notice-dialog.tsx` and `announcement-cards.tsx` import `isVideoUrl` from `file-preview` (same helper markdown already uses; extension set includes `mov` / `m4v`).

## Verification
- `pnpm --filter web test` on `is-editable-keyboard-target`, `visual-viewport-keyboard`, `file-preview`, `use-keyboard-open`
- `pnpm check` / `pnpm typecheck` (pre-commit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7899166d-38cd-467b-8c34-1186a9261dbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7899166d-38cd-467b-8c34-1186a9261dbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

