### PR TITLE
chore(web): delete narrating comments in members-table, auth, star-rating, and auth errors

### DIFF
--- a/apps/web/src/app/(auth)/error.tsx
+++ b/apps/web/src/app/(auth)/error.tsx
@@ -22,10 +22,7 @@ export default function Error({
 }) {
   const t = useTranslations("Auth.Error");
 
-  // Effect is necessary: Error logging when component is displayed
-  // Logs error to console (or error reporting service) when error occurs
   useEffect(() => {
-    // Log the error to an error reporting service
     console.error(error);
   }, [error]);
 

--- a/apps/web/src/app/(auth)/oauth/callback/page.tsx
+++ b/apps/web/src/app/(auth)/oauth/callback/page.tsx
@@ -50,7 +50,6 @@ export default function OAuthCallbackPage() {
   const errorDescription = searchParams.get("error_description");
 
   useEffect(() => {
-    // Check for OAuth error in URL
     if (oauthError) {
       setError(
         errorDescription || oauthError || t("errors.authorizationFailed"),
@@ -173,7 +172,6 @@ export default function OAuthCallbackPage() {
     }
   }
 
-  // Show error if OAuth error in URL
   if (oauthError) {
     return (
       <div className="container mx-auto max-w-2xl py-8">
@@ -203,7 +201,6 @@ export default function OAuthCallbackPage() {
     );
   }
 
-  // Show success if we have a token response
   if (tokenResponse?.access_token) {
     const { showApiAccessWarning, showRefreshWarning } =
       getOAuthCallbackTokenWarnings(tokenResponse);
@@ -303,7 +300,6 @@ export default function OAuthCallbackPage() {
     );
   }
 
-  // Show form to exchange code
   return (
     <div className="container mx-auto max-w-2xl py-8">
       <Card>

--- a/apps/web/src/app/(auth)/oauth/consent/page.tsx
+++ b/apps/web/src/app/(auth)/oauth/consent/page.tsx
@@ -61,14 +61,12 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
     );
   }
 
-  // Check if user is authenticated
   const session = await getSession();
 
   if (!session?.session) {
     redirect(redirectQuery ? `/signin?${redirectQuery}` : "/signin");
   }
 
-  // Fetch public client info for display on consent page
   const clientResult = await getOAuthClientPublic(client_id);
 
   if (clientResult.isErr()) {

--- a/apps/web/src/components/agents/star-rating.tsx
+++ b/apps/web/src/components/agents/star-rating.tsx
@@ -32,7 +32,6 @@ export function StarRating({
     lg: "gap-1",
   };
 
-  // Calculate star fills based on average rating
   const fullStars = Math.floor(averageRating);
   const partialFillPercent = (averageRating % 1) * 100;
   const hasPartialStar = partialFillPercent > 0;
@@ -40,22 +39,18 @@ export function StarRating({
 
   const starFills: number[] = [];
 
-  // Add full stars
   for (let i = 0; i < fullStars; i++) {
     starFills.push(100);
   }
 
-  // Add partial star if needed
   if (hasPartialStar) {
     starFills.push(partialFillPercent);
   }
 
-  // Add empty stars
   for (let i = 0; i < emptyStars; i++) {
     starFills.push(0);
   }
 
-  // If totalRatings is not provided, show only stars
   if (totalRatings === undefined) {
     return (
       <div className={cn("flex items-center", gapClasses[size], className)}>
@@ -66,24 +61,20 @@ export function StarRating({
     );
   }
 
-  // Full rating display with text and count
   return (
     <div className={cn("flex items-center gap-1", className)}>
-      {/* Rating number - only show if showRatingNumber is true */}
       {showRatingNumber && (
         <span className={cn("font-medium", textSizeClasses[size])}>
           {averageRating.toFixed(1)}
         </span>
       )}
 
-      {/* Stars */}
       <div className={cn("flex items-center", gapClasses[size])}>
         {starFills.map((fillPercentage, index) => (
           <StarIcon key={index} fillPercentage={fillPercentage} size={size} />
         ))}
       </div>
 
-      {/* Total count */}
       <span className={cn("text-muted-foreground", textSizeClasses[size])}>
         {"("}
         {totalRatings}

--- a/apps/web/src/components/members-table/members-table.tsx
+++ b/apps/web/src/components/members-table/members-table.tsx
@@ -71,7 +71,6 @@ function combineMembersAndPendingInvitations(
   members: OrganizationMember[],
   pendingInvitations: PendingInvitation[],
 ): MemberRowData[] {
-  // Sort members by role score, then by name
   const sortedMembers = [...members].sort((a, b) => {
     const roleScoreDiff =
       (RoleScoreMap[a.role] ?? 0) - (RoleScoreMap[b.role] ?? 0);
@@ -79,20 +78,16 @@ function combineMembersAndPendingInvitations(
     return roleScoreDiff !== 0 ? roleScoreDiff : nameDiff;
   });
 
-  // Get set of member emails for quick lookup
   const memberEmails = new Set(
     sortedMembers.map((member) => member.user.email.toLowerCase()),
   );
 
-  // Filter invitations: exclude those matching member emails
   const filteredInvitations = pendingInvitations.filter(
     (invitation) => !memberEmails.has(invitation.email.toLowerCase()),
   );
 
-  // Convert members to row data
   const memberRows = sortedMembers.map(convertMemberWithUserToMemberRowData);
 
-  // Convert filtered invitations to row data
   const invitationRows = filteredInvitations.map(
     convertInvitationToMemberRowData,
   );

--- a/apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
+++ b/apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
@@ -647,7 +647,6 @@ export function CreateOrganizationWizard({
             key={step}
             className="animate-in fade-in-0 slide-in-from-bottom-1 my-auto w-full duration-200 ease-out motion-reduce:animate-none"
           >
-            {/* Step 1 — Details */}
             {step === 0 && (
               <Form {...form}>
                 <form id="create-org-details" onSubmit={handleDetailsContinue}>
@@ -737,7 +736,6 @@ export function CreateOrganizationWizard({
               </Form>
             )}
 
-            {/* Step 2 — Logo */}
             {step === 1 && (
               <>
                 <div className="flex min-h-24 flex-none items-center justify-center">
@@ -813,7 +811,6 @@ export function CreateOrganizationWizard({
               </>
             )}
 
-            {/* Step 3 — Brand Guidelines */}
             {step === 2 && (
               <>
                 <div className="flex min-h-24 flex-none items-center justify-center">
@@ -907,7 +904,6 @@ export function CreateOrganizationWizard({
               </>
             )}
 
-            {/* Step 4 — created; confirm and invite */}
             {step === SUCCESS_STEP && (
               <>
                 {/* Tighter than the setup steps: this slide stacks the link

--- a/apps/web/src/lib/auth/errors.ts
+++ b/apps/web/src/lib/auth/errors.ts
@@ -42,13 +42,6 @@ export function isAdminAccessRequiredError(
 }
 
 /**
- * The session could not be read, so we do not know whether the user is signed
- * in. Distinct from `UnAuthenticatedError` on purpose: the error boundary
- * redirects that one to /signin, which is the wrong answer for a Core stall -
- * it reads as a logout to a user whose session is fine and throws away what
- * they were doing. This one falls through to the normal retryable error UI.
- */
-/**
  * The outage's counterpart to `UNAUTHENTICATED_ERROR_DIGEST`, and for the same
  * reason: `reason` and the name are gone by the time a deployed browser sees
  * this error, so the boundary had no way to tell a Core stall from a bug and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly narrating-comment cleanup. Comments-only: 34 deletions across 7 web files. No logic, exports, or behavior changes.

## Deleted

- `members-table.tsx`: five restating comments in `combineMembersAndPendingInvitations`
- `(auth)/error.tsx`: false “error reporting service” stack (`console.error` kept)
- OAuth callback/consent: branch-label comments (token-exchange protocol comment kept)
- `star-rating.tsx`: algorithm/JSX section labels (prop JSDoc kept)
- `create-organization-wizard.tsx`: duplicate JSX step labels (effect “once” comments kept)
- `auth/errors.ts`: duplicate Core-auth-outage JSDoc (digest comment on `CORE_AUTH_UNAVAILABLE_ERROR_DIGEST` kept)

## Intentionally kept

- OAuth token-exchange `application/x-www-form-urlencoded` constraint
- Wizard effect comments (favicon/brand/invite run once)
- Star-rating prop JSDoc
- Digest comment on `CORE_AUTH_UNAVAILABLE_ERROR_DIGEST`

Skipped generated/shadcn sidebar, product/security PRs, and anything already cleaned in #4495. Every listed comment was still present; nothing skipped as already removed.

## Verification

- `pnpm check` (Biome) and `pnpm typecheck` via pre-commit hook
- Diff is comment deletions only (`7 files changed, 34 deletions`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31488246-1254-4475-a497-88e43bcc5ec0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31488246-1254-4475-a497-88e43bcc5ec0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

