### PR TITLE
docs(adr): retitle ADR 0006 Hire-ban remainder and fix ADR 0028 Mac v1 live-rule bullet

### DIFF
--- a/docs/adr/0006-stop-agent-browse-and-app-hire.md
+++ b/docs/adr/0006-stop-agent-browse-and-app-hire.md
@@ -1,4 +1,4 @@
-# Stop marketplace Agent browse and app Hire; Jobs live at `/jobs/{jobId}`
+# Ban app marketplace Hire; Jobs live at `/jobs/{jobId}`
 
 - Status: Partially superseded by [ADR-0024](./0024-restore-agent-catalog-browse-without-app-hire.md). The app Hire ban remains in force; only the “stop agent browse” decision is superseded.
 

--- a/docs/adr/0028-apple-native-clients.md
+++ b/docs/adr/0028-apple-native-clients.md
@@ -18,6 +18,6 @@ Sokosumi’s first native client is an Apple Xcode workspace at `apps/apple`: sh
 
 - No `package.json` under `apps/apple` until a spec needs one. `pnpm-workspace.yaml` is `apps/*`; an empty npm package would join turbo by accident (same rule as `apps/cli`).
 - Xcode is outside turbo/Biome. Generate Swift clients from Core `openapi.json`; do not import `@sokosumi/database` or Prisma.
-- Mac v1 is sign-in, workspace, room list, one room transcript, composer, history pagination, live Ably, unread on opened rooms. Coworker stream, Soko Bot, files, mentions polish, and OS push wait.
+- Chat parity lives in [`apps/apple/PARITY.md`](../../apps/apple/PARITY.md); this ADR is the platform decision. Still out: iOS target, APNs.
 - ADR 0023 still holds for web. A Mac/iOS `UserNotifications` / APNs renderer is a new decision when that slice starts.
 - Product intent: [`apps/apple/VISION.md`](../../apps/apple/VISION.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
ADR 0006’s heading still said “stop agent browse” after #4413 rewrote the body for ADR-0024. Title now matches the remaining Hire ban and `/jobs/{jobId}` rule. Filename kept so existing links stay.

ADR 0028’s Consequences still froze Mac v1 at the original tracer and listed coworker stream, files, and mentions polish as waiting. Chat parity lives in `apps/apple/PARITY.md`; this ADR stays the platform decision. Still named as out: iOS target, APNs. No shipping claims for OS push or Soko Bot chat.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9667074-884e-49f6-954a-534bafa7b9d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9667074-884e-49f6-954a-534bafa7b9d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

