### PR TITLE
chore(web): point in-app auth navigation at /signin instead of /login

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/task-share-modal.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-share-modal.tsx
@@ -97,7 +97,7 @@ export function TaskShareModal({
           action: {
             label: t("Errors.unauthenticatedAction"),
             onClick: () => {
-              router.push("/login");
+              router.push("/signin");
             },
           },
         });

--- a/apps/web/src/app/(auth)/error.tsx
+++ b/apps/web/src/app/(auth)/error.tsx
@@ -48,7 +48,7 @@ export default function Error({
             {t("tryAgain")}
           </Button>
           <Button asChild variant="secondary" className="w-full">
-            <Link href="/login">{t("goLogin")}</Link>
+            <Link href="/signin">{t("goLogin")}</Link>
           </Button>
         </CardFooter>
       </Card>

--- a/apps/web/src/app/(auth)/forgot-password/components/form.tsx
+++ b/apps/web/src/app/(auth)/forgot-password/components/form.tsx
@@ -46,7 +46,7 @@ export default function ForgotPasswordForm({
     }
 
     toast.success(t("success"));
-    router.push("/login");
+    router.push("/signin");
   }
 
   const { isSubmitting } = form.formState;

--- a/apps/web/src/app/(auth)/reset-password/components/form.tsx
+++ b/apps/web/src/app/(auth)/reset-password/components/form.tsx
@@ -45,7 +45,7 @@ export default function ResetPasswordForm({ token }: ResetPasswordFormProps) {
     }
 
     toast.success(t("success"));
-    router.push("/login");
+    router.push("/signin");
   }
 
   const { isSubmitting } = form.formState;

--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -24,7 +24,7 @@ export default async function ResetPasswordPage({
   const { token } = await searchParams;
 
   if (!token) {
-    redirect("/login");
+    redirect("/signin");
   }
 
   return (

--- a/apps/web/src/app/(auth)/signin/components/form.tsx
+++ b/apps/web/src/app/(auth)/signin/components/form.tsx
@@ -61,7 +61,7 @@ export default function SignInForm({
     },
   });
 
-  // when user first sees the register page
+  // when user first sees the login area
   useEffect(() => {
     fireGTMEvent.viewLoginArea();
   }, []);

--- a/apps/web/src/app/(auth)/signup/components/form.tsx
+++ b/apps/web/src/app/(auth)/signup/components/form.tsx
@@ -160,7 +160,7 @@ export default function SignUpForm({
             {t("Login.message")}
           </span>
           <Link
-            href="/login"
+            href="/signin"
             className="text-primary text-sm font-medium hover:underline"
           >
             {t("Login.link")}

--- a/apps/web/src/app/(auth)/signup/loading.tsx
+++ b/apps/web/src/app/(auth)/signup/loading.tsx
@@ -24,7 +24,7 @@ export default function RegisterLoadingPage() {
             {t("Form.Login.message")}
           </span>
           <Link
-            href="/login"
+            href="/signin"
             className="text-primary text-sm font-medium hover:underline"
           >
             {t("Form.Login.link")}

--- a/apps/web/src/components/billing/organization-subscription-section.tsx
+++ b/apps/web/src/components/billing/organization-subscription-section.tsx
@@ -109,7 +109,7 @@ export function OrganizationSubscriptionSection({
     isEnterpriseContract && !isEnterpriseConsumable;
 
   const handleOpenLogin = useCallback(() => {
-    router.push("/login");
+    router.push("/signin");
   }, [router]);
 
   const getSubscriptionActionErrorMessage = useCallback(

--- a/apps/web/src/components/billing/personal-subscription-section.tsx
+++ b/apps/web/src/components/billing/personal-subscription-section.tsx
@@ -90,7 +90,7 @@ export function PersonalSubscriptionSection({
               action: {
                 label: t("Errors.unauthenticatedAction"),
                 onClick: () => {
-                  router.push("/login");
+                  router.push("/signin");
                 },
               },
             });

--- a/apps/web/src/components/credits/coupon-form.tsx
+++ b/apps/web/src/components/credits/coupon-form.tsx
@@ -109,7 +109,7 @@ export default function CouponForm({
                   action: {
                     label: t("Errors.unauthenticatedAction"),
                     onClick: () => {
-                      router.push(`/login`);
+                      router.push(`/signin`);
                     },
                   },
                 });

--- a/apps/web/src/components/credits/credits-form.tsx
+++ b/apps/web/src/components/credits/credits-form.tsx
@@ -174,7 +174,7 @@ export default function CreditsForm({
               action: {
                 label: t("Errors.unauthenticatedAction"),
                 onClick: () => {
-                  router.push(`/login`);
+                  router.push(`/signin`);
                 },
               },
             });

--- a/apps/web/src/components/jobs/job-details/job-details-name.tsx
+++ b/apps/web/src/components/jobs/job-details/job-details-name.tsx
@@ -81,7 +81,7 @@ export function useJobDetailsNameController(
           action: {
             label: t("Errors.unauthenticatedAction"),
             onClick: () => {
-              router.push(`/login`);
+              router.push(`/signin`);
             },
           },
         });

--- a/apps/web/src/components/jobs/job-details/job-share-modal.tsx
+++ b/apps/web/src/components/jobs/job-details/job-share-modal.tsx
@@ -93,7 +93,7 @@ export default function JobShareModal({
           action: {
             label: t("Errors.unauthenticatedAction"),
             onClick: () => {
-              router.push(`/login`);
+              router.push(`/signin`);
             },
           },
         });

--- a/apps/web/src/components/jobs/job-details/refund-request.tsx
+++ b/apps/web/src/components/jobs/job-details/refund-request.tsx
@@ -302,7 +302,7 @@ export default function RequestRefundButton({
             action: {
               label: t("Errors.unauthenticatedAction"),
               onClick: () => {
-                router.push(`/login`);
+                router.push(`/signin`);
               },
             },
           });

--- a/apps/web/src/components/members-table/invitation-actions-modal-context.tsx
+++ b/apps/web/src/components/members-table/invitation-actions-modal-context.tsx
@@ -56,7 +56,7 @@ export function InvitationActionsModalContextProvider({
         action: {
           label: t("Errors.unauthorizedAction"),
           onClick: () => {
-            router.push(`/login`);
+            router.push(`/signin`);
           },
         },
       });

--- a/apps/web/src/components/members-table/member-actions-modal-context.tsx
+++ b/apps/web/src/components/members-table/member-actions-modal-context.tsx
@@ -115,7 +115,7 @@ export function MemberActionsModalContextProvider({
         action: {
           label: t("Errors.unauthorizedAction"),
           onClick: () => {
-            router.push(`/login`);
+            router.push(`/signin`);
           },
         },
       });

--- a/apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
+++ b/apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
@@ -395,7 +395,7 @@ export function CreateOrganizationWizard({
           toast.error(message, {
             action: {
               label: t("Errors.unauthorizedAction"),
-              onClick: () => router.push("/login"),
+              onClick: () => router.push("/signin"),
             },
           });
         } else {

--- a/apps/web/src/components/organizations/organization-information/form.tsx
+++ b/apps/web/src/components/organizations/organization-information/form.tsx
@@ -234,7 +234,7 @@ export default function OrganizationInformationForm({
             action: {
               label: t("Errors.unauthorizedAction"),
               onClick: async () => {
-                router.push("/login");
+                router.push("/signin");
               },
             },
           });

--- a/apps/web/src/components/organizations/organization-member-invite/form.tsx
+++ b/apps/web/src/components/organizations/organization-member-invite/form.tsx
@@ -59,7 +59,7 @@ export default function OrganizationMemberInviteForm({
           action: {
             label: t("Errors.unauthorizedAction"),
             onClick: () => {
-              router.push("/login");
+              router.push("/signin");
             },
           },
         });

--- a/apps/web/src/components/organizations/organization-remove/form.tsx
+++ b/apps/web/src/components/organizations/organization-remove/form.tsx
@@ -150,7 +150,7 @@ export default function OrganizationRemoveForm({
           action: {
             label: t("Errors.unauthorizedAction"),
             onClick: async () => {
-              router.push("/login");
+              router.push("/signin");
             },
           },
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
In-app auth navigation now goes to `/signin` instead of `/login`. Bookmark shims stay: `/login` and `/register` still redirect (query preserved via `getRedirectQueryString`), and `proxy.ts` still allowlists both paths.

## What changed
- Replaced remaining in-app `href` / `router.push` / `redirect` callers that sent people to `/login` with `/signin` (signup, auth error, reset/forgot-password, org/billing/credits/jobs/members, task share).
- Corrected the copy-paste GTM comment on the sign-in form (`register page` → `login area`).

## What did not change
- `/login` and `/register` pages remain as bookmark shims.
- `proxy.ts` `EXCLUDED_PATHS` still includes `/login` and `/register`.
- No org slug path consolidation, no new redirect helpers.

## Verification
- Grep: no remaining in-app `/login` hrefs/redirects in `apps/web/src` except `proxy.ts` allowlist.
- `pnpm check` and `pnpm typecheck` via husky (green).
- Runtime: `/login` → `/signin`, `/login?returnUrl=/agents` → `/signin?returnUrl=%2Fagents`, `/reset-password` (no token) → `/signin`, `/signup` Login link → `/signin`, `/register` → `/signup`.

<a href="https://cursor.com/agents/bc-38c35de5-1614-4112-a16e-e3dfc5ffe9db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-nav-signin-shims.mp4"><img src="https://cursor.com/artifacts/c/art-3dd3113b-46cb-4cad-a76d-0a988dfcdf48" alt="auth-nav-signin-shims.mp4" /></a>
![Signup Login link on /signup](https://cursor.com/artifacts/c/art-2024b32a-2207-4d61-87dd-b2716a48ea49)
![/login bookmark shim lands on /signin](https://cursor.com/artifacts/c/art-55ad6662-425d-475a-9127-6e7259245616)
![/login?returnUrl=/agents lands on /signin with query](https://cursor.com/artifacts/c/art-726f5141-cda7-434f-8666-a7054f588aa1)
![/register bookmark shim lands on /signup](https://cursor.com/artifacts/c/art-5de1492b-3597-485d-84a9-c577a0c03885)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38c35de5-1614-4112-a16e-e3dfc5ffe9db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38c35de5-1614-4112-a16e-e3dfc5ffe9db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

