### PR TITLE
chore(core): delete narrating comments in stripe invoice credit service

### DIFF
--- a/apps/core/src/services/stripe-invoice-credit.service.ts
+++ b/apps/core/src/services/stripe-invoice-credit.service.ts
@@ -397,7 +397,6 @@ function buildInvoiceCreditGrants(
 export async function handleInvoicePaidEvent(
   invoice: Stripe.Invoice,
 ): Promise<void> {
-  // Validate invoice has required data
   if (!invoice.id) {
     return;
   }
@@ -411,28 +410,23 @@ export async function handleInvoicePaidEvent(
     return;
   }
 
-  // Get the Stripe customer ID from the invoice
   const stripeCustomerId =
     typeof invoice.customer === "string"
       ? invoice.customer
       : invoice.customer.id;
 
-  // Look up the user or organization by stripeCustomerId
   let userId: string | null = null;
   let organizationId: string | null = null;
   let purchasedSeats = 1;
 
-  // First, try to find a user with this stripeCustomerId
   const user = await userRepository.getUserByStripeCustomerId(
     stripeCustomerId,
     prisma,
   );
 
   if (user) {
-    // This is a user purchase
     userId = user.id;
   } else {
-    // Try to find an organization with this stripeCustomerId
     const organization =
       await organizationRepository.getOrganizationByStripeCustomerId(
         stripeCustomerId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Comment-only cleanup in `handleInvoicePaidEvent`.

Removes six restating comments that duplicated the next line of lookup/branch logic in `apps/core/src/services/stripe-invoice-credit.service.ts`. Control flow is unchanged. The 5xx retry why-comment stays: a silent 200 would drop credits when the Stripe customer-id write-back has not landed yet.

## Verification

- `pnpm check` and `pnpm typecheck` via pre-commit hook (green)
- Diff is six comment deletions in one file; no tests added (comment-only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c65d494-8d50-4e2f-af68-318d9400bbe3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c65d494-8d50-4e2f-af68-318d9400bbe3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

